### PR TITLE
feat: add MVP version of `solo quick-start single`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,4 @@
 registry=https://artifacts.hashgraph.io/artifactory/central-npm-external
 audit=false
-loglevel=verbose
+#loglevel=verbose
 always-auth=true

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -12,23 +12,25 @@ import {type ExplorerCommand} from './explorer.js';
 import {type BlockNodeCommand} from './block-node.js';
 import {container} from 'tsyringe-neo';
 import {InjectTokens} from '../core/dependency-injection/inject-tokens.js';
+import {type QuickStartCommand} from './quick-start.js';
+import {type CommandDefinition} from '../types/index.js';
 
 /**
  * Return a list of Yargs command builder to be exposed through CLI
  * @returns an array of Yargs command builder
  */
-export function Initialize() {
-  const initCmd = container.resolve(InjectTokens.InitCommand) as InitCommand;
-  const clusterCmd = container.resolve(InjectTokens.ClusterCommand) as ClusterCommand;
-  const networkCommand = container.resolve(InjectTokens.NetworkCommand) as NetworkCommand;
-  const nodeCmd = container.resolve(InjectTokens.NodeCommand) as NodeCommand;
-  const relayCmd = container.resolve(InjectTokens.RelayCommand) as RelayCommand;
-  const accountCmd = container.resolve(InjectTokens.AccountCommand) as AccountCommand;
-  const mirrorNodeCmd = container.resolve(InjectTokens.MirrorNodeCommand) as MirrorNodeCommand;
-  const explorerCommand = container.resolve(InjectTokens.ExplorerCommand) as ExplorerCommand;
-  const deploymentCommand = container.resolve(InjectTokens.DeploymentCommand) as DeploymentCommand;
-  const blockNodeCommand = container.resolve(InjectTokens.BlockNodeCommand) as BlockNodeCommand;
-
+export function Initialize(): CommandDefinition[] {
+  const initCmd: InitCommand = container.resolve(InjectTokens.InitCommand);
+  const clusterCmd: ClusterCommand = container.resolve(InjectTokens.ClusterCommand);
+  const networkCommand: NetworkCommand = container.resolve(InjectTokens.NetworkCommand);
+  const nodeCmd: NodeCommand = container.resolve(InjectTokens.NodeCommand);
+  const relayCmd: RelayCommand = container.resolve(InjectTokens.RelayCommand);
+  const accountCmd: AccountCommand = container.resolve(InjectTokens.AccountCommand);
+  const mirrorNodeCmd: MirrorNodeCommand = container.resolve(InjectTokens.MirrorNodeCommand);
+  const explorerCommand: ExplorerCommand = container.resolve(InjectTokens.ExplorerCommand);
+  const deploymentCommand: DeploymentCommand = container.resolve(InjectTokens.DeploymentCommand);
+  const blockNodeCommand: BlockNodeCommand = container.resolve(InjectTokens.BlockNodeCommand);
+  const quickStartCommand: QuickStartCommand = container.resolve(InjectTokens.QuickStartCommand);
   return [
     initCmd.getCommandDefinition(),
     accountCmd.getCommandDefinition(),
@@ -40,5 +42,6 @@ export function Initialize() {
     explorerCommand.getCommandDefinition(),
     deploymentCommand.getCommandDefinition(),
     blockNodeCommand.getCommandDefinition(),
+    quickStartCommand.getCommandDefinition(),
   ];
 }

--- a/src/commands/quick-start.ts
+++ b/src/commands/quick-start.ts
@@ -179,7 +179,8 @@ export class QuickStartCommand extends BaseCommand {
             this.argvPushGlobalFlags(argv);
             await main(argv);
           },
-        }, // ClusterReferenceTest.setup(options);
+        },
+        // ClusterReferenceTest.setup(options);
         // NodeTest.keys(options);
         // NetworkTest.deploy(options);
         // NodeTest.setup(options);

