### PR TITLE
fix: resolve issues on gcp with extract platform script

### DIFF
--- a/resources/extract-platform.sh
+++ b/resources/extract-platform.sh
@@ -4,59 +4,162 @@
 # e.g. extract-platform v0.42.5
 set -o pipefail
 
+readonly HAPI_DIR=/opt/hgcapp/services-hedera/HapiApp2.0
+readonly LOG_FILE="${HAPI_DIR}/output/extract-platform.log"
+
+function log() {
+  local message="${1}"
+
+  if [[ ! -f "${LOG_FILE}" ]]; then
+    mkdir -p "${HAPI_DIR}/output"
+    touch "${LOG_FILE}"
+  fi
+
+  printf "%s - %s\n" "$(date '+%Y-%m-%d %H:%M:%S')" "${message}" | tee -a "${LOG_FILE}"
+}
+
 readonly tag="${1}"
 if [[ -z "${tag}" ]]; then
-    echo "Release tag is required (e.g. v0.42.5)";
-    exit 1
+  echo "Release tag is required (e.g. v0.42.5)"
+  exit 1
 fi
 
-readonly HAPI_DIR=/opt/hgcapp/services-hedera/HapiApp2.0
+RELEASE_DIR="$(awk -F'.' '{print $1"."$2}' <<<"${tag}")"
+readonly RELEASE_DIR
 readonly HEDERA_USER_HOME_DIR=/home/hedera
 readonly HEDERA_BUILDS_URL='https://builds.hedera.com'
-readonly RELEASE_DIR="$(awk -F'.' '{print $1"."$2}' <<< "${tag}")"
 readonly BUILD_ZIP_FILE="${HEDERA_USER_HOME_DIR}/build-${tag}.zip"
 readonly BUILD_ZIP_URL="${HEDERA_BUILDS_URL}/node/software/${RELEASE_DIR}/build-${tag}.zip"
 readonly CHECKSUM_FILE="${HEDERA_USER_HOME_DIR}/build-${tag}.sha384"
 readonly CHECKSUM_URL="${HEDERA_BUILDS_URL}/node/software/${RELEASE_DIR}/build-${tag}.sha384"
-readonly LOG_FILE="${HAPI_DIR}/output/extract-platform.log"
-echo "extract-platform.sh: begin................................" | tee -a ${LOG_FILE}
+
+log "extract-platform.sh: begin................................"
 
 # download
-echo "Downloading ${BUILD_ZIP_URL}" | tee -a ${LOG_FILE}
-[[ -f "${BUILD_ZIP_FILE}" ]] || curl -sSf "${BUILD_ZIP_URL}" -o "${BUILD_ZIP_FILE}" | tee -a ${LOG_FILE}
-[[ $? -ne 0 ]] && exit 1
-echo "Downloading ${CHECKSUM_URL}" | tee -a ${LOG_FILE}
-[[ -f "${CHECKSUM_FILE}" ]] || curl -sSf "${CHECKSUM_URL}" -o "${CHECKSUM_FILE}" | tee -a ${LOG_FILE}
-[[ $? -ne 0 ]] && exit 1
-cd ${HEDERA_USER_HOME_DIR}
-sha384sum -c ${CHECKSUM_FILE} | tee -a ${LOG_FILE}
-if [[ $? -ne 0 ]]; then
-    echo "SHA sum of ${BUILD_ZIP_FILE} does not match. Aborting." | tee -a ${LOG_FILE}
+log "Checking if ${BUILD_ZIP_FILE} exists..."
+if [[ ! -f "${BUILD_ZIP_FILE}" ]]; then
+  log "Downloading ${BUILD_ZIP_URL}..."
+  curl -sSf "${BUILD_ZIP_URL}" -o "${BUILD_ZIP_FILE}" > >(tee -a "${LOG_FILE}") 2>&1
+  ec="${?}"
+  if [[ "${ec}" -ne 0 ]]; then
+    log "Failed to download ${BUILD_ZIP_URL}. Error code: ${ec}"
     exit 1
+  fi
 fi
 
