### PR TITLE
chore: remove '--node-aliases' for 'solo node logs' command

### DIFF
--- a/src/commands/node/flags.ts
+++ b/src/commands/node/flags.ts
@@ -184,7 +184,7 @@ export const ADD_EXECUTE_FLAGS = {
 
 export const LOGS_FLAGS = {
   required: [flags.deployment],
-  optional: [flags.quiet, flags.nodeAliasesUnparsed],
+  optional: [flags.quiet],
 };
 
 export const STATES_FLAGS = {

--- a/src/commands/node/flags.ts
+++ b/src/commands/node/flags.ts
@@ -183,8 +183,8 @@ export const ADD_EXECUTE_FLAGS = {
 };
 
 export const LOGS_FLAGS = {
-  required: [flags.deployment, flags.nodeAliasesUnparsed],
-  optional: [flags.quiet],
+  required: [flags.deployment],
+  optional: [flags.quiet, flags.nodeAliasesUnparsed],
 };
 
 export const STATES_FLAGS = {

--- a/test/test-utility.ts
+++ b/test/test-utility.ts
@@ -124,14 +124,11 @@ export function startNodesTest(argv: Argv, commandInvoker: CommandInvoker, nodeC
   }).timeout(Duration.ofMinutes(30).toMillis());
 
   it('node log command should work', async () => {
-    const logsArgv: Argv = argv.clone();
-    logsArgv.setArg(flags.nodeAliasesUnparsed, '');
-
     await commandInvoker.invoke({
-      argv: logsArgv,
+      argv: argv,
       command: NodeCommand.COMMAND_NAME,
       subcommand: 'logs',
-      callback: async (argv): Promise<boolean> => nodeCmd.handlers.logs(argv),
+      callback: async argv => nodeCmd.handlers.logs(argv),
     });
 
     const soloLogPath: string = PathEx.joinWithRealPath(SOLO_LOGS_DIR, 'solo.log');

--- a/test/test-utility.ts
+++ b/test/test-utility.ts
@@ -124,11 +124,14 @@ export function startNodesTest(argv: Argv, commandInvoker: CommandInvoker, nodeC
   }).timeout(Duration.ofMinutes(30).toMillis());
 
   it('node log command should work', async () => {
+    const logsArgv: Argv = argv.clone();
+    logsArgv.setArg(flags.nodeAliasesUnparsed, '');
+
     await commandInvoker.invoke({
-      argv: argv,
+      argv: logsArgv,
       command: NodeCommand.COMMAND_NAME,
       subcommand: 'logs',
-      callback: async argv => nodeCmd.handlers.logs(argv),
+      callback: async (argv): Promise<boolean> => nodeCmd.handlers.logs(argv),
     });
 
     const soloLogPath: string = PathEx.joinWithRealPath(SOLO_LOGS_DIR, 'solo.log');


### PR DESCRIPTION
## Description

* `solo node logs` - remove the `--node-aliases` flag

### Related Issues

* Closes # https://github.com/hiero-ledger/solo/issues/2198

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[x] This PR added no TODOs or commented out code
* \[x] This PR has no breaking changes
* \[x] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[x] All related issues have been linked to this PR
* \[x] All changes in this PR are included in the description
* \[x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented
