### PR TITLE
chore: ensure download-artifacts and attach-docs-enabled are boolean values in Hugo Docs build workflow

### DIFF
--- a/.github/workflows/flow-hugo-publish.yaml
+++ b/.github/workflows/flow-hugo-publish.yaml
@@ -118,7 +118,7 @@ jobs:
       - hugo-docs-build
     with:
       docs-build-label: 'main'
-      download-artifacts: ${{ needs.setup.outputs.download-artifacts }}
+      download-artifacts: ${{ needs.setup.outputs.download-artifacts == 'true' }}
       ref: ${{ needs.setup.outputs.ref }}
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -134,4 +134,4 @@ jobs:
     with:
       docs-build-label: ${{ needs.setup.outputs.docs-build-label }}
       dry-run-enabled: ${{ inputs.dry-run-enabled }}
-      attach-docs-enabled: ${{ needs.setup.outputs.attach-docs-enabled }}
+      attach-docs-enabled: ${{ needs.setup.outputs.attach-docs-enabled == 'true' }}


### PR DESCRIPTION
## Description

This pull request changes the following:

This pull request updates the `.github/workflows/flow-hugo-publish.yaml` file to ensure boolean outputs are explicitly compared to the string `'true'`. This change improves the reliability and clarity of conditional evaluations in the workflow.

Workflow updates:

* Updated the `download-artifacts` parameter to explicitly compare `needs.setup.outputs.download-artifacts` with `'true'`. (`[.github/workflows/flow-hugo-publish.yamlL121-R121](diffhunk://#diff-d5ec53944df3276238a84b403bcc823827d7b0bd6bc5ee2fb56c629a66555752L121-R121)`)
* Updated the `attach-docs-enabled` parameter to explicitly compare `needs.setup.outputs.attach-docs-enabled` with `'true'`. (`[.github/workflows/flow-hugo-publish.yamlL137-R137](diffhunk://#diff-d5ec53944df3276238a84b403bcc823827d7b0bd6bc5ee2fb56c629a66555752L137-R137)`)

### Related Issues

* Closes #731 
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
