### PR TITLE
fix: load keys from pfx files in settings.txt should always be true for Solo

### DIFF
--- a/examples/custom-network-config/settings.txt
+++ b/examples/custom-network-config/settings.txt
@@ -1,7 +1,7 @@
 checkSignedStateFromDisk,                      1
 csvFileName,                                   MainNetStats
 doUpnp,                                        false
-loadKeysFromPfxFiles,                          0
+loadKeysFromPfxFiles,                          1
 maxOutgoingSyncs,                              1
 reconnect.active,                              1
 reconnect.reconnectWindowSeconds,              -1

--- a/examples/performance-tuning/latitude/settings.txt
+++ b/examples/performance-tuning/latitude/settings.txt
@@ -1,6 +1,7 @@
 checkSignedStateFromDisk,                      1
 csvFileName,                                   MainNetStats
 doUpnp,                                        false
+loadKeysFromPfxFiles,                          1
 maxOutgoingSyncs,                              1
 reconnect.active,                              1
 reconnect.reconnectWindowSeconds,              -1

--- a/examples/performance-tuning/solo-gke/settings.txt
+++ b/examples/performance-tuning/solo-gke/settings.txt
@@ -1,7 +1,7 @@
 checkSignedStateFromDisk,                      1
 csvFileName,                                   MainNetStats
 doUpnp,                                        false
-loadKeysFromPfxFiles,                          0
+loadKeysFromPfxFiles,                          1
 maxOutgoingSyncs,                              1
 reconnect.active,                              1
 reconnect.reconnectWindowSeconds,              -1
@@ -15,4 +15,3 @@ merkleDb.hashesRamToDiskThreshold,             8388608
 event.creation.maxCreationRate,                20
 virtualMap.familyThrottleThreshold,            6000000000
 merkleDb.maxFileChannelsPerFileReader,	       1
-

--- a/examples/performance-tuning/solo-perf-test/settings.txt
+++ b/examples/performance-tuning/solo-perf-test/settings.txt
@@ -1,7 +1,7 @@
 checkSignedStateFromDisk,                      1
 csvFileName,                                   MainNetStats
 doUpnp,                                        false
-loadKeysFromPfxFiles,                          0
+loadKeysFromPfxFiles,                          1
 maxOutgoingSyncs,                              1
 reconnect.active,                              1
 reconnect.reconnectWindowSeconds,              -1

--- a/examples/solo-gke-test/settings.txt
+++ b/examples/solo-gke-test/settings.txt
@@ -1,7 +1,7 @@
 checkSignedStateFromDisk,                      1
 csvFileName,                                   MainNetStats
 doUpnp,                                        false
-loadKeysFromPfxFiles,                          0
+loadKeysFromPfxFiles,                          1
 maxOutgoingSyncs,                              1
 reconnect.active,                              1
 reconnect.reconnectWindowSeconds,              -1

--- a/resources/templates/settings.txt
+++ b/resources/templates/settings.txt
@@ -1,2 +1,3 @@
 state.mainClassNameOverride,                   com.hedera.services.ServicesMain
 state.saveStatePeriod, 60
+loadKeysFromPfxFiles, 1


### PR DESCRIPTION
## Description

This pull request changes the following:

* load keys from pfx files in settings.txt should always be true for Solo

### Related Issues

* Closes #
* Related to #1543 

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
