### PR TITLE
docs: Correct "accross" to "across" in cluster configuration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ nvm install v20.18.0
 # lists available node versions already installed
 nvm ls
 
-# swith to selected node version
+# switch to selected node version
 # nvm use <version>
 nvm use v20.18.0
 

--- a/docs/design/archive/multi_user_cluster_support.md
+++ b/docs/design/archive/multi_user_cluster_support.md
@@ -103,7 +103,7 @@ metadata:
     migratedBy: lenin.mehedy@swirldslabs.com
     fromVersion: 1.0.31 # usually it should be incremental
     ~~configMap: my-network-1-migrate-1.0.31 # config map name. It should have the script and relevant data~~
-clusters: # acquire leases accross all clusters and namespaces
+clusters: # acquire leases across all clusters and namespaces
   - name: cluster-1
     namespace: solo-1
   - name: cluster-2


### PR DESCRIPTION


## Changes
- Fixed spelling error in docs/design/archive/multi_user_cluster_support.md
- Changed "accross" to "across" in clusters configuration section
- Updated README.md with improved node version switch instructions

## Impact
Documentation improvements for better readability and correctness.