--- a/src/commands/quick-start.ts
+++ b/src/commands/quick-start.ts
@@ -271,6 +271,24 @@ export class QuickStartCommand extends BaseCommand {
             await main(argv);
           },
         },
+        {
+          title: 'solo relay deploy',
+          task: async (context_): Promise<void> => {
+            const argv: string[] = this.newArgv();
+            argv.push(
+              'relay',
+              'deploy',
+              this.optionFromFlag(Flags.deployment),
+              context_.config.deployment,
+              this.optionFromFlag(Flags.clusterRef),
+              context_.config.clusterRef,
+              this.optionFromFlag(Flags.nodeAliasesUnparsed),
+              'node1',
+            );
+            this.argvPushGlobalFlags(argv, context_.config.cacheDir);
+            await main(argv);
+          },
+        },
       ],
       {
         concurrent: false,

--- a/src/commands/quick-start.ts
+++ b/src/commands/quick-start.ts
@@ -220,7 +220,15 @@ export class QuickStartCommand extends BaseCommand {
             await main(argv);
           },
         },
-        // NodeTest.setup(options);
+        {
+          title: 'solo node setup',
+          task: async (context_): Promise<void> => {
+            const argv: string[] = this.newArgv();
+            argv.push('node', 'setup', this.optionFromFlag(Flags.deployment), context_.config.deployment);
+            this.argvPushGlobalFlags(argv, context_.config.cacheDir);
+            await main(argv);
+          },
+        },
         // NodeTest.start(options);
         // MirrorNodeTest.deploy(options);
       ],

