### PR TITLE
chore: fix hugo build issue not picking up GH_TOKEN since it is in a Taskfile task call

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -139,7 +139,7 @@ jobs:
 
       - name: Build Production Distribution
         run: |
-          set -x
+          set -eo pipefail
           npm install
           echo "VERSION=${{ needs.prepare-release.outputs.version }}"
           [[ -n "${{ needs.prepare-release.outputs.version }}" ]] && npm version ${{ needs.prepare-release.outputs.version }} -f --no-git-tag-version --allow-same-version
@@ -217,7 +217,7 @@ jobs:
       - name: Set Inputs
         id: set-inputs
         run: |
-          set -xeo pipefail
+          set -eo pipefail
           if [[ "${{ inputs.dry-run-enabled }}" == 'true' ]]; then
             echo "Dry run enabled, setting ref to `github.ref` since tag won't exist."
             echo "tag_ref=${{ github.ref }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/flow-hugo-publish.yaml
+++ b/.github/workflows/flow-hugo-publish.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Set Inputs
         id: set-inputs
         run: |
-          set -xeo pipefail
+          set -eo pipefail
           echo "::group::Set Inputs"
           echo "Inputs:"
           echo "docs-build-label=${{ inputs.docs-build-label }}"

--- a/.github/workflows/zxc-hugo-build.yaml
+++ b/.github/workflows/zxc-hugo-build.yaml
@@ -103,7 +103,7 @@ jobs:
       - name: List Artifacts
         if: ${{ inputs.download-artifacts && !cancelled() && !failure() }}
         run: |
-          set -xeo pipefail
+          set -eo pipefail
           echo "Listing downloaded build artifacts:"
           ls -la ./docs/site/build # what to upload as a release artifact
           ls -la ./docs/site/public # what to upload to GitHub Pages
@@ -112,13 +112,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.github-token }} # We want this to be null unless we want to pull the existing release artifacts
         run: |
-          set -xeo pipefail
+          set -eo pipefail
           cd docs/site
           DOCS_BUILD_LABEL="${{ inputs.docs-build-label }}"
           if [[ -z ${DOCS_BUILD_LABEL} ]]; then
-           task build 
+           GH_TOKEN=${{ secrets.github-token }} task build 
           else
-            HUGO_SOLO_VERSION=${DOCS_BUILD_LABEL} task build
+            GH_TOKEN=${{ secrets.github-token }} HUGO_SOLO_VERSION=${DOCS_BUILD_LABEL} task build
           fi
 
       # Upload the built site to artifacts

--- a/.github/workflows/zxc-hugo-publish.yaml
+++ b/.github/workflows/zxc-hugo-publish.yaml
@@ -77,17 +77,15 @@ jobs:
 
       - name: List Artifacts
         run: |
