### PR TITLE
fix: lower step-by-step guide to a single node to be able to pass the CI pipeline consistently since block node was added

### DIFF
--- a/.github/workflows/script/update_md.sh
+++ b/.github/workflows/script/update_md.sh
@@ -43,10 +43,10 @@ export SOLO_CLUSTER_REF_CONNECT_OUTPUT=$( cat ${BUILD_DIR}/cluster-ref-connect.l
 solo deployment create -n "${SOLO_NAMESPACE}" --deployment "${SOLO_DEPLOYMENT}" | tee ${BUILD_DIR}/deployment-create.log
 export SOLO_DEPLOYMENT_CREATE_OUTPUT=$( cat ${BUILD_DIR}/deployment-create.log | tee ${BUILD_DIR}/test.log )
 
-solo deployment add-cluster --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_NAME} --num-consensus-nodes 2 | tee ${BUILD_DIR}/deployment-add-cluster.log
+solo deployment add-cluster --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_NAME} --num-consensus-nodes 1 | tee ${BUILD_DIR}/deployment-add-cluster.log
 export SOLO_DEPLOYMENT_ADD_CLUSTER_OUTPUT=$( cat ${BUILD_DIR}/deployment-add-cluster.log | tee ${BUILD_DIR}/test.log )
 
-solo node keys --gossip-keys --tls-keys -i node1,node2 --deployment "${SOLO_DEPLOYMENT}" | tee ${BUILD_DIR}/keys.log
+solo node keys --gossip-keys --tls-keys --deployment "${SOLO_DEPLOYMENT}" | tee ${BUILD_DIR}/keys.log
 export SOLO_NODE_KEY_PEM_OUTPUT=$( cat ${BUILD_DIR}/keys.log | tee ${BUILD_DIR}/test.log )
 
 solo cluster-ref setup -s "${SOLO_CLUSTER_SETUP_NAMESPACE}" | tee ${BUILD_DIR}/cluster-setup.log
@@ -55,26 +55,26 @@ export SOLO_CLUSTER_SETUP_OUTPUT=$( cat ${BUILD_DIR}/cluster-setup.log | tee ${B
 solo block node add --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-"${SOLO_CLUSTER_NAME}" "${CONSENSUS_NODE_FLAG[@]}" | tee ${BUILD_DIR}/block-node-add.log
 export SOLO_BLOCK_NODE_ADD_OUTPUT=$( cat ${BUILD_DIR}/block-node-add.log | tee ${BUILD_DIR}/test.log )
 
-solo network deploy -i node1,node2 --deployment "${SOLO_DEPLOYMENT}" | tee ${BUILD_DIR}/network-deploy.log
+solo network deploy --deployment "${SOLO_DEPLOYMENT}" | tee ${BUILD_DIR}/network-deploy.log
 export SOLO_NETWORK_DEPLOY_OUTPUT=$( cat ${BUILD_DIR}/network-deploy.log | tee ${BUILD_DIR}/test.log )
 
-solo node setup -i node1,node2 --deployment "${SOLO_DEPLOYMENT}" "${CONSENSUS_NODE_FLAG[@]}" | tee ${BUILD_DIR}/node-setup.log
+solo node setup --deployment "${SOLO_DEPLOYMENT}" "${CONSENSUS_NODE_FLAG[@]}" | tee ${BUILD_DIR}/node-setup.log
 export SOLO_NODE_SETUP_OUTPUT=$( cat ${BUILD_DIR}/node-setup.log | tee ${BUILD_DIR}/test.log )
 
-solo node start -i node1,node2 --deployment "${SOLO_DEPLOYMENT}" | tee ${BUILD_DIR}/node-start.log
+solo node start --deployment "${SOLO_DEPLOYMENT}" | tee ${BUILD_DIR}/node-start.log
 export SOLO_NODE_START_OUTPUT=$( cat ${BUILD_DIR}/node-start.log | tee ${BUILD_DIR}/test.log )
 
 # shellcheck disable=SC2086
 solo mirror-node deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_NAME} -q | tee ${BUILD_DIR}/mirror-node-deploy.log
 export SOLO_MIRROR_NODE_DEPLOY_OUTPUT=$( cat ${BUILD_DIR}/mirror-node-deploy.log | tee ${BUILD_DIR}/test.log )
 
-solo relay deploy -i node1,node2 --deployment "${SOLO_DEPLOYMENT}" | tee ${BUILD_DIR}/relay-deploy.log
+solo relay deploy -i node1 --deployment "${SOLO_DEPLOYMENT}" | tee ${BUILD_DIR}/relay-deploy.log
 export SOLO_RELAY_DEPLOY_OUTPUT=$( cat ${BUILD_DIR}/relay-deploy.log | tee ${BUILD_DIR}/test.log )
 
 solo explorer deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_NAME} -q | tee ${BUILD_DIR}/explorer-deploy.log
 export SOLO_EXPLORER_DEPLOY_OUTPUT=$( cat ${BUILD_DIR}/explorer-deploy.log | tee ${BUILD_DIR}/test.log )
 
-solo relay destroy -i node1,node2 --deployment "${SOLO_DEPLOYMENT}" | tee ${BUILD_DIR}/relay-destroy.log
+solo relay destroy -i node1 --deployment "${SOLO_DEPLOYMENT}" | tee ${BUILD_DIR}/relay-destroy.log
 export SOLO_RELAY_DESTROY_OUTPUT=$( cat ${BUILD_DIR}/relay-destroy.log | tee ${BUILD_DIR}/test.log )
 
 solo mirror-node destroy --deployment "${SOLO_DEPLOYMENT}" --force -q | tee ${BUILD_DIR}/mirror-node-destroy.log