--- a/src/commands/quick-start.ts
+++ b/src/commands/quick-start.ts
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {Listr} from 'listr2';
+import {SoloError} from '../core/errors/solo-error.js';
+import * as constants from '../core/constants.js';
+import {BaseCommand} from './base.js';
+import {Flags, Flags as flags} from './flags.js';
+import {type AnyListrContext, type AnyYargs, type ArgvStruct} from '../types/aliases.js';
+import {type CommandDefinition} from '../types/index.js';
+import {type CommandFlag, type CommandFlags} from '../types/flag-types.js';
+import {CommandBuilder, CommandGroup, Subcommand} from '../core/command-path-builders/command-builder.js';
+import {inject, injectable} from 'tsyringe-neo';
+import {InjectTokens} from '../core/dependency-injection/inject-tokens.js';
+import {type ComponentFactoryApi} from '../core/config/remote/api/component-factory-api.js';
+import {main} from '../index.js';
+
+interface QuickStartDeployConfigClass {
+  dummyVariable?: string; // Placeholder for actual configuration properties
+}
+
+interface QuickStartDeployContext {
+  config: QuickStartDeployConfigClass;
+}
+
+interface QuickStartDestroyConfigClass {
+  dummyVariable?: string; // Placeholder for actual configuration properties
+}
+
+interface QuickStartDestroyContext {
+  config: QuickStartDestroyConfigClass;
+}
+
+@injectable()
+export class QuickStartCommand extends BaseCommand {
+  public constructor(@inject(InjectTokens.ComponentFactory) private readonly componentFactory: ComponentFactoryApi) {
+    super();
+  }
+
+  public static readonly COMMAND_NAME: string = 'quick-start';
+
+  private static readonly SINGLE_ADD_CONFIGS_NAME: string = 'singleAddConfigs';
+
+  private static readonly SINGLE_DESTROY_CONFIGS_NAME: string = 'singleDestroyConfigs';
+
+  private static readonly SINGLE_ADD_FLAGS_LIST: CommandFlags = {
+    required: [],
+    optional: [
+      flags.apiPermissionProperties,
+      flags.applicationEnv,
+      flags.applicationProperties,
+      flags.cacheDir,
+      flags.clusterRef,
+      flags.clusterSetupNamespace,
+      flags.context,
+      flags.deployment,
+      flags.devMode,
+      flags.log4j2Xml,
+      flags.namespace,
+      flags.networkDeploymentValuesFile,
+      flags.numberOfConsensusNodes,
+      flags.persistentVolumeClaims,
+      flags.pinger,
+      flags.quiet,
+      flags.releaseTag,
+      flags.soloChartVersion,
+      // TODO: flags.mirrorNodeValuesFile,
+      // TODO: flags.explorerValuesFile,
+      // TODO: flags.relayValuesFile,
+    ],
+  };
+
+  private static readonly SINGLE_DESTROY_FLAGS_LIST: CommandFlags = {
+    required: [],
+    optional: [],
+  };
+
+  private newArgv(): string[] {
+    return ['${PATH}/node', '${SOLO_ROOT}/solo.ts'];
+  }
+
+  private optionFromFlag(flag: CommandFlag): string {
+    return `--${flag.name}`;
+  }
+
+  private argvPushGlobalFlags(argv: string[]): string[] {
+    argv.push(this.optionFromFlag(Flags.devMode), this.optionFromFlag(Flags.quiet));
+    return argv;
+  }
+
+  private async prepareValuesArgForQuickStart(config: QuickStartDeployConfigClass): Promise<string> {
+    return '';
+  }
+
+  private async deploy(argv: ArgvStruct): Promise<boolean> {
+    const tasks: Listr<QuickStartDeployContext> = new Listr<QuickStartDeployContext>(
+      [
+        {
+          title: 'Initialize',
+          task: async (context_, task): Promise<Listr<AnyListrContext>> => {
+            this.configManager.update(argv);
+
+            flags.disablePrompts(QuickStartCommand.SINGLE_ADD_FLAGS_LIST.optional);
+
+            const allFlags: CommandFlag[] = [
+              ...QuickStartCommand.SINGLE_ADD_FLAGS_LIST.required,
+              ...QuickStartCommand.SINGLE_ADD_FLAGS_LIST.optional,
+            ];
+
+            await this.configManager.executePrompt(task, allFlags);
+
+            context_.config = this.configManager.getConfig(
+              QuickStartCommand.SINGLE_ADD_CONFIGS_NAME,
+              allFlags,
+            ) as QuickStartDeployConfigClass;
+            return null;
+          },
+        },
+        {
+          title: 'solo init',
+          task: async (): Promise<void> => {
+            const argv: string[] = this.newArgv();
+            argv.push('init');
+            this.argvPushGlobalFlags(argv);
+            await main(argv);
+          },
+        },
+      ],
+      {
+        concurrent: false,
+        rendererOptions: constants.LISTR_DEFAULT_RENDERER_OPTION,
+      },
+    );
+
+    try {
+      await tasks.run();
+    } catch (error) {
+      throw new SoloError(`Error deploying Solo in quick-start mode: ${error.message}`, error);
+    }
+
+    return true;
+  }
+
+  private async destroy(argv: ArgvStruct): Promise<boolean> {
+    const tasks: Listr<QuickStartDestroyContext> = new Listr<QuickStartDestroyContext>([
+      {
+        title: 'Initialize',
+        task: async (context_, task): Promise<Listr<AnyListrContext>> => {
+          this.configManager.update(argv);
+
+          flags.disablePrompts(QuickStartCommand.SINGLE_DESTROY_FLAGS_LIST.optional);
+
+          const allFlags: CommandFlag[] = [
+            ...QuickStartCommand.SINGLE_DESTROY_FLAGS_LIST.required,
+            ...QuickStartCommand.SINGLE_DESTROY_FLAGS_LIST.optional,
+          ];
+
+          await this.configManager.executePrompt(task, allFlags);
+
+          context_.config = this.configManager.getConfig(
+            QuickStartCommand.SINGLE_DESTROY_CONFIGS_NAME,
+            allFlags,
+          ) as QuickStartDestroyConfigClass;
+
+          return null;
+        },
+      },
+    ]);
+
+    try {
+      await tasks.run();
+    } catch (error) {
+      throw new SoloError(`Error destroying Solo in quick-start mode: ${error.message}`, error);
+    }
+
+    return true;
+  }
+
+  public getCommandDefinition(): CommandDefinition {
+    return new CommandBuilder(QuickStartCommand.COMMAND_NAME, 'Manage quick start for solo network', this.logger)
+      .addCommandGroup(
+        new CommandGroup('single', 'A single consensus node quick start configuration')
+          .addSubcommand(
+            new Subcommand(
+              'deploy',
+              'Deploys all required components for the selected quick start configuration',
+              this,
+              this.deploy,
+              (y: AnyYargs): void => {
+                flags.setRequiredCommandFlags(y, ...QuickStartCommand.SINGLE_ADD_FLAGS_LIST.required);
+                flags.setOptionalCommandFlags(y, ...QuickStartCommand.SINGLE_ADD_FLAGS_LIST.optional);
+              },
+            ),
+          )
+          .addSubcommand(
+            new Subcommand(
+              'destroy',
+              'Removes the deployed resources for the selected quick start configuration',
+              this,
+              this.destroy,
+              (y: AnyYargs): void => {
+                flags.setRequiredCommandFlags(y, ...QuickStartCommand.SINGLE_DESTROY_FLAGS_LIST.required);
+                flags.setOptionalCommandFlags(y, ...QuickStartCommand.SINGLE_DESTROY_FLAGS_LIST.optional);
+              },
+            ),
+          ),
+      )
+      .build();
+  }
+
+  public async close(): Promise<void> {} // no-op
+}

