### PR TITLE
chore: fix issue causing hugo build checkout to skip

### DIFF
--- a/.github/workflows/flow-hugo-publish.yaml
+++ b/.github/workflows/flow-hugo-publish.yaml
@@ -70,25 +70,25 @@ jobs:
         id: set-inputs
         run: |
           set -xeo pipefail
-          echo ":::group::Set Inputs"
+          echo "::group::Set Inputs"
           echo "Inputs:"
           echo "docs-build-label=${{ inputs.docs-build-label }}"
           echo "dry-run-enabled=${{ inputs.dry-run-enabled }}"
           echo "github.ref=${{ github.ref }}"
           echo "github.ref_name=${{ github.ref_name }}"
           echo "github.event_name=${{ github.event_name }}"
-          echo ":::endgroup::"
+          echo "::endgroup::"
           
-          echo ":::group::Default Output Values"
+          echo "::group::Default Output Values"
           DOCS_BUILD_LABEL="${{ inputs.docs-build-label }}"
           echo "defaulting: DOCS_BUILD_LABEL=${DOCS_BUILD_LABEL}"
           MAIN_REF="main"
           echo "defaulting: MAIN_REF=${MAIN_REF}"
           VERSIONED_RELEASE=false
           echo "defaulting: VERSIONED_RELEASE=${VERSIONED_RELEASE}"
-          echo ":::endgroup::"
+          echo "::endgroup::"
          
-          echo ":::group::Setting Inputs" 
+          echo "::group::Setting Inputs" 
           if [[ -z "${DOCS_BUILD_LABEL}" ]]; then
             echo "No docs-build-label input provided for push to 'main' or 'release/*', defaulting to 'main'."
             DOCS_BUILD_LABEL='main'
@@ -117,16 +117,16 @@ jobs:
             MAIN_REF="main"
             echo "setting: MAIN_REF=${MAIN_REF}"
           fi
-          echo ":::endgroup::"
+          echo "::endgroup::"
           
-          echo ":::group::Output Values"
+          echo "::group::Output Values"
           echo "docs_build_label=${DOCS_BUILD_LABEL}" >> $GITHUB_OUTPUT
           echo "output: docs_build_label=${DOCS_BUILD_LABEL}"
           echo "main_ref=${MAIN_REF}" >> $GITHUB_OUTPUT
           echo "output: main_ref=${MAIN_REF}"
           echo "versioned_release=${VERSIONED_RELEASE}" >> $GITHUB_OUTPUT
           echo "output: versioned_release=${VERSIONED_RELEASE}"
-          echo ":::endgroup::"
+          echo "::endgroup::"
 
   # ------- Hugo Build and Publish for Version Tag and Main Branch -------
 

--- a/.github/workflows/zxc-hugo-build.yaml
+++ b/.github/workflows/zxc-hugo-build.yaml
@@ -72,7 +72,6 @@ jobs:
           fi
 
       - name: Checkout Code
-        if: ${{ inputs.docs-build-label == 'main' && github.ref_name != 'main' && !cancelled() && !failure() }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Description

This pull request changes the following:

This pull request includes updates to GitHub Actions workflows to standardize logging and improve clarity in the `flow-hugo-publish` workflow, as well as a minor cleanup in the `zxc-hugo-build` workflow.

### Workflow Updates

**Standardized Logging in `flow-hugo-publish` Workflow:**
* Updated the group markers in `.github/workflows/flow-hugo-publish.yaml` from `:::group::` and `:::endgroup::` to the correct syntax `::group::` and `::endgroup::` for improved compatibility and readability. [[1]](diffhunk://#diff-d5ec53944df3276238a84b403bcc823827d7b0bd6bc5ee2fb56c629a66555752L73-R91) [[2]](diffhunk://#diff-d5ec53944df3276238a84b403bcc823827d7b0bd6bc5ee2fb56c629a66555752L120-R129)

**Cleanup in `zxc-hugo-build` Workflow:**
* Removed an unused conditional statement from the `Checkout Code` step in `.github/workflows/zxc-hugo-build.yaml` to simplify the workflow logic.

### Related Issues

* Closes #
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