-          set -xeo pipefail
+          set -eo pipefail
           echo "Listing downloaded build artifacts:"
           ls -la ./docs/site/build # what to upload as a release artifact
           ls -la ./docs/site/public # what to upload to GitHub Pages
 
       - name: Attach Docs as Release Artifacts
         if: ${{ inputs.attach-docs-enabled && !inputs.dry-run-enabled && !cancelled() && !failure() }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -xeo pipefail
+          set -eo pipefail
           RELEASE_VERSION="${{ inputs.docs-build-label }}"
           # Ensure the release version is set
           if [[ -z "${RELEASE_VERSION}" ]]; then
@@ -96,7 +94,7 @@ jobs:
           fi
           cd docs/site
           # Create the release artifact tarballs
-          HUGO_SOLO_VERSION="${RELEASE_VERSION}" task github:upload:release:assets
+          GH_TOKEN=${{ secrets.GITHUB_TOKEN }} HUGO_SOLO_VERSION="${RELEASE_VERSION}" task github:upload:release:assets
 
       # Upload / stage the built site to GitHub Pages
       - name: Upload Pages Artifact

--- a/docs/site/Taskfile.github.yaml
+++ b/docs/site/Taskfile.github.yaml
@@ -3,15 +3,13 @@ tasks:
   github:list:solo:releases:
     desc: List GitHub releases for hiero-ledger/solo using gh CLI and output as JSON (excluding empty assets)
     silent: true
-    deps: [solo:version,install:gh]
-    status:
+    deps: [install:gh]
+    cmds:
       - |
         if [[ -z "${GH_TOKEN}" ]]; then
           echo "WARN: GH_TOKEN is not set. Cannot run `gh` commands, skipping step." >&2
           exit 1
         fi
-    cmds:
-      - |
         printf "\r::group::Fetching GitHub releases for hiero-ledger/solo...\n"
         mkdir -p build
         touch build/github-releases.json
@@ -146,7 +144,6 @@ tasks:
 
   github:augment:releases:
     desc: Add npmjsLatest field to each release in github-releases.json and save to build/releases.json
-    deps: [npmjs:latest:solo:version,npmjs:list:solo:versions,github:list:solo:releases]
     silent: true
     cmds:
       - |

--- a/docs/site/Taskfile.github.yaml
+++ b/docs/site/Taskfile.github.yaml
@@ -1,10 +1,9 @@
 version: 3
 tasks:
-  # this will need adjusting once I get an artifact published
   github:list:solo:releases:
     desc: List GitHub releases for hiero-ledger/solo using gh CLI and output as JSON (excluding empty assets)
     silent: true
-    deps: [install:gh]
+    deps: [solo:version,install:gh]
     status:
       - |
         if [[ -z "${GH_TOKEN}" ]]; then
@@ -147,7 +146,7 @@ tasks:
 
   github:augment:releases:
     desc: Add npmjsLatest field to each release in github-releases.json and save to build/releases.json
-    deps: [github:list:solo:releases]
+    deps: [npmjs:latest:solo:version,npmjs:list:solo:versions,github:list:solo:releases]
     silent: true
     cmds:
       - |

--- a/docs/site/Taskfile.github.yaml
+++ b/docs/site/Taskfile.github.yaml
@@ -8,7 +8,7 @@ tasks:
       - |
         if [[ -z "${GH_TOKEN}" ]]; then
           echo "WARN: GH_TOKEN is not set. Cannot run `gh` commands, skipping step." >&2
-          exit 1
+          exit 0
         fi
         printf "\r::group::Fetching GitHub releases for hiero-ledger/solo...\n"
         mkdir -p build
@@ -196,16 +196,15 @@ tasks:
     deps: [install:gh]
     requires:
       vars: [HUGO_SOLO_VERSION]
-    status:
-      - |
-        if [[ -z "${GH_TOKEN}" ]]; then
-          echo "WARN: GH_TOKEN is not set. Cannot run `gh` commands, skipping step." >&2
-          exit 1
-        fi
     cmds:
       - |
         # Start with strict mode for the shell script
         set -e -o pipefail
+
+        if [[ -z "${GH_TOKEN}" ]]; then
+          echo "WARN: GH_TOKEN is not set. Cannot run `gh` commands, skipping step." >&2
+          exit 0
+        fi
 
         # HUGO_SOLO_VERSION is expected from the environment. Task fails if not set.
         RELEASE_TAG=${HUGO_SOLO_VERSION}

--- a/docs/site/Taskfile.yaml
+++ b/docs/site/Taskfile.yaml
@@ -141,6 +141,7 @@ tasks:
         BUILD_DIR=docs/site/build
         SOLO_VERSION_FILE=$BUILD_DIR/version.txt
         mkdir -p $BUILD_DIR
+        touch $BUILD_DIR/github-releases.json
         echo -n "v$(node -p "require('./package.json').version")" > $SOLO_VERSION_FILE
         SOLO_VERSION=$(<"$SOLO_VERSION_FILE")
         SOLO_VERSION=$(echo "$SOLO_VERSION" | tr -d '\r\n[:space:]')


### PR DESCRIPTION
## Description

This pull request changes the following:

This pull request includes updates across several workflow files and task files to improve error handling and streamline the build process. The main changes involve replacing `set -xeo pipefail` with `set -eo pipefail` for better control over script execution, adding necessary environment variables for tasks, and refining task dependencies and commands.

### Workflow Updates

* [`.github/workflows/flow-deploy-release-artifact.yaml`](diffhunk://#diff-f1bcd1ef387efde297c1469d5f2c6ed7ba81f38b14e3d54d270914d1125bb2ccL142-R142): Replaced `set -xeo pipefail` with `set -eo pipefail` in multiple job steps to simplify error handling during script execution. [[1]](diffhunk://#diff-f1bcd1ef387efde297c1469d5f2c6ed7ba81f38b14e3d54d270914d1125bb2ccL142-R142) [[2]](diffhunk://#diff-f1bcd1ef387efde297c1469d5f2c6ed7ba81f38b14e3d54d270914d1125bb2ccL220-R220)
* [`.github/workflows/flow-hugo-publish.yaml`](diffhunk://#diff-d5ec53944df3276238a84b403bcc823827d7b0bd6bc5ee2fb56c629a66555752L72-R72): Updated job steps to use `set -eo pipefail` instead of `set -xeo pipefail`.
* [`.github/workflows/zxc-hugo-build.yaml`](diffhunk://#diff-d7c642da522cbc1a5707cd0d06ee304ddf3126d545e13b7eabea821f8a452910L115-R121): Added `GH_TOKEN` environment variable to build commands and replaced `set -xeo pipefail` with `set -eo pipefail` for better script control. [[1]](diffhunk://#diff-d7c642da522cbc1a5707cd0d06ee304ddf3126d545e13b7eabea821f8a452910L115-R121) [[2]](diffhunk://#diff-d7c642da522cbc1a5707cd0d06ee304ddf3126d545e13b7eabea821f8a452910L106-R106)
* [`.github/workflows/zxc-hugo-publish.yaml`](diffhunk://#diff-cc7fa61f95c59ad89fe0c53cb4033762e4ce7ecead4376befc08952970f4e12aL80-R88): Refined artifact listing and release attachment steps by using `set -eo pipefail` and adding `GH_TOKEN` for release-related tasks. [[1]](diffhunk://#diff-cc7fa61f95c59ad89fe0c53cb4033762e4ce7ecead4376befc08952970f4e12aL80-R88) [[2]](diffhunk://#diff-cc7fa61f95c59ad89fe0c53cb4033762e4ce7ecead4376befc08952970f4e12aL99-R97)

### Task File Updates

* [`docs/site/Taskfile.github.yaml`](diffhunk://#diff-7a445dc9e0cd56100303e986643a8da9630004b4fa9221751d4cbc67a07f5c06L3-L15): Adjusted task dependencies and commands, including moving `cmds` for `github:list:solo:releases` and removing unnecessary `deps` for `github:augment:releases`. [[1]](diffhunk://#diff-7a445dc9e0cd56100303e986643a8da9630004b4fa9221751d4cbc67a07f5c06L3-L15) [[2]](diffhunk://#diff-7a445dc9e0cd56100303e986643a8da9630004b4fa9221751d4cbc67a07f5c06L150)
* [`docs/site/Taskfile.yaml`](diffhunk://#diff-ca1683e09f8618eb4f2e4ed7d3534abe1367d012ed3089c47a13921b9d254dfeR144): Added the creation of `github-releases.json` in the build directory during the build process to ensure required files are available.

### Related Issues

* Closes #731 
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