--- a/src/commands/quick-start.ts
+++ b/src/commands/quick-start.ts
@@ -162,7 +162,6 @@ export class QuickStartCommand extends BaseCommand {
             await main(argv);
           },
         },
-        // DeploymentTest.addCluster(options);
         {
           title: 'solo deployment add-cluster',
           task: async (context_): Promise<void> => {

--- a/src/commands/quick-start.ts
+++ b/src/commands/quick-start.ts
@@ -229,8 +229,17 @@ export class QuickStartCommand extends BaseCommand {
             await main(argv);
           },
         },
-        // NodeTest.start(options);
+        {
+          title: 'solo node start',
+          task: async (context_): Promise<void> => {
+            const argv: string[] = this.newArgv();
+            argv.push('node', 'start', this.optionFromFlag(Flags.deployment), context_.config.deployment);
+            this.argvPushGlobalFlags(argv);
+            await main(argv);
+          },
+        },
         // MirrorNodeTest.deploy(options);
+        // ExplorerTest.deploy(options);
       ],
       {
         concurrent: false,

--- a/src/commands/quick-start.ts
+++ b/src/commands/quick-start.ts
@@ -118,10 +118,10 @@ export class QuickStartCommand extends BaseCommand {
               allFlags,
             ) as QuickStartDeployConfigClass;
 
-            context_.config.clusterRef = context_.config.clusterRef || `solo-${uuid4()}`; // TODO come up with better solution to avoid conflicts
+            context_.config.clusterRef = context_.config.clusterRef || `solo-${uuid4().slice(-8)}`; // TODO come up with better solution to avoid conflicts
             context_.config.context = context_.config.context || this.k8Factory.default().contexts().readCurrent();
-            context_.config.deployment = context_.config.deployment || `solo-deployment-${uuid4()}`; // TODO come up with better solution to avoid conflicts
-            context_.config.namespace = context_.config.namespace || NamespaceName.of(`solo-${uuid4()}`); // TODO come up with better solution to avoid conflicts
+            context_.config.deployment = context_.config.deployment || `solo-deployment-${uuid4().slice(-8)}`; // TODO come up with better solution to avoid conflicts
+            context_.config.namespace = context_.config.namespace || NamespaceName.of(`solo-${uuid4().slice(-8)}`); // TODO come up with better solution to avoid conflicts
             context_.config.numberOfConsensusNodes = context_.config.numberOfConsensusNodes || 1;
             return null;
           },

--- a/src/commands/quick-start.ts
+++ b/src/commands/quick-start.ts
@@ -289,6 +289,7 @@ export class QuickStartCommand extends BaseCommand {
             await main(argv);
           },
         },
