### PR TITLE
fix: update Hugo workflows to standardize output variable names and improve dry-run handling

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -83,7 +83,9 @@ jobs:
         run: |
           cat VERSION
           [[ "${{ github.event.inputs.dry-run-enabled }}" == true && ! -f VERSION ]] && echo -n "0.0.0-latest" > VERSION
-          echo "version=$(cat VERSION | tr -d '[:space:]')" | tee -a ${GITHUB_OUTPUT}
+          TRIMMED_VERSION=$(cat VERSION | tr -d '[:space:]')
+          echo "version=${TRIMMED_VERSION}" >> $GITHUB_OUTPUT
+          echo "version=${TRIMMED_VERSION}"
 
   create-github-release:
     name: Github / Release
@@ -203,7 +205,7 @@ jobs:
     name: Hugo Docs Setup
     runs-on: hiero-solo-linux-medium
     outputs:
-      tag-ref: ${{ steps.set-inputs.outputs.tag-ref }}
+      tag-ref: ${{ steps.set-inputs.outputs.tag_ref }}
     needs:
       - prepare-release
     steps:
@@ -218,10 +220,12 @@ jobs:
           set -xeo pipefail
           if [[ "${{ inputs.dry-run-enabled }}" == 'true' ]]; then
             echo "Dry run enabled, setting ref to `github.ref` since tag won't exist."
-            echo "tag-ref=${{ github.ref }}" >> $GITHUB_OUTPUT
+            echo "tag_ref=${{ github.ref }}" >> $GITHUB_OUTPUT
+            echo "tag_ref=${{ github.ref }}"
           else
             echo "Dry run not enabled, setting ref to 'refs/tags/v${{ needs.prepare-release.outputs.version }}'."
-            echo "tag-ref='refs/tags/v${{ needs.prepare-release.outputs.version }}'" >> $GITHUB_OUTPUT
+            echo "tag_ref='refs/tags/v${{ needs.prepare-release.outputs.version }}'" >> $GITHUB_OUTPUT
+            echo "tag_ref='refs/tags/v${{ needs.prepare-release.outputs.version }}'"
           fi
 
   # Do a Hugo build for the docs site for the release branch

--- a/.github/workflows/flow-hugo-publish.yaml
+++ b/.github/workflows/flow-hugo-publish.yaml
@@ -57,9 +57,9 @@ jobs:
     name: Setup
     runs-on: hiero-solo-linux-medium
     outputs:
-      docs-build-label: ${{ steps.set-inputs.outputs.docs-build-label }}
-      attach-docs-enabled: ${{ steps.set-inputs.outputs.attach-docs-enabled }}
-      download-artifacts: ${{ steps.set-inputs.outputs.download-artifacts }}
+      docs-build-label: ${{ steps.set-inputs.outputs.docs_build_label }}
+      main-ref: ${{ steps.set-inputs.outputs.main_ref }}
+      versioned-release: ${{ steps.set-inputs.outputs.versioned_release }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
@@ -70,36 +70,70 @@ jobs:
         id: set-inputs
         run: |
           set -xeo pipefail
-          SOLO_VERSION="${{ inputs.docs-build-label }}"
-          DOWNLOAD_ARTIFACTS=false
+          echo ":::group::Set Inputs"
+          echo "Inputs:"
+          echo "docs-build-label=${{ inputs.docs-build-label }}"
+          echo "dry-run-enabled=${{ inputs.dry-run-enabled }}"
+          echo "github.ref=${{ github.ref }}"
+          echo "github.ref_name=${{ github.ref_name }}"
+          echo "github.event_name=${{ github.event_name }}"
+          echo ":::endgroup::"
           
-          if [[ -z "${SOLO_VERSION}" ]]; then
+          echo ":::group::Default Output Values"
+          DOCS_BUILD_LABEL="${{ inputs.docs-build-label }}"
+          echo "defaulting: DOCS_BUILD_LABEL=${DOCS_BUILD_LABEL}"
+          MAIN_REF="main"
+          echo "defaulting: MAIN_REF=${MAIN_REF}"
+          VERSIONED_RELEASE=false
+          echo "defaulting: VERSIONED_RELEASE=${VERSIONED_RELEASE}"
+          echo ":::endgroup::"
+         
+          echo ":::group::Setting Inputs" 
+          if [[ -z "${DOCS_BUILD_LABEL}" ]]; then
             echo "No docs-build-label input provided for push to 'main' or 'release/*', defaulting to 'main'."
-            SOLO_VERSION='main'
+            DOCS_BUILD_LABEL='main'
+            echo "setting: DOCS_BUILD_LABEL=${DOCS_BUILD_LABEL}"
           fi
-          echo "docs-build-label=${SOLO_VERSION}" >> $GITHUB_OUTPUT
-          
+         
           # Only download artifacts and attach docs to a release if this is a workflow_dispatch running with a version tag
           if [[ "${{ github.ref_name }}" != "main" && "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "attach-docs-enabled=true" >> $GITHUB_OUTPUT
-            DOWNLOAD_ARTIFACTS=true
+            echo "Running with a version tag and via workflow_dispatch, this is a versioned release."
+            VERSIONED_RELEASE=true
+            echo "setting: VERSIONED_RELEASE=${VERSIONED_RELEASE}"
           else
-            echo "attach-docs-enabled=false" >> $GITHUB_OUTPUT
+            echo "Running with 'main' or 'release/*' branch."
+            VERSIONED_RELEASE=false
+            echo "setting: VERSIONED_RELEASE=${VERSIONED_RELEASE}"
           fi
-          echo "download-artifacts=${DOWNLOAD_ARTIFACTS}" >> $GITHUB_OUTPUT
           
           # If the github.ref_name is `main`, then we will checkout github.ref, else checkout `main` for the 
           #  docs-build-label = `main`
           if [[ "${{ github.ref_name }}" == "main" ]]; then
-            echo "ref=${{ github.ref }}" >> $GITHUB_OUTPUT
+            echo "Running on 'main' branch, setting MAIN_REF to github.ref."
+            MAIN_REF="${{ github.ref }}"
+            echo "setting: MAIN_REF=${MAIN_REF}"
           else
-            echo "ref=main" >> $GITHUB_OUTPUT
+            echo "Running on a branch or tag other than 'main', setting MAIN_REF to 'main'."
+            MAIN_REF="main"
+            echo "setting: MAIN_REF=${MAIN_REF}"
           fi
+          echo ":::endgroup::"
+          
+          echo ":::group::Output Values"
+          echo "docs_build_label=${DOCS_BUILD_LABEL}" >> $GITHUB_OUTPUT
+          echo "output: docs_build_label=${DOCS_BUILD_LABEL}"
+          echo "main_ref=${MAIN_REF}" >> $GITHUB_OUTPUT
+          echo "output: main_ref=${MAIN_REF}"
+          echo "versioned_release=${VERSIONED_RELEASE}" >> $GITHUB_OUTPUT
+          echo "output: versioned_release=${VERSIONED_RELEASE}"
+          echo ":::endgroup::"
+
+  # ------- Hugo Build and Publish for Version Tag and Main Branch -------
 
   # Do a Hugo build for the docs site for a version tag
   hugo-docs-build:
     name: Hugo Docs Build
-    if: ${{ needs.setup.outputs.docs-build-label != 'main' && github.ref_name != 'main' && !cancelled() && !failure() }}
+    if: ${{ needs.setup.outputs.versioned-release == 'true' && !cancelled() && !failure() }}
     uses: ./.github/workflows/zxc-hugo-build.yaml
     needs:
       - setup
@@ -113,7 +147,6 @@ jobs:
   #  to GitHub Pages.  This runs after hugo-docs-build if the docs-build-label is not 'main'.
   hugo-docs-build-main:
     name: Hugo Docs Build Main
-    if: ${{ needs.setup.outputs.download-artifacts == 'true' && !cancelled() && !failure() }}
     uses: ./.github/workflows/zxc-hugo-build.yaml
     needs:
       - setup
@@ -121,7 +154,7 @@ jobs:
     with:
       docs-build-label: 'main'
       download-artifacts: true
-      ref: ${{ needs.setup.outputs.ref }}
+      ref: ${{ needs.setup.outputs.main-ref }}
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -135,21 +168,22 @@ jobs:
       - hugo-docs-build-main
     with:
       docs-build-label: ${{ needs.setup.outputs.docs-build-label }}
-      dry-run-enabled: ${{ inputs.dry-run-enabled == true }}
       attach-docs-enabled: true
+      dry-run-enabled: ${{ inputs.dry-run-enabled == true }}
+
+  # ------- Hugo Build and Publish for Main Branch Only -------
 
   # Do a Hugo build for the docs site for the main branch, this is when the hugo-docs-build is skipped, the need clause
   #  is different
   hugo-docs-build-main-only:
     name: Hugo Docs Build Main
-    if: ${{ needs.setup.outputs.download-artifacts != 'true' && !cancelled() && !failure() }}
+    if: ${{ needs.setup.outputs.versioned-release == 'false' && !cancelled() && !failure() }}
     uses: ./.github/workflows/zxc-hugo-build.yaml
     needs:
       - setup
     with:
       docs-build-label: 'main'
-      download-artifacts: false
-      ref: ${{ needs.setup.outputs.ref }}
+      ref: ${{ needs.setup.outputs.main-ref }}
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -163,5 +197,4 @@ jobs:
       - hugo-docs-build-main-only
     with:
       docs-build-label: ${{ needs.setup.outputs.docs-build-label }}
-      dry-run-enabled: ${{ inputs.dry-run-enabled == true }}
-      attach-docs-enabled: false
+      dry-run-enabled: ${{ inputs.dry-run-enabled == true }} # compare to true, because it could be an empty string which throws an error


### PR DESCRIPTION
## Description

This pull request changes the following:

This pull request updates GitHub Actions workflows to improve consistency, readability, and functionality. Key changes include renaming output variables for clarity, enhancing logging and debugging, and refining conditional logic for better workflow behavior.

### Workflow Variable Updates:
* [`.github/workflows/flow-deploy-release-artifact.yaml`](diffhunk://#diff-f1bcd1ef387efde297c1469d5f2c6ed7ba81f38b14e3d54d270914d1125bb2ccL206-R208): Renamed output variables from `tag-ref` to `tag_ref` and updated related references for consistency. [[1]](diffhunk://#diff-f1bcd1ef387efde297c1469d5f2c6ed7ba81f38b14e3d54d270914d1125bb2ccL206-R208) [[2]](diffhunk://#diff-f1bcd1ef387efde297c1469d5f2c6ed7ba81f38b14e3d54d270914d1125bb2ccL221-R228)
* [`.github/workflows/flow-hugo-publish.yaml`](diffhunk://#diff-d5ec53944df3276238a84b403bcc823827d7b0bd6bc5ee2fb56c629a66555752L60-R62): Renamed outputs such as `docs-build-label` to `docs_build_label`, `attach-docs-enabled` to `versioned_release`, and `download-artifacts` to `main_ref`. Updated corresponding references throughout the file. [[1]](diffhunk://#diff-d5ec53944df3276238a84b403bcc823827d7b0bd6bc5ee2fb56c629a66555752L60-R62) [[2]](diffhunk://#diff-d5ec53944df3276238a84b403bcc823827d7b0bd6bc5ee2fb56c629a66555752L116-R157)

### Enhanced Logging and Debugging:
* [`.github/workflows/flow-hugo-publish.yaml`](diffhunk://#diff-d5ec53944df3276238a84b403bcc823827d7b0bd6bc5ee2fb56c629a66555752L73-R136): Added grouped logs for input values, default output values, and final output values to improve debugging and traceability.

### Conditional Logic Refinements:
* [`.github/workflows/flow-hugo-publish.yaml`](diffhunk://#diff-d5ec53944df3276238a84b403bcc823827d7b0bd6bc5ee2fb56c629a66555752L138-R186): Improved conditional logic for determining workflow execution paths, such as distinguishing between versioned releases and main branch builds. [[1]](diffhunk://#diff-d5ec53944df3276238a84b403bcc823827d7b0bd6bc5ee2fb56c629a66555752L138-R186) [[2]](diffhunk://#diff-d5ec53944df3276238a84b403bcc823827d7b0bd6bc5ee2fb56c629a66555752L166-R200)

### Output Handling Improvements:
* [`.github/workflows/flow-deploy-release-artifact.yaml`](diffhunk://#diff-f1bcd1ef387efde297c1469d5f2c6ed7ba81f38b14e3d54d270914d1125bb2ccL86-R88): Updated how output variables like `version` and `tag_ref` are echoed and stored, ensuring proper formatting and readability. [[1]](diffhunk://#diff-f1bcd1ef387efde297c1469d5f2c6ed7ba81f38b14e3d54d270914d1125bb2ccL86-R88) [[2]](diffhunk://#diff-f1bcd1ef387efde297c1469d5f2c6ed7ba81f38b14e3d54d270914d1125bb2ccL221-R228)


### Related Issues

* Closes #731
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
