### PR TITLE
fix: explorer deploy use incorrect env variable in task file

### DIFF
--- a/.github/workflows/script/solo_smoke_test.sh
+++ b/.github/workflows/script/solo_smoke_test.sh
@@ -18,7 +18,7 @@ function clone_smart_contract_repo ()
     echo "Directory hedera-smart-contracts exists."
   else
     echo "Directory hedera-smart-contracts does not exist."
-    git clone https://github.com/hashgraph/hedera-smart-contracts --branch only-erc20-tests-v2
+    git clone https://github.com/hashgraph/hedera-smart-contracts --branch only-erc20-tests-v3
   fi
 }
 

--- a/examples/Taskfile.examples.yml
+++ b/examples/Taskfile.examples.yml
@@ -523,10 +523,11 @@ tasks:
       - |
         if [[ "${EXPLORER_DEPLOYMENT}" != "" ]]; then
           if [ -n "${SOLO_CLUSTER_NAME}" ]; then
-            echo "EXPLORER_CLUSTER_CONTEXT=kind-${SOLO_CLUSTER_NAME}"
+            export EXPLORER_CLUSTER_CONTEXT=kind-${SOLO_CLUSTER_NAME}
           else
-            echo "EXPLORER_CLUSTER_CONTEXT=kind-{{ .SOLO_CLUSTER_NAME }}"
-          fi        
+            export EXPLORER_CLUSTER_CONTEXT=kind-{{ .SOLO_CLUSTER_NAME }}
+          fi
+          echo "EXPLORER_CLUSTER_CONTEXT=${EXPLORER_CLUSTER_CONTEXT}"
           # create deployment on different namespace
           SOLO_HOME_DIR=${SOLO_HOME_DIR} npm run solo-test -- deployment create --deployment ${EXPLORER_DEPLOYMENT} --namespace ${EXPLORER_NAME_SPACE}  
           SOLO_HOME_DIR=${SOLO_HOME_DIR} npm run solo-test -- deployment add-cluster --deployment ${EXPLORER_DEPLOYMENT} --cluster-ref ${EXPLORER_CLUSTER_CONTEXT} --num-consensus-nodes ${SOLO_NETWORK_SIZE}

--- a/examples/Taskfile.examples.yml
+++ b/examples/Taskfile.examples.yml
@@ -96,6 +96,7 @@ tasks:
       - echo "Checking variables..."
       - echo "solo_user_dir={{ .solo_user_dir }}"
       - echo "SOLO_HOME=${SOLO_HOME}"
+      - echo "SOLO_CLUSTER_NAME=${SOLO_CLUSTER_NAME}"
       - echo "SOLO_NETWORK_SIZE=${SOLO_NETWORK_SIZE}"
       - echo "SOLO_CHART_VERSION=${SOLO_CHART_VERSION}"
       - echo "CONSENSUS_NODE_VERSION=${CONSENSUS_NODE_VERSION}"
@@ -122,7 +123,6 @@ tasks:
       - echo "CLUSTER_TLS_FLAGS=${CLUSTER_TLS_FLAGS}"
       - echo "EXPLORER_DEPLOYMENT=${EXPLORER_DEPLOYMENT}"
       - echo "EXPLORER_NAME_SPACE=${EXPLORER_NAME_SPACE}"
-      - echo "EXPLORER_CLUSTER_CONTEXT=${EXPLORER_CLUSTER_CONTEXT}"
       - echo "NETWORK_DEPLOY_EXTRA_FLAGS=${NETWORK_DEPLOY_EXTRA_FLAGS}"
       - echo "MIRROR_NODE_DEPLOY_EXTRA_FLAGS=${MIRROR_NODE_DEPLOY_EXTRA_FLAGS}"
       - echo "EXPLORER_DEPLOY_EXTRA_FLAGS=${EXPLORER_DEPLOY_EXTRA_FLAGS}"
@@ -522,6 +522,11 @@ tasks:
     cmds:
       - |
         if [[ "${EXPLORER_DEPLOYMENT}" != "" ]]; then
+          if [ -n "${SOLO_CLUSTER_NAME}" ]; then
+            echo "EXPLORER_CLUSTER_CONTEXT=kind-${SOLO_CLUSTER_NAME}"
+          else
+            echo "EXPLORER_CLUSTER_CONTEXT=kind-{{ .SOLO_CLUSTER_NAME }}"
+          fi        
           # create deployment on different namespace
           SOLO_HOME_DIR=${SOLO_HOME_DIR} npm run solo-test -- deployment create --deployment ${EXPLORER_DEPLOYMENT} --namespace ${EXPLORER_NAME_SPACE}  
           SOLO_HOME_DIR=${SOLO_HOME_DIR} npm run solo-test -- deployment add-cluster --deployment ${EXPLORER_DEPLOYMENT} --cluster-ref ${EXPLORER_CLUSTER_CONTEXT} --num-consensus-nodes ${SOLO_NETWORK_SIZE}

--- a/examples/Taskfile.yml
+++ b/examples/Taskfile.yml
@@ -25,6 +25,5 @@ env:
   ENABLE_MIRROR_INGRESS: "--enable-ingress"
   EXPLORER_NAME_SPACE: "explorer-name-space"
   EXPLORER_DEPLOYMENT: "explorer-deployment"
-  EXPLORER_CLUSTER_CONTEXT: kind-{{.SOLO_CLUSTER_NAME}}
 vars:
   use_port_forwards: "true"


### PR DESCRIPTION
## Description

This pull request changes the following:

* when a shell env var `SOLO_CLUSTER_NAME` is set, cluster are setup to use the define cluster kind-$SOLO_CLUSTER_NAME}

but this line make explorer uses cluster context defined in env section of task file, not the shell environment
```
EXPLORER_CLUSTER_CONTEXT: kind-{{.SOLO_CLUSTER_NAME}}
```

### Related Issues

* Closes #2299 
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