--- a/docs/site/content/en/docs/step-by-step-guide.md
+++ b/docs/site/content/en/docs/step-by-step-guide.md
@@ -8,6 +8,9 @@ type: docs
 
 ## Solo User Guide
 
+> \[!NOTE]
+> For less than 16 GB of memory to dedicate to Docker please skip the block node add and destroy steps.
+
 ### Table of Contents
 
 * [Setup Kubernetes cluster](#setup-kubernetes-cluster)
@@ -31,7 +34,6 @@ type: docs
   * [Destroy network](#destroy-network)
 
 For those who would like to have more control or need some customized setups, here are some step by step instructions of how to setup and deploy a solo network.
-
 ### Setup Kubernetes cluster
 
 #### Remote cluster
@@ -50,9 +52,9 @@ kubectl config use-context <context-name>
 First, use the following command to set up the environment variables:
 
 ```
-export SOLO_CLUSTER_NAME=solo
-export SOLO_NAMESPACE=solo
-export SOLO_CLUSTER_SETUP_NAMESPACE=solo-cluster
+export SOLO_CLUSTER_NAME=solo-cluster
+export SOLO_NAMESPACE=solo-e2e
+export SOLO_CLUSTER_SETUP_NAMESPACE=solo-cluster-setup
 export SOLO_DEPLOYMENT=solo-deployment
 
 ```
@@ -131,7 +133,7 @@ solo init
 ```
 
 ******************************* Solo *********************************************
-Version			: 0.36.0
+Version			: 0.37.1
 Kubernetes Context	: kind-solo-e2e
 Kubernetes Cluster	: kind-solo-e2e
 Current Command		: init
@@ -143,7 +145,7 @@ Current Command		: init
 ✔ Check dependency: helm [OS: darwin, Release: 23.6.0, Arch: arm64]
 ✔ Check dependencies
 ❯ Create local configuration
-↓ Create local configuration [SKIPPED: Create local configuration]
+✔ Create local configuration
 ❯ Setup chart manager
 push repo hedera-json-rpc-relay -> https://hiero-ledger.github.io/hiero-json-rpc-relay/charts
 push repo mirror -> https://hashgraph.github.io/hedera-mirror-node/charts
@@ -163,7 +165,7 @@ If a full reset is needed, delete the directory or relevant sub-directories befo
 * Associates a cluster reference to a k8s context
 
 ```
-solo cluster-ref connect --cluster-ref kind-${SOLO_CLUSTER_SETUP_NAMESPACE} --context kind-${SOLO_CLUSTER_NAME}
+solo cluster-ref connect --cluster-ref kind-${SOLO_CLUSTER_NAME} --context kind-${SOLO_CLUSTER_NAME}
 ```
 
 * Example output
@@ -171,7 +173,7 @@ solo cluster-ref connect --cluster-ref kind-${SOLO_CLUSTER_SETUP_NAMESPACE} --co
 ```
 
 ******************************* Solo *********************************************
-Version			: 0.36.0
+Version			: 0.37.1
 Kubernetes Context	: kind-solo-e2e
 Kubernetes Cluster	: kind-solo-e2e
 Current Command		: cluster-ref connect --cluster-ref kind-solo-e2e --context kind-solo-e2e
@@ -197,22 +199,22 @@ solo deployment create -n "${SOLO_NAMESPACE}" --deployment "${SOLO_DEPLOYMENT}"
 ```
 
 ******************************* Solo *********************************************
-Version			: 0.36.0
+Version			: 0.37.1
 Kubernetes Context	: kind-solo-e2e
 Kubernetes Cluster	: kind-solo-e2e
-Current Command		: deployment create --namespace solo --deployment solo-deployment --realm 0 --shard 0
-Kubernetes Namespace	: solo
+Current Command		: deployment create --namespace solo-e2e --deployment solo-deployment --realm 0 --shard 0
+Kubernetes Namespace	: solo-e2e
 **********************************************************************************
 ❯ Initialize
 ✔ Initialize
 ❯ Add deployment to local config
-✔ Adding deployment: solo-deployment with namespace: solo to local config
+✔ Adding deployment: solo-deployment with namespace: solo-e2e to local config
 ```
 
 * Add a cluster to deployment
 
 ```
-solo deployment add-cluster --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_SETUP_NAMESPACE} --num-consensus-nodes 3
+solo deployment add-cluster --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_NAME} --num-consensus-nodes 3
 ```
 
 * Example output
@@ -220,17 +222,17 @@ solo deployment add-cluster --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind
 ```
 
 ******************************* Solo *********************************************
-Version			: 0.36.0
+Version			: 0.37.1
 Kubernetes Context	: kind-solo-e2e
 Kubernetes Cluster	: kind-solo-e2e
-Current Command		: deployment add-cluster --deployment solo-deployment --cluster-ref kind-solo-e2e --num-consensus-nodes 3
+Current Command		: deployment add-cluster --deployment solo-deployment --cluster-ref kind-solo-e2e --num-consensus-nodes 1
 **********************************************************************************
 ❯ Initialize
 ✔ Initialize
 ❯ Verify args
 ✔ Verify args
-❯ check network state
-✔ check network state
+❯ check ledger phase
+✔ check ledger phase
 ❯ Test cluster connection
 ✔ Test cluster connection: kind-solo-e2e, context: kind-solo-e2e
 ❯ Verify prerequisites
@@ -244,7 +246,7 @@ Current Command		: deployment add-cluster --deployment solo-deployment --cluster
 #### Generate `pem` formatted node keys
 
 ```
-solo node keys --gossip-keys --tls-keys -i node1,node2,node3 --deployment "${SOLO_DEPLOYMENT}"
+solo node keys --gossip-keys --tls-keys --deployment "${SOLO_DEPLOYMENT}"
 ```
 
 * Example output
@@ -252,10 +254,10 @@ solo node keys --gossip-keys --tls-keys -i node1,node2,node3 --deployment "${SOL
 ```
 
 ******************************* Solo *********************************************
-Version			: 0.36.0
+Version			: 0.37.1
 Kubernetes Context	: kind-solo-e2e
 Kubernetes Cluster	: kind-solo-e2e
-Current Command		: node keys --gossip-keys --tls-keys --node-aliases node1,node2,node3 --deployment solo-deployment
+Current Command		: node keys --gossip-keys --tls-keys --deployment solo-deployment
 **********************************************************************************
 ❯ Initialize
 ✔ Initialize
@@ -264,19 +266,11 @@ Current Command		: node keys --gossip-keys --tls-keys --node-aliases node1,node2
 ✔ Backup old files
 ❯ Gossip key for node: node1
 ✔ Gossip key for node: node1
-❯ Gossip key for node: node2
-✔ Gossip key for node: node2
-❯ Gossip key for node: node3
-✔ Gossip key for node: node3
 ✔ Generate gossip keys
 ❯ Generate gRPC TLS Keys
 ❯ Backup old files
 ❯ TLS key for node: node1
-❯ TLS key for node: node2
-❯ TLS key for node: node3
 ✔ Backup old files
-✔ TLS key for node: node3
-✔ TLS key for node: node2
 ✔ TLS key for node: node1
 ✔ Generate gRPC TLS Keys
 ❯ Finalize
@@ -303,10 +297,10 @@ solo cluster-ref setup -s "${SOLO_CLUSTER_SETUP_NAMESPACE}"
 ```
 
 ******************************* Solo *********************************************
-Version			: 0.36.0
+Version			: 0.37.1
 Kubernetes Context	: kind-solo-e2e
 Kubernetes Cluster	: kind-solo-e2e
-Current Command		: cluster-ref setup --cluster-setup-namespace solo-cluster
+Current Command		: cluster-ref setup --cluster-setup-namespace solo-cluster-setup
 **********************************************************************************
 ❯ Initialize
 ✔ Initialize
@@ -314,12 +308,52 @@ Current Command		: cluster-ref setup --cluster-setup-namespace solo-cluster
 ✔ Prepare chart values
 ❯ Install 'solo-cluster-setup' chart
 ********************** Installed solo-cluster-setup chart **********************
-Version			: 0.50.0
+Version			: 0.53.0
 ********************************************************************************
 ✔ Install 'solo-cluster-setup' chart
 ```
 
 In a separate terminal, you may run `k9s` to view the pod status.
+
+#### Deploy a block node
+```
+solo block node add --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_NAME}
+```
+
+* Example output
+
+```
+
+******************************* Solo *********************************************
+Version			: 0.37.1
+Kubernetes Context	: kind-solo-e2e
+Kubernetes Cluster	: kind-solo-e2e
+Current Command		: block node add --deployment solo-deployment --cluster-ref kind-solo-e2e --release-tag v0.62.1
+**********************************************************************************
+❯ Initialize
+❯ Acquire lock
+✔ Acquire lock - lock acquired successfully, attempt: 1/10
+✔ Initialize
+❯ Prepare release name
+✔ Prepare release name
+❯ Prepare chart values
+✔ Prepare chart values
+❯ Deploy block node
+************************* Installed block-node-0 chart *************************
+Version			: 0.9.0
+********************************************************************************
+✔ Deploy block node
+❯ Check block node pod is running
+✔ Check block node pod is running
+❯ Check software
+✔ Check software
+❯ Check block node pod is ready
+✔ Check block node pod is ready
+❯ Check block node readiness
+✔ Check block node readiness - [1/100] success
+❯ Add block node component in remote config
+✔ Add block node component in remote config
+```
 
 #### Deploy helm chart with Hedera network components
 
@@ -328,7 +362,7 @@ It may take a while (5~15 minutes depending on your internet speed) to download 
 If it fails, ensure you have enough resources allocated for Docker engine and retry the command.
 
 ```
-solo network deploy -i node1,node2,node3 --deployment "${SOLO_DEPLOYMENT}"
+solo network deploy --deployment "${SOLO_DEPLOYMENT}"
 ```
 
 * Example output
@@ -336,10 +370,10 @@ solo network deploy -i node1,node2,node3 --deployment "${SOLO_DEPLOYMENT}"
 ```
 
 ******************************* Solo *********************************************
-Version			: 0.36.0
+Version			: 0.37.1
 Kubernetes Context	: kind-solo-e2e
 Kubernetes Cluster	: kind-solo-e2e
-Current Command		: network deploy --node-aliases node1,node2,node3 --deployment solo-deployment
+Current Command		: network deploy --deployment solo-deployment
 **********************************************************************************
 ❯ Initialize
 ❯ Acquire lock
@@ -358,22 +392,14 @@ Current Command		: network deploy --node-aliases node1,node2,node3 --deployment 
 ❯ Copy node keys to secrets
 ❯ Copy TLS keys
 ❯ Node: node1, cluster: kind-solo-e2e
-❯ Node: node2, cluster: kind-solo-e2e
-❯ Node: node3, cluster: kind-solo-e2e
 ❯ Copy Gossip keys
-❯ Copy Gossip keys
-❯ Copy Gossip keys
+✔ Copy TLS keys
 ✔ Copy Gossip keys
 ✔ Node: node1, cluster: kind-solo-e2e
-✔ Copy Gossip keys
-✔ Node: node3, cluster: kind-solo-e2e
-✔ Copy Gossip keys
-✔ Node: node2, cluster: kind-solo-e2e
-✔ Copy TLS keys
 ✔ Copy node keys to secrets
 ❯ Install chart 'solo-deployment'
 *********************** Installed solo-deployment chart ************************
-Version			: 0.50.0
+Version			: 0.53.0
 ********************************************************************************
 ✔ Install chart 'solo-deployment'
 ❯ Check for load balancer
@@ -383,24 +409,12 @@ Version			: 0.50.0
 ❯ Check node pods are running
 ❯ Check Node: node1, Cluster: kind-solo-e2e
 ✔ Check Node: node1, Cluster: kind-solo-e2e
-❯ Check Node: node2, Cluster: kind-solo-e2e
-✔ Check Node: node2, Cluster: kind-solo-e2e
-❯ Check Node: node3, Cluster: kind-solo-e2e
-✔ Check Node: node3, Cluster: kind-solo-e2e
 ✔ Check node pods are running
 ❯ Check proxy pods are running
 ❯ Check HAProxy for: node1, cluster: kind-solo-e2e
-❯ Check HAProxy for: node2, cluster: kind-solo-e2e
-❯ Check HAProxy for: node3, cluster: kind-solo-e2e
 ❯ Check Envoy Proxy for: node1, cluster: kind-solo-e2e
-❯ Check Envoy Proxy for: node2, cluster: kind-solo-e2e
-❯ Check Envoy Proxy for: node3, cluster: kind-solo-e2e
-✔ Check HAProxy for: node3, cluster: kind-solo-e2e
 ✔ Check Envoy Proxy for: node1, cluster: kind-solo-e2e
 ✔ Check HAProxy for: node1, cluster: kind-solo-e2e
-✔ Check Envoy Proxy for: node2, cluster: kind-solo-e2e
-✔ Check Envoy Proxy for: node3, cluster: kind-solo-e2e
-✔ Check HAProxy for: node2, cluster: kind-solo-e2e
 ✔ Check proxy pods are running
 ❯ Check auxiliary pods are ready
 ❯ Check MinIO
@@ -408,6 +422,8 @@ Version			: 0.50.0
 ✔ Check auxiliary pods are ready
 ❯ Add node and proxies to remote config
 ✔ Add node and proxies to remote config
+❯ Copy block-nodes.json
+✔ Copy block-nodes.json
 ```
 
 #### Setup node with Hedera platform software.
@@ -415,7 +431,7 @@ Version			: 0.50.0
 * It may take a while as it download the hedera platform code from <https://builds.hedera.com/>
 
 ```
-solo node setup -i node1,node2,node3 --deployment "${SOLO_DEPLOYMENT}"
+solo node setup --deployment "${SOLO_DEPLOYMENT}"
 ```
 
 * Example output
@@ -423,10 +439,10 @@ solo node setup -i node1,node2,node3 --deployment "${SOLO_DEPLOYMENT}"
 ```
 
 ******************************* Solo *********************************************
-Version			: 0.36.0
+Version			: 0.37.1
 Kubernetes Context	: kind-solo-e2e
 Kubernetes Cluster	: kind-solo-e2e
-Current Command		: node setup --node-aliases node1,node2,node3 --deployment solo-deployment
+Current Command		: node setup --deployment solo-deployment --release-tag v0.62.1
 **********************************************************************************
 ❯ Initialize
 ❯ Acquire lock
@@ -435,55 +451,31 @@ Current Command		: node setup --node-aliases node1,node2,node3 --deployment solo
 ❯ Validate nodes states
 ❯ Validating state for node node1
 ✔ Validating state for node node1 - valid state: requested
-❯ Validating state for node node2
-✔ Validating state for node node2 - valid state: requested
-❯ Validating state for node node3
-✔ Validating state for node node3 - valid state: requested
 ✔ Validate nodes states
 ❯ Identify network pods
 ❯ Check network pod: node1
-❯ Check network pod: node2
-❯ Check network pod: node3
 ✔ Check network pod: node1
-✔ Check network pod: node3
-✔ Check network pod: node2
 ✔ Identify network pods
 ❯ Fetch platform software into network nodes
-❯ Update node: node1 [ platformVersion = v0.59.5, context = kind-solo-e2e ]
-❯ Update node: node2 [ platformVersion = v0.59.5, context = kind-solo-e2e ]
-❯ Update node: node3 [ platformVersion = v0.59.5, context = kind-solo-e2e ]
-✔ Update node: node2 [ platformVersion = v0.59.5, context = kind-solo-e2e ]
-✔ Update node: node1 [ platformVersion = v0.59.5, context = kind-solo-e2e ]
-✔ Update node: node3 [ platformVersion = v0.59.5, context = kind-solo-e2e ]
+❯ Update node: node1 [ platformVersion = v0.62.1, context = kind-solo-e2e ]
+✔ Update node: node1 [ platformVersion = v0.62.1, context = kind-solo-e2e ]
 ✔ Fetch platform software into network nodes
 ❯ Setup network nodes
 ❯ Node: node1
-❯ Node: node2
-❯ Node: node3
-❯ Copy configuration files
-❯ Copy configuration files
 ❯ Copy configuration files
 ✔ Copy configuration files
 ❯ Set file permissions
-✔ Copy configuration files
-❯ Set file permissions
-✔ Copy configuration files
-❯ Set file permissions
-✔ Set file permissions
-✔ Node: node2
-✔ Set file permissions
-✔ Node: node3
 ✔ Set file permissions
 ✔ Node: node1
 ✔ Setup network nodes
-❯ Change node state to setup in remote config
-✔ Change node state to setup in remote config
+❯ Change node state to configured in remote config
+✔ Change node state to configured in remote config
 ```
 
 * Start the nodes
 
 ```
-solo node start -i node1,node2,node3 --deployment "${SOLO_DEPLOYMENT}"
+solo node start --deployment "${SOLO_DEPLOYMENT}"
 ```
 
 * Example output
@@ -491,10 +483,10 @@ solo node start -i node1,node2,node3 --deployment "${SOLO_DEPLOYMENT}"
 ```
 
 ******************************* Solo *********************************************
-Version			: 0.36.0
+Version			: 0.37.1
 Kubernetes Context	: kind-solo-e2e
 Kubernetes Cluster	: kind-solo-e2e
-Current Command		: node start --node-aliases node1,node2,node3 --deployment solo-deployment
+Current Command		: node start --deployment solo-deployment
 **********************************************************************************
 ❯ Initialize
 ❯ Acquire lock
@@ -502,57 +494,33 @@ Current Command		: node start --node-aliases node1,node2,node3 --deployment solo
 ✔ Initialize
 ❯ Validate nodes states
 ❯ Validating state for node node1
-✔ Validating state for node node1 - valid state: setup
-❯ Validating state for node node2
-✔ Validating state for node node2 - valid state: setup
-❯ Validating state for node node3
-✔ Validating state for node node3 - valid state: setup
+✔ Validating state for node node1 - valid state: configured
 ✔ Validate nodes states
 ❯ Identify existing network nodes
 ❯ Check network pod: node1
-❯ Check network pod: node2
-❯ Check network pod: node3
 ✔ Check network pod: node1
-✔ Check network pod: node2
-✔ Check network pod: node3
 ✔ Identify existing network nodes
 ❯ Upload state files network nodes
 ↓ Upload state files network nodes [SKIPPED: Upload state files network nodes]
 ❯ Starting nodes
 ❯ Start node: node1
-❯ Start node: node2
-❯ Start node: node3
-✔ Start node: node2
-✔ Start node: node3
 ✔ Start node: node1
 ✔ Starting nodes
 ❯ Enable port forwarding for JVM debugger
 ↓ Enable port forwarding for JVM debugger [SKIPPED: Enable port forwarding for JVM debugger]
 ❯ Check all nodes are ACTIVE
 ❯ Check network pod: node1 
-❯ Check network pod: node2 
-❯ Check network pod: node3 
-✔ Check network pod: node1  - status ACTIVE, attempt: 17/300
-✔ Check network pod: node3  - status ACTIVE, attempt: 17/300
-✔ Check network pod: node2  - status ACTIVE, attempt: 18/300
+✔ Check network pod: node1  - status ACTIVE, attempt: 16/300
 ✔ Check all nodes are ACTIVE
 ❯ Check node proxies are ACTIVE
 ❯ Check proxy for node: node1
 ✔ Check proxy for node: node1
-❯ Check proxy for node: node2
-✔ Check proxy for node: node2
-❯ Check proxy for node: node3
-✔ Check proxy for node: node3
 ✔ Check node proxies are ACTIVE
 ❯ Change node state to started in remote config
 ✔ Change node state to started in remote config
 ❯ Add node stakes
 ❯ Adding stake for node: node1
 ✔ Adding stake for node: node1
-❯ Adding stake for node: node2
-✔ Adding stake for node: node2
-❯ Adding stake for node: node3
-✔ Adding stake for node: node3
 ✔ Add node stakes
 ```
 
@@ -561,7 +529,7 @@ Current Command		: node start --node-aliases node1,node2,node3 --deployment solo
 #### Deploy mirror node
 
 ```
-solo mirror-node deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_SETUP_NAMESPACE}
+solo mirror-node deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_NAME}
 ```
 
 * Example output
@@ -569,7 +537,7 @@ solo mirror-node deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${S
 ```
 
 ******************************* Solo *********************************************
-Version			: 0.36.0
+Version			: 0.37.1
 Kubernetes Context	: kind-solo-e2e
 Kubernetes Cluster	: kind-solo-e2e
 Current Command		: mirror-node deploy --deployment solo-deployment --cluster-ref kind-solo-e2e --quiet-mode
@@ -585,7 +553,7 @@ Current Command		: mirror-node deploy --deployment solo-deployment --cluster-ref
 ↓ Install mirror ingress controller [SKIPPED: Install mirror ingress controller]
 ❯ Deploy mirror-node
 **************************** Installed mirror chart ****************************
-Version			: v0.126.0
+Version			: v0.129.1
 ********************************************************************************
 ✔ Deploy mirror-node
 ✔ Enable mirror-node
@@ -596,10 +564,10 @@ Version			: v0.126.0
 ❯ Check Monitor
 ❯ Check Importer
 ✔ Check Postgres DB
-✔ Check Importer
-✔ Check GRPC
-✔ Check REST API
 ✔ Check Monitor
+✔ Check GRPC
+✔ Check Importer
+✔ Check REST API
 ✔ Check pods are ready
 ❯ Seed DB data
 ❯ Insert data in public.file_data
@@ -612,7 +580,7 @@ Version			: v0.126.0
 #### Deploy explorer mode
 
 ```
-solo explorer deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_SETUP_NAMESPACE}
+solo explorer deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_NAME}
 ```
 
 * Example output
@@ -620,10 +588,10 @@ solo explorer deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO
 ```
 
 ******************************* Solo *********************************************
-Version			: 0.36.0
+Version			: 0.37.1
 Kubernetes Context	: kind-solo-e2e
 Kubernetes Cluster	: kind-solo-e2e
-Current Command		: explorer deploy --deployment solo-deployment --quiet-mode
+Current Command		: explorer deploy --deployment solo-deployment --cluster-ref kind-solo-e2e --quiet-mode
 **********************************************************************************
 ❯ Initialize
 ❯ Acquire lock
@@ -634,8 +602,8 @@ Current Command		: explorer deploy --deployment solo-deployment --quiet-mode
 ❯ Install cert manager
 ↓ Install cert manager [SKIPPED: Install cert manager]
 ❯ Install explorer
-*********************** Installed hiero-explorer chart ************************
-Version			: 24.12.1
+************************ Installed hiero-explorer chart ************************
+Version			: 24.15.0
 ********************************************************************************
 ✔ Install explorer
 ❯ Install explorer ingress controller
@@ -645,15 +613,13 @@ Version			: 24.12.1
 ❯ Check haproxy ingress controller pod is ready
 ↓ Check haproxy ingress controller pod is ready [SKIPPED: Check haproxy ingress controller pod is ready]
 ❯ Add explorer to remote config
-*********************************** ERROR *****************************************
-Explorer deployment failed: Error deploying explorer: Invalid cluster: undefined
-***********************************************************************************
+✔ Add explorer to remote config
 ```
 
 #### Deploy a JSON RPC relay
 
 ```
-solo relay deploy -i node1,node2,node3 --deployment "${SOLO_DEPLOYMENT}"
+solo relay deploy -i node1 --deployment "${SOLO_DEPLOYMENT}"
 ```
 
 * Example output
@@ -661,10 +627,10 @@ solo relay deploy -i node1,node2,node3 --deployment "${SOLO_DEPLOYMENT}"
 ```
 
 ******************************* Solo *********************************************
-Version			: 0.36.0
+Version			: 0.37.1
 Kubernetes Context	: kind-solo-e2e
 Kubernetes Cluster	: kind-solo-e2e
-Current Command		: relay deploy --node-aliases node1,node2,node3 --deployment solo-deployment
+Current Command		: relay deploy --node-aliases node1 --deployment solo-deployment
 **********************************************************************************
 ❯ Initialize
 ❯ Acquire lock
@@ -675,7 +641,7 @@ Current Command		: relay deploy --node-aliases node1,node2,node3 --deployment so
 ❯ Prepare chart values
 ✔ Prepare chart values
 ❯ Deploy JSON RPC Relay
-******************* Installed relay-node1-node2-node3 chart ********************
+************************* Installed relay-node1 chart **************************
 Version			: v0.67.0
 ********************************************************************************
 ✔ Deploy JSON RPC Relay
@@ -691,10 +657,11 @@ Version			: v0.67.0
 
 Next: [Execution Developer](execution-developer)
 
+
 #### Destroy relay node
 
 ```
-solo relay destroy --deployment "${SOLO_DEPLOYMENT}"
+solo relay destroy -i node1 --deployment "${SOLO_DEPLOYMENT}"
 ```
 
 * Example output
@@ -702,10 +669,10 @@ solo relay destroy --deployment "${SOLO_DEPLOYMENT}"
 ```
 
 ******************************* Solo *********************************************
-Version			: 0.36.0
+Version			: 0.37.1
 Kubernetes Context	: kind-solo-e2e
 Kubernetes Cluster	: kind-solo-e2e
-Current Command		: relay destroy --node-aliases node1,node2,node3 --deployment solo-deployment
+Current Command		: relay destroy --node-aliases node1 --deployment solo-deployment
 **********************************************************************************
 ❯ Initialize
 ❯ Acquire lock
@@ -715,9 +682,10 @@ Current Command		: relay destroy --node-aliases node1,node2,node3 --deployment s
 
  *** Destroyed Relays ***
 -------------------------------------------------------------------------------
- - hiero-explorer [hiero-explorer-chart-24.12.1]
- - mirror [hedera-mirror-0.126.0]
- - solo-deployment [solo-deployment-0.50.0]
+ - block-node-0 [block-node-helm-chart-0.9.0]
+ - hiero-explorer [hiero-explorer-chart-24.15.0]
+ - mirror [hedera-mirror-0.129.1]
+ - solo-deployment [solo-deployment-0.53.0]
 
 
 ✔ Destroy JSON RPC Relay
@@ -728,7 +696,7 @@ Current Command		: relay destroy --node-aliases node1,node2,node3 --deployment s
 #### Destroy mirror node
 
 ```
-solo mirror-node destroy --deployment "${SOLO_DEPLOYMENT}"
+solo mirror-node destroy --deployment "${SOLO_DEPLOYMENT}" --force
 ```
 
 * Example output
@@ -736,7 +704,7 @@ solo mirror-node destroy --deployment "${SOLO_DEPLOYMENT}"
 ```
 
 ******************************* Solo *********************************************
-Version			: 0.36.0
+Version			: 0.37.1
 Kubernetes Context	: kind-solo-e2e
 Kubernetes Cluster	: kind-solo-e2e
 Current Command		: mirror-node destroy --deployment solo-deployment --quiet-mode
@@ -758,7 +726,7 @@ Current Command		: mirror-node destroy --deployment solo-deployment --quiet-mode
 #### Destroy explorer node
 
 ```
-solo explorer destroy --deployment "${SOLO_DEPLOYMENT}"
+solo explorer destroy --deployment "${SOLO_DEPLOYMENT}" --force
 ```
 
 * Example output
@@ -766,7 +734,7 @@ solo explorer destroy --deployment "${SOLO_DEPLOYMENT}"
 ```
 
 ******************************* Solo *********************************************
-Version			: 0.36.0
+Version			: 0.37.1
 Kubernetes Context	: kind-solo-e2e
 Kubernetes Cluster	: kind-solo-e2e
 Current Command		: explorer destroy --deployment solo-deployment --quiet-mode
@@ -782,15 +750,13 @@ Current Command		: explorer destroy --deployment solo-deployment --quiet-mode
 ❯ Uninstall explorer ingress controller
 ✔ Uninstall explorer ingress controller
 ❯ Remove explorer from remote config
-*********************************** ERROR *****************************************
-Explorer destruction failed: Error destroy explorer: Component mirrorNodeExplorer of type mirrorNodeExplorers not found while attempting to remove
-***********************************************************************************
+✔ Remove explorer from remote config
 ```
 
 #### Destroy network
 
 ```
-solo network destroy --deployment "${SOLO_DEPLOYMENT}"
+solo network destroy --deployment "${SOLO_DEPLOYMENT}" --force
 ```
 
 * Example output
@@ -798,7 +764,7 @@ solo network destroy --deployment "${SOLO_DEPLOYMENT}"
 ```
 
 ******************************* Solo *********************************************
-Version			: 0.36.0
+Version			: 0.37.1
 Kubernetes Context	: kind-solo-e2e
 Kubernetes Cluster	: kind-solo-e2e
 Current Command		: network destroy --deployment solo-deployment --quiet-mode
@@ -810,7 +776,35 @@ Current Command		: network destroy --deployment solo-deployment --quiet-mode
 ❯ Remove deployment from local configuration
 ✔ Remove deployment from local configuration
 ❯ Running sub-tasks to destroy network
-✔ Deleting the RemoteConfig configmap in namespace solo
+✔ Deleting the RemoteConfig configmap in namespace solo-e2e
+```
+
+#### Destroy block node
+
+```
+solo block node destroy --deployment "${SOLO_DEPLOYMENT}"
+```
+
+* Example output
+
+```
+
+******************************* Solo *********************************************
+Version			: 0.37.1
+Kubernetes Context	: kind-solo-e2e
+Kubernetes Cluster	: kind-solo-e2e
+Current Command		: block node destroy --deployment solo-deployment
+**********************************************************************************
+❯ Initialize
+❯ Acquire lock
+✔ Acquire lock - lock acquired successfully, attempt: 1/10
+✔ Initialize
+❯ Look-up block node
+✔ Look-up block node
+❯ Destroy block node
+✔ Destroy block node
+❯ Disable block node component in remote config
+✔ Disable block node component in remote config
 ```
 
 You may view the list of pods using `k9s` as below:

--- a/docs/site/content/en/docs/step-by-step-guide.md.template
+++ b/docs/site/content/en/docs/step-by-step-guide.md.template
@@ -8,6 +8,9 @@ type: docs
 
 ## Solo User Guide
 
+> \[!NOTE]
+> For less than 16 GB of memory to dedicate to Docker please skip the block node add and destroy steps.
+
 ### Table of Contents
 
 * [Setup Kubernetes cluster](#setup-kubernetes-cluster)

--- a/docs/site/content/en/docs/step-by-step-guide.md.template
+++ b/docs/site/content/en/docs/step-by-step-guide.md.template
@@ -370,7 +370,7 @@ Context: kind-solo                                <0> all   <a>       Attach    
 │ solo                envoy-proxy-node2-667f848689-628cx                             ●  1/1   Running         0 1 │
 │ solo                envoy-proxy-node3-6bb4b4cbdf-dmwtr                             ●  1/1   Running         0 1 │
 │ solo                solo-deployment-grpc-75bb9c6c55-l7kvt                     ●  1/1   Running         0 1 │
-│ solo                solo-deployment-hedera-explorer-6565ccb4cb-9dbw2          ●  1/1   Running         0 1 │
+│ solo                solo-deployment-hiero-explorer-6565ccb4cb-9dbw2          ●  1/1   Running         0 1 │
 │ solo                solo-deployment-importer-dd74fd466-vs4mb                  ●  1/1   Running         0 1 │
 │ solo                solo-deployment-monitor-54b8f57db9-fn5qq                  ●  1/1   Running         0 1 │
 │ solo                solo-deployment-postgres-postgresql-0                     ●  1/1   Running         0 1 │

--- a/docs/site/content/en/docs/step-by-step-guide.md.template
+++ b/docs/site/content/en/docs/step-by-step-guide.md.template
@@ -154,7 +154,7 @@ $SOLO_DEPLOYMENT_ADD_CLUSTER_OUTPUT
 #### Generate `pem` formatted node keys
 
 ```
-solo node keys --gossip-keys --tls-keys -i node1,node2,node3 --deployment "${SOLO_DEPLOYMENT}"
+solo node keys --gossip-keys --tls-keys --deployment "${SOLO_DEPLOYMENT}"
 ```
 
 * Example output
@@ -204,7 +204,7 @@ It may take a while (5~15 minutes depending on your internet speed) to download 
 If it fails, ensure you have enough resources allocated for Docker engine and retry the command.
 
 ```
-solo network deploy -i node1,node2,node3 --deployment "${SOLO_DEPLOYMENT}"
+solo network deploy --deployment "${SOLO_DEPLOYMENT}"
 ```
 
 * Example output
@@ -218,7 +218,7 @@ $SOLO_NETWORK_DEPLOY_OUTPUT
 * It may take a while as it download the hedera platform code from <https://builds.hedera.com/>
 
 ```
-solo node setup -i node1,node2,node3 --deployment "${SOLO_DEPLOYMENT}"
+solo node setup --deployment "${SOLO_DEPLOYMENT}"
 ```
 
 * Example output
@@ -230,7 +230,7 @@ $SOLO_NODE_SETUP_OUTPUT
 * Start the nodes
 
 ```
-solo node start -i node1,node2,node3 --deployment "${SOLO_DEPLOYMENT}"
+solo node start --deployment "${SOLO_DEPLOYMENT}"
 ```
 
 * Example output
@@ -268,7 +268,7 @@ $SOLO_EXPLORER_DEPLOY_OUTPUT
 #### Deploy a JSON RPC relay
 
 ```
-solo relay deploy -i node1,node2,node3 --deployment "${SOLO_DEPLOYMENT}"
+solo relay deploy -i node1 --deployment "${SOLO_DEPLOYMENT}"
 ```
 
 * Example output
@@ -285,7 +285,7 @@ Next: [Execution Developer](execution-developer)
 #### Destroy relay node
 
 ```
-solo relay destroy -i node1,node2,node3 --deployment "${SOLO_DEPLOYMENT}"
+solo relay destroy -i node1 --deployment "${SOLO_DEPLOYMENT}"
 ```
 
 * Example output


### PR DESCRIPTION
## Description

This pull request changes the following:

This pull request updates the Solo deployment scripts and documentation to simplify node configurations and improve resource compatibility. The changes reduce the number of consensus nodes and relay nodes in the deployment process and streamline related commands. Additionally, documentation now includes a note about resource requirements for Docker users.

### Updates to Deployment Scripts:

* Reduced the number of consensus nodes in the `solo deployment add-cluster` command from 2 to 1 for simpler cluster setups. (`.github/workflows/script/update_md.sh`, [.github/workflows/script/update_md.shL46-R49](diffhunk://#diff-2f77041d856d4671898dab659aec7bd1fb35f2760ec4988fb460943e8369b15dL46-R49))
* Removed node-specific identifiers (`-i node1,node2`) from commands such as `solo node keys`, `solo network deploy`, `solo node setup`, and `solo node start`. This simplifies deployment by applying configurations globally. (`.github/workflows/script/update_md.sh`, [.github/workflows/script/update_md.shL58-R77](diffhunk://#diff-2f77041d856d4671898dab659aec7bd1fb35f2760ec4988fb460943e8369b15dL58-R77))

### Updates to Documentation:

* Added a note advising users with less than 16 GB of memory to skip block node add and destroy steps for compatibility. (`docs/site/content/en/docs/step-by-step-guide.md.template`, [docs/site/content/en/docs/step-by-step-guide.md.templateR11-R13](diffhunk://#diff-5533c9332a70b9f6fcd89a81d50ea3e6e5c57fff0bc8a12dc170c4d0175bfa88R11-R13))
* Updated documentation commands to align with script changes, removing node-specific identifiers for `solo node keys`, `solo network deploy`, `solo node setup`, `solo node start`, `solo relay deploy`, and `solo relay destroy`. (`docs/site/content/en/docs/step-by-step-guide.md.template`, [[1]](diffhunk://#diff-5533c9332a70b9f6fcd89a81d50ea3e6e5c57fff0bc8a12dc170c4d0175bfa88L157-R160) [[2]](diffhunk://#diff-5533c9332a70b9f6fcd89a81d50ea3e6e5c57fff0bc8a12dc170c4d0175bfa88L207-R210) [[3]](diffhunk://#diff-5533c9332a70b9f6fcd89a81d50ea3e6e5c57fff0bc8a12dc170c4d0175bfa88L221-R224) [[4]](diffhunk://#diff-5533c9332a70b9f6fcd89a81d50ea3e6e5c57fff0bc8a12dc170c4d0175bfa88L233-R236) [[5]](diffhunk://#diff-5533c9332a70b9f6fcd89a81d50ea3e6e5c57fff0bc8a12dc170c4d0175bfa88L271-R274) [[6]](diffhunk://#diff-5533c9332a70b9f6fcd89a81d50ea3e6e5c57fff0bc8a12dc170c4d0175bfa88L288-R291)

### Related Issues

* Closes #2100
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