+        // TODO expose port forward endpoints and dump the URLs to the user output
       ],
       {
         concurrent: false,

--- a/src/commands/quick-start.ts
+++ b/src/commands/quick-start.ts
@@ -99,6 +99,7 @@ export class QuickStartCommand extends BaseCommand {
   private async deploy(argv: ArgvStruct): Promise<boolean> {
     const tasks: Listr<QuickStartDeployContext> = new Listr<QuickStartDeployContext>(
       [
+        // TODO fix the sysout problem that causes this output only, but then dumps the rest of the output on exit, but it shows multiple lines for all of the row updates
         {
           title: 'Initialize',
           task: async (context_, task): Promise<Listr<AnyListrContext>> => {
@@ -285,11 +286,14 @@ export class QuickStartCommand extends BaseCommand {
               this.optionFromFlag(Flags.nodeAliasesUnparsed),
               'node1',
             );
-            this.argvPushGlobalFlags(argv, context_.config.cacheDir);
+            this.argvPushGlobalFlags(argv);
             await main(argv);
           },
         },
         // TODO expose port forward endpoints and dump the URLs to the user output
+        // TODO update documentation
+        // TODO make sure CLI Help script is working
+        // TODO manually test from the command line
       ],
       {
         concurrent: false,
@@ -330,6 +334,7 @@ export class QuickStartCommand extends BaseCommand {
           return null;
         },
       },
+      // TODO implement destroy tasks
     ]);
 
     try {

--- a/src/commands/quick-start.ts
+++ b/src/commands/quick-start.ts
@@ -255,7 +255,22 @@ export class QuickStartCommand extends BaseCommand {
             await main(argv);
           },
         },
-        // ExplorerTest.deploy(options);
+        {
+          title: 'solo explorer deploy',
+          task: async (context_): Promise<void> => {
+            const argv: string[] = this.newArgv();
+            argv.push(
+              'explorer',
+              'deploy',
+              this.optionFromFlag(Flags.deployment),
+              context_.config.deployment,
+              this.optionFromFlag(Flags.clusterRef),
+              context_.config.clusterRef,
+            );
+            this.argvPushGlobalFlags(argv, context_.config.cacheDir);
+            await main(argv);
+          },
+        },
       ],
       {
         concurrent: false,

--- a/src/commands/quick-start.ts
+++ b/src/commands/quick-start.ts
@@ -238,7 +238,23 @@ export class QuickStartCommand extends BaseCommand {
             await main(argv);
           },
         },
-        // MirrorNodeTest.deploy(options);
+        {
+          title: 'solo mirror-node deploy',
+          task: async (context_): Promise<void> => {
+            const argv: string[] = this.newArgv();
+            argv.push(
+              'mirror-node',
+              'deploy',
+              this.optionFromFlag(Flags.deployment),
+              context_.config.deployment,
+              this.optionFromFlag(Flags.clusterRef),
+              context_.config.clusterRef,
+              this.optionFromFlag(Flags.pinger),
+            );
+            this.argvPushGlobalFlags(argv, context_.config.cacheDir);
+            await main(argv);
+          },
+        },
         // ExplorerTest.deploy(options);
       ],
       {

--- a/src/core/dependency-injection/container-init.ts
+++ b/src/core/dependency-injection/container-init.ts
@@ -59,6 +59,7 @@ import {DefaultConfigSource} from '../../data/configuration/impl/default-config-
 import {type SoloConfigSchema} from '../../data/schema/model/solo/solo-config-schema.js';
 import {SoloConfigSchemaDefinition} from '../../data/schema/migration/impl/solo/solo-config-schema-definition.js';
 import {BeanFactorySupplier} from './bean-factory-supplier.js';
+import {QuickStartCommand} from '../../commands/quick-start.js';
 
 export type InstanceOverrides = Map<symbol, SingletonContainer | ValueContainer>;
 
@@ -129,6 +130,7 @@ export class Container {
       new SingletonContainer(InjectTokens.ObjectMapper, ClassToObjectMapper),
       new SingletonContainer(InjectTokens.ComponentFactory, ComponentFactory),
       new SingletonContainer(InjectTokens.RemoteConfigValidator, RemoteConfigValidator),
+      new SingletonContainer(InjectTokens.QuickStartCommand, QuickStartCommand),
     ];
   }
 