-echo "Deleting previous version under $HAPI_DIR/data/lib/* and $HAPI_DIR/data/apps/*" | tee -a ${LOG_FILE}
-sudo rm -rf ${HAPI_DIR}/data/lib/* | tee -a ${LOG_FILE}
-sudo rm -rf ${HAPI_DIR}/data/apps/* | tee -a ${LOG_FILE}
+log "Checking if ${CHECKSUM_FILE} exists..."
+
+if [[ ! -f "${CHECKSUM_FILE}" ]]; then
+  log "Downloading ${CHECKSUM_URL}..."
+  curl -sSf "${CHECKSUM_URL}" -o "${CHECKSUM_FILE}" > >(tee -a "${LOG_FILE}") 2>&1
+  ec="${?}"
+  if [[ "${ec}" -ne 0 ]]; then
+    log "Failed to download ${CHECKSUM_URL}. Error code: ${ec}"
+    exit 1
+  fi
+fi
+
+# shellcheck disable=SC2164
+cd ${HEDERA_USER_HOME_DIR}
+ec="${?}"
+
+if [[ "${ec}" -ne 0 ]]; then
+  log "Failed to change directory to ${HEDERA_USER_HOME_DIR}. Error code: ${ec}"
+  exit 1
+fi
+
+log "Verifying SHA sum of ${BUILD_ZIP_FILE} against ${CHECKSUM_FILE}"
+sha384sum -c "${CHECKSUM_FILE}" > >(tee -a "${LOG_FILE}") 2>&1
+ec="${?}"
+if [[ "${ec}" -ne 0 ]]; then
+  log "SHA384 sum of ${BUILD_ZIP_FILE} does not match. Aborting."
+  exit 1
+fi
+
+log "Deleting previous version under $HAPI_DIR/data/lib/*.jar and $HAPI_DIR/data/apps/*.jar"
+rm -rvf ${HAPI_DIR}/data/lib/*.jar > >(tee -a "${LOG_FILE}") 2>&1
+rm -rvf ${HAPI_DIR}/data/apps/*.jar > >(tee -a "${LOG_FILE}") 2>&1
+
+# ensure the HapiApp2.0 directory exists
+if [[ ! -d "${HAPI_DIR}" ]]; then
+  log "Creating directory ${HAPI_DIR}"
+  mkdir -p "${HAPI_DIR}" > >(tee -a "${LOG_FILE}") 2>&1
+  ec="${?}"
+  if [[ "${ec}" -ne 0 ]]; then
+    log "Failed to create directory ${HAPI_DIR}"
+    exit 1
+  fi
+
+  chown hedera:hedera "${HAPI_DIR}" > >(tee -a "${LOG_FILE}") 2>&1
+  ec="${?}"
+  if [[ "${ec}" -ne 0 ]]; then
+    log "Failed to change ownership of ${HAPI_DIR} to the hedera user and group"
+    exit 1
+  fi
+fi
 
 # extract
-echo "Extracting ${BUILD_ZIP_FILE}" | tee -a ${LOG_FILE}
-[[ -d "${HAPI_DIR}" ]] || mkdir -p "${HAPI_DIR}" | tee -a ${LOG_FILE}
-echo "HAPI_DIR=${HAPI_DIR}" | tee -a ${LOG_FILE}
-cd ${HAPI_DIR}
-pwd | tee -a ${LOG_FILE}
-ls -al | tee -a ${LOG_FILE}
-
 echo "Using unzip to extract files"
 
 # To avoid "Device or resource busy" error when unzip tries to delete pre-existing file first before extracting
 # Uncompress to a temporary directory and then move the files to the target directory
 
-mkdir /tmp/extract
-unzip -o "${BUILD_ZIP_FILE}" -d /tmp/extract | tee -a ${LOG_FILE}
-sudo cp -rf /tmp/extract/* "${HAPI_DIR}" | tee -a ${LOG_FILE}
-rm -rf /tmp/extract
+mkdir -p /tmp/extract
+ec="${?}"
+if [[ "${ec}" -ne 0 ]]; then
+  log "Failed to create temporary directory /tmp/extract. Error code: ${ec}"
+  exit 1
+fi
 
-[[ $? -ne 0 ]] && echo "Failure occurred during decompress" && exit 1
-echo "................................end: extract-platform.sh" | tee -a ${LOG_FILE}
+unzip -o "${BUILD_ZIP_FILE}" -d /tmp/extract > >(tee -a "${LOG_FILE}") 2>&1
+ec="${?}"
+if [[ "${ec}" -ne 0 ]]; then
+  log "Failed to unzip ${BUILD_ZIP_FILE}. Error code: ${ec}"
+  exit 1
+fi
+
+cp -rf /tmp/extract/data/lib/* "${HAPI_DIR}/data/lib/" > >(tee -a "${LOG_FILE}") 2>&1
+ec="${?}"
+if [[ "${ec}" -ne 0 ]]; then
+  log "Failed to copy libraries from /tmp/extract/lib to ${HAPI_DIR}/data/lib. Error code: ${ec}"
+  exit 1
+fi
+
+cp -rf /tmp/extract/data/apps/* "${HAPI_DIR}/data/apps/" > >(tee -a "${LOG_FILE}") 2>&1
+ec="${?}"
+if [[ "${ec}" -ne 0 ]]; then
+  log "Failed to copy applications from /tmp/extract/apps to ${HAPI_DIR}/data/apps. Error code: ${ec}"
+  exit 1
+fi
+
+cp -f /tmp/extract/VERSION "${HAPI_DIR}/VERSION" > >(tee -a "${LOG_FILE}") 2>&1
+ec="${?}"
+if [[ "${ec}" -ne 0 ]]; then
+  log "Failed to copy VERSION file from /tmp/extract to ${HAPI_DIR}/VERSION. Error code: ${ec}"
+  exit 1
+fi
+
+cp -f /tmp/extract/immediate.sh "${HAPI_DIR}/immediate.sh" > >(tee -a "${LOG_FILE}") 2>&1
+ec="${?}"
+if [[ "${ec}" -ne 0 ]]; then
+  log "Failed to copy immediate.sh from /tmp/extract to ${HAPI_DIR}/immediate.sh. Error code: ${ec}"
+  exit 1
+fi
+
+cp -f /tmp/extract/during-freeze.sh "${HAPI_DIR}/during_freeze.sh" > >(tee -a "${LOG_FILE}") 2>&1
+ec="${?}"
+if [[ "${ec}" -ne 0 ]]; then
+  log "Failed to copy during-freeze.sh from /tmp/extract to ${HAPI_DIR}/during-freeze.sh. Error code: ${ec}"
+  exit 1
+fi
+
+log "Removing temporary directory /tmp/extract"
+rm -rf /tmp/extract > >(tee -a "${LOG_FILE}") 2>&1
+ec="${?}"
+if [[ "${ec}" -ne 0 ]]; then
+  log "Failed to remove temporary directory /tmp/extract. Error code: ${ec}"
+  exit 1
+fi
+
+log "................................end: extract-platform.sh"
 exit 0

--- a/src/core/platform-installer.ts
+++ b/src/core/platform-installer.ts
@@ -121,6 +121,7 @@ export class PlatformInstaller {
       const container = k8Containers.readByRef(containerReference);
 
       await container.execContainer(`chmod +x ${extractScript}`);
+      await container.execContainer(`chown root:root ${extractScript}`);
       await container.execContainer([extractScript, tag]);
 
       return true;


### PR DESCRIPTION
## Description

This pull request enhances the robustness and maintainability of the platform extraction and installation process by introducing improved logging, error handling, and ownership management. Key changes include refactoring the `extract-platform.sh` script for better structure and reliability and updating the `PlatformInstaller` class to ensure proper file ownership during execution.

### Improvements to `extract-platform.sh` script:

* Added a reusable `log` function to centralize logging and ensure consistent timestamped messages are written to both the console and a log file.
* Enhanced error handling by checking the exit codes (`ec`) of critical operations (e.g., downloading files, directory creation, file extraction) and logging detailed error messages before exiting on failure.
* Refactored the script to ensure proper cleanup of temporary directories (`/tmp/extract`) and added checks for directory existence before creating or modifying them.
* Improved file management by explicitly copying files (e.g., `VERSION`, `immediate.sh`, `during-freeze.sh`) to their target locations with error handling, replacing the previous bulk copy approach.

### Updates to `PlatformInstaller` class:

* Added a step to change the ownership of the `extractScript` file to `root:root` before execution, ensuring appropriate permissions and ownership for security and consistency.

### Related Issues

* Closes #2068 

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[x] This PR added no TODOs or commented out code
* \[x] This PR has no breaking changes
* \[x] Any technical debt has been documented as a separate issue and linked to this PR
* \[x] Any `package.json` changes have been explained to and approved by a repository manager
* \[x] All related issues have been linked to this PR
* \[x] All changes in this PR are included in the description
* \[x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[x] These changes required manual testing that is documented below
* \[x] Anything not tested is documented

The following manual testing was done:

* Tested locally using the container image running in docker.

The following was not tested:

* Changes to the `PlatformInstaller` class.

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