--- a/src/core/dependency-injection/inject-tokens.ts
+++ b/src/core/dependency-injection/inject-tokens.ts
@@ -61,4 +61,5 @@ export const InjectTokens = {
   LocalConfigSource: Symbol.for('LocalConfigSource'),
   LocalConfigRuntimeState: Symbol.for('LocalConfigRuntimeState'),
   HomeDirectory: Symbol.for('HomeDirectory'),
+  QuickStartCommand: Symbol.for('QuickStartCommand'),
 };

--- a/src/core/middlewares.ts
+++ b/src/core/middlewares.ts
@@ -154,6 +154,7 @@ export class Middlewares {
 
       const skip =
         command === 'init' ||
+        command === 'quick-start' ||
         (command === 'cluster-ref' && subCommand === 'connect') ||
         (command === 'cluster-ref' && subCommand === 'disconnect') ||
         (command === 'cluster-ref' && subCommand === 'info') ||
@@ -185,7 +186,7 @@ export class Middlewares {
   public loadLocalConfig() {
     return async (argv: any): Promise<AnyObject> => {
       const command: string = argv._[0];
-      const runMiddleware: boolean = command !== 'init';
+      const runMiddleware: boolean = command !== 'init' && command !== 'quick-start';
 
       if (runMiddleware) {
         this.logger.debug('Loading local config');
@@ -201,7 +202,7 @@ export class Middlewares {
    * @returns callback function to be executed from listr
    */
   public checkIfInitialized() {
-    const logger = this.logger;
+    const logger: SoloLogger = this.logger;
 
     /**
      * @param argv - listr Argv
@@ -209,8 +210,8 @@ export class Middlewares {
     return async (argv: any): Promise<AnyObject> => {
       logger.debug('Checking if local config exists');
 
-      const command = argv._[0];
-      const allowMissingLocalConfig = command === 'init';
+      const command: any = argv._[0];
+      const allowMissingLocalConfig: boolean = command === 'init' || command === 'quick-start';
 
       if (!allowMissingLocalConfig && !this.localConfig.configFileExists()) {
         throw new SoloError('Please run `solo init` to create required files');

--- a/test/e2e/commands/dual-cluster-full.test.ts
+++ b/test/e2e/commands/dual-cluster-full.test.ts
@@ -21,6 +21,7 @@ import {DeploymentTest} from './tests/deployment-test.js';
 import {NodeTest} from './tests/node-test.js';
 import {NetworkTest} from './tests/network-test.js';
 import {MirrorNodeTest} from './tests/mirror-node-test.js';
+import {ExplorerTest} from './tests/explorer-test.js';
 
 const testName: string = 'dual-cluster-full';
 
@@ -70,6 +71,7 @@ const endToEndTestSuite: EndToEndTestSuite = new EndToEndTestSuiteBuilder()
       NodeTest.setup(options);
       NodeTest.start(options);
       MirrorNodeTest.deploy(options);
+      ExplorerTest.deploy(options);
 
       // TODO json rpc relay deploy
       // TODO json rpc relay destroy

--- a/test/e2e/commands/quick-start-single.test.ts
+++ b/test/e2e/commands/quick-start-single.test.ts
@@ -51,6 +51,7 @@ const endToEndTestSuite: EndToEndTestSuite = new EndToEndTestSuiteBuilder()
         testLogger.info(`${testName}: starting ${testName} e2e test`);
       }).timeout(Duration.ofMinutes(5).toMillis());
 
+      // TODO pass in namespace for cache directory for proper destroy on restart
       it(`${testName}: deploy`, async (): Promise<void> => {
         testLogger.info(`${testName}: beginning ${testName}: deploy`);
         await main(soloQuickStartDeploy(testName));

--- a/test/e2e/commands/quick-start-single.test.ts
+++ b/test/e2e/commands/quick-start-single.test.ts
@@ -57,6 +57,8 @@ const endToEndTestSuite: EndToEndTestSuite = new EndToEndTestSuiteBuilder()
         await main(soloQuickStartDeploy(testName));
         testLogger.info(`${testName}: finished ${testName}: deploy`);
       }).timeout(Duration.ofMinutes(15).toMillis());
+
+      // TODO add verifications
     });
   })
   .build();

--- a/test/e2e/commands/quick-start-single.test.ts
+++ b/test/e2e/commands/quick-start-single.test.ts
@@ -59,6 +59,7 @@ const endToEndTestSuite: EndToEndTestSuite = new EndToEndTestSuiteBuilder()
       }).timeout(Duration.ofMinutes(15).toMillis());
 
       // TODO add verifications
+      // TODO integrate into CI e2e test suite
     });
   })
   .build();

--- a/test/e2e/commands/quick-start-single.test.ts
+++ b/test/e2e/commands/quick-start-single.test.ts
@@ -55,7 +55,7 @@ const endToEndTestSuite: EndToEndTestSuite = new EndToEndTestSuiteBuilder()
         testLogger.info(`${testName}: beginning ${testName}: deploy`);
         await main(soloQuickStartDeploy(testName));
         testLogger.info(`${testName}: finished ${testName}: deploy`);
-      });
+      }).timeout(Duration.ofMinutes(15).toMillis());
     });
   })
   .build();

--- a/test/e2e/commands/quick-start-single.test.ts
+++ b/test/e2e/commands/quick-start-single.test.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {describe} from 'mocha';
+
+import {resetForTest} from '../../test-container.js';
+import {container} from 'tsyringe-neo';
+import {InjectTokens} from '../../../src/core/dependency-injection/inject-tokens.js';
+import fs from 'node:fs';
+import {type K8ClientFactory} from '../../../src/integration/kube/k8-client/k8-client-factory.js';
+import {type K8} from '../../../src/integration/kube/k8.js';
+import {DEFAULT_LOCAL_CONFIG_FILE} from '../../../src/core/constants.js';
+import {Duration} from '../../../src/core/time/duration.js';
+import {PathEx} from '../../../src/business/utils/path-ex.js';
+
+import {EndToEndTestSuiteBuilder} from '../end-to-end-test-suite-builder.js';
+import {type EndToEndTestSuite} from '../end-to-end-test-suite.js';
+import {type BaseTestOptions} from './tests/base-test-options.js';
+import {main} from '../../../src/index.js';
+import {BaseCommandTest} from './tests/base-command-test.js';
+
+const testName: string = 'quick-start-single';
+const testTitle: string = 'Quick Start Single E2E Test';
+const endToEndTestSuite: EndToEndTestSuite = new EndToEndTestSuiteBuilder()
+  .withTestName(testName)
+  .withTestSuiteName(`${testTitle} Suite`)
+  .withNamespace(testName)
+  .withDeployment(`${testName}-deployment`)
+  .withClusterCount(1)
+  .withTestSuiteCallback((options: BaseTestOptions): void => {
+    describe(testTitle, (): void => {
+      const {testCacheDirectory, testLogger, namespace, contexts} = options;
+
+      // TODO the kube config context causes issues if it isn't one of the selected clusters we are deploying to
+      before(async (): Promise<void> => {
+        fs.rmSync(testCacheDirectory, {recursive: true, force: true});
+        try {
+          fs.rmSync(PathEx.joinWithRealPath(testCacheDirectory, '..', DEFAULT_LOCAL_CONFIG_FILE), {
+            force: true,
+          });
+        } catch {
+          // allowed to fail if the file doesn't exist
+        }
+        if (!fs.existsSync(testCacheDirectory)) {
+          fs.mkdirSync(testCacheDirectory, {recursive: true});
+        }
+        resetForTest(namespace.name, testCacheDirectory, false);
+        for (const item of contexts) {
+          const k8Client: K8 = container.resolve<K8ClientFactory>(InjectTokens.K8Factory).getK8(item);
+          await k8Client.namespaces().delete(namespace);
+        }
+        testLogger.info(`${testName}: starting ${testName} e2e test`);
+      }).timeout(Duration.ofMinutes(5).toMillis());
+
+      it(`${testName}: deploy`, async (): Promise<void> => {
+        testLogger.info(`${testName}: beginning ${testName}: deploy`);
+        await main(soloQuickStartDeploy(testName));
+        testLogger.info(`${testName}: finished ${testName}: deploy`);
+      });
+    });
+  })
+  .build();
+endToEndTestSuite.runTestSuite();
+
+export function soloQuickStartDeploy(testName: string): string[] {
+  const {newArgv, argvPushGlobalFlags} = BaseCommandTest;
+
+  const argv: string[] = newArgv();
+  argv.push('quick-start', 'single', 'deploy');
+  argvPushGlobalFlags(argv, testName);
+  return argv;
+}


### PR DESCRIPTION
## Description

This pull request changes the following:

This pull request introduces a new `QuickStartCommand` for managing quick-start configurations in the Solo CLI, along with associated changes to integrate it into the codebase. The changes include the addition of the command's implementation, updates to dependency injection, middleware adjustments, and test enhancements.

### New Feature: QuickStartCommand

* Added a new `QuickStartCommand` class in `src/commands/quick-start.ts` to handle quick-start configurations, including deployment and destruction of Solo network components. This includes extensive task definitions using the `Listr` library.

### Integration with Dependency Injection

* Registered `QuickStartCommand` in the dependency injection container by adding it to `InjectTokens` and the container initialization logic in `src/core/dependency-injection/container-init.ts`. [[1]](diffhunk://#diff-bfc5b5b71069f7cc7c3eed677ba72d3b9c320adb0a2deebc68e650337974957eR64) [[2]](diffhunk://#diff-d3d9f3072e7e58ca07997f6a1f263edafa3a80f9b24edefa795c5187ee0004f0R62) [[3]](diffhunk://#diff-d3d9f3072e7e58ca07997f6a1f263edafa3a80f9b24edefa795c5187ee0004f0R133)

### Middleware Adjustments

* Updated `src/core/middlewares.ts` to ensure the `quick-start` command bypasses certain middleware checks, such as loading local configuration and initialization checks. [[1]](diffhunk://#diff-a6b2bf11281e7714143ec44c640c6ac7abc81b59c1bd385434fe8fc39a2ceabbR157) [[2]](diffhunk://#diff-a6b2bf11281e7714143ec44c640c6ac7abc81b59c1bd385434fe8fc39a2ceabbL188-R189) [[3]](diffhunk://#diff-a6b2bf11281e7714143ec44c640c6ac7abc81b59c1bd385434fe8fc39a2ceabbL204-R214)

### CLI Command Registration

* Modified `src/commands/index.ts` to include the `QuickStartCommand` in the list of available CLI commands and ensure it is properly initialized and exposed. [[1]](diffhunk://#diff-a6a1db61476382a80351bf0b40126b3cfca87878293a3fca70dfe04367f4a11fR15-R33) [[2]](diffhunk://#diff-a6a1db61476382a80351bf0b40126b3cfca87878293a3fca70dfe04367f4a11fR45)

### Testing Enhancements

* Added `ExplorerTest.deploy` to the end-to-end test suite in `test/e2e/commands/dual-cluster-full.test.ts` to ensure the new command's functionality is tested. [[1]](diffhunk://#diff-2265f1eb7bfcba119c015f4adede876258cefd59074941636d391ae2663163e1R24) [[2]](diffhunk://#diff-2265f1eb7bfcba119c015f4adede876258cefd59074941636d391ae2663163e1R74)

### Related Issues

* Closes #
* Related to #962

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
