### PR TITLE
chore: remove unnecessary logging of argv in command handlers

### DIFF
--- a/src/commands/account.ts
+++ b/src/commands/account.ts
@@ -770,7 +770,6 @@ export class AccountCommand extends BaseCommand {
             },
             handler: async (argv: ArgvStruct) => {
               self.logger.info("==== Running 'account init' ===");
-              self.logger.info(argv);
 
               await self
                 .init(argv)
@@ -794,7 +793,6 @@ export class AccountCommand extends BaseCommand {
             },
             handler: async (argv: ArgvStruct) => {
               self.logger.info("==== Running 'account create' ===");
-              self.logger.info(argv);
 
               await self
                 .create(argv)
@@ -818,7 +816,6 @@ export class AccountCommand extends BaseCommand {
             },
             handler: async (argv: ArgvStruct) => {
               self.logger.info("==== Running 'account update' ===");
-              self.logger.info(argv);
 
               await self
                 .update(argv)
@@ -842,7 +839,6 @@ export class AccountCommand extends BaseCommand {
             },
             handler: async (argv: ArgvStruct) => {
               self.logger.info("==== Running 'account get' ===");
-              self.logger.info(argv);
 
               await self
                 .get(argv)

--- a/src/commands/deployment.ts
+++ b/src/commands/deployment.ts
@@ -400,7 +400,6 @@ export class DeploymentCommand extends BaseCommand {
             },
             handler: async (argv: ArgvStruct) => {
               self.logger.info("==== Running 'deployment create' ===");
-              self.logger.info(argv);
 
               await self
                 .create(argv)
@@ -425,7 +424,6 @@ export class DeploymentCommand extends BaseCommand {
             },
             handler: async (argv: ArgvStruct) => {
               self.logger.info("==== Running 'deployment delete' ===");
-              self.logger.info(argv);
 
               await self
                 .delete(argv)
@@ -450,7 +448,6 @@ export class DeploymentCommand extends BaseCommand {
             },
             handler: async argv => {
               self.logger.info("==== Running 'deployment list' ===");
-              self.logger.info(argv);
 
               await self
                 .list(argv)
@@ -475,7 +472,6 @@ export class DeploymentCommand extends BaseCommand {
             },
             handler: async (argv: ArgvStruct) => {
               self.logger.info("==== Running 'deployment add-cluster' ===");
-              self.logger.info(argv);
 
               await self
                 .addCluster(argv)

--- a/src/commands/explorer.ts
+++ b/src/commands/explorer.ts
@@ -627,7 +627,6 @@ export class ExplorerCommand extends BaseCommand {
             },
             handler: async (argv: ArgvStruct) => {
               self.logger.info("==== Running explorer deploy' ===");
-              self.logger.info(argv);
 
               await self
                 .deploy(argv)
@@ -651,7 +650,6 @@ export class ExplorerCommand extends BaseCommand {
             },
             handler: async (argv: ArgvStruct) => {
               self.logger.info('==== Running explorer destroy ===');
-              self.logger.info(argv);
 
               await self
                 .destroy(argv)

--- a/src/commands/mirror-node.ts
+++ b/src/commands/mirror-node.ts
@@ -985,7 +985,6 @@ export class MirrorNodeCommand extends BaseCommand {
             },
             handler: async argv => {
               self.logger.info("==== Running 'mirror-node deploy' ===");
-              self.logger.info(argv);
 
               await self
                 .deploy(argv)
@@ -1014,7 +1013,6 @@ export class MirrorNodeCommand extends BaseCommand {
               ),
             handler: async argv => {
               self.logger.info("==== Running 'mirror-node destroy' ===");
-              self.logger.info(argv);
 
               await self
                 .destroy(argv)

--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -1372,7 +1372,6 @@ export class NetworkCommand extends BaseCommand {
             },
             handler: async (argv: ArgvStruct): Promise<void> => {
               self.logger.info("==== Running 'network deploy' ===");
-              self.logger.info(argv);
 
               await self
                 .deploy(argv)
@@ -1397,7 +1396,6 @@ export class NetworkCommand extends BaseCommand {
             },
             handler: async (argv: ArgvStruct): Promise<void> => {
               self.logger.info("==== Running 'network destroy' ===");
-              self.logger.info(argv);
 
               await self
                 .destroy(argv)

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -425,7 +425,7 @@ export class RelayCommand extends BaseCommand {
             const pods: Pod[] = await this.k8Factory
               .getK8(context_.config.clusterContext)
               .pods()
-              .list(context_.config.namespace, [`app.kubernetes.io/name=relay`]);
+              .list(context_.config.namespace, ['app.kubernetes.io/name=relay']);
             if (pods.length === 0) {
               throw new SoloError('No Relay pod found');
             }
@@ -583,7 +583,6 @@ export class RelayCommand extends BaseCommand {
             },
             handler: async (argv: ArgvStruct) => {
               self.logger.info("==== Running 'relay deploy' ===", {argv});
-              self.logger.info(argv);
 
               await self.deploy(argv).then(r => {
                 self.logger.info('==== Finished running `relay deploy`====');

--- a/src/core/yargs-command.ts
+++ b/src/core/yargs-command.ts
@@ -50,7 +50,6 @@ export class YargsCommand {
         },
         handler: async (argv: any) => {
           commandDef.logger.info(`==== Running '${commandNamespace} ${command}' ===`);
-          commandDef.logger.info(argv);
           await commandDef.handlers[handler](argv)
             .then((r: any) => {
               commandDef.logger.info(`==== Finished running '${commandNamespace} ${command}' ====`);


### PR DESCRIPTION
## Description

This pull request changes the following:

This pull request focuses on removing redundant logging of the `argv` object across various command handlers in the codebase. These changes streamline the logging output and ensure that only relevant information is logged during command execution.

### Removal of redundant `argv` logging:

#### Account commands:
* Removed `argv` logging in the handlers for `account init`, `account create`, `account update`, and `account get` commands in `src/commands/account.ts`. [[1]](diffhunk://#diff-a6cd96f569fd82c8eeae60c972cbedb3b7ba1e680793e399a65049c22de0c176L773) [[2]](diffhunk://#diff-a6cd96f569fd82c8eeae60c972cbedb3b7ba1e680793e399a65049c22de0c176L797) [[3]](diffhunk://#diff-a6cd96f569fd82c8eeae60c972cbedb3b7ba1e680793e399a65049c22de0c176L821) [[4]](diffhunk://#diff-a6cd96f569fd82c8eeae60c972cbedb3b7ba1e680793e399a65049c22de0c176L845)

#### Deployment commands:
* Removed `argv` logging in the handlers for `deployment create`, `deployment delete`, `deployment list`, and `deployment add-cluster` commands in `src/commands/deployment.ts`. [[1]](diffhunk://#diff-bafe44fc868cf6bfe48d74ac07ad392ee0c9086b1218029906c076f472d337adL403) [[2]](diffhunk://#diff-bafe44fc868cf6bfe48d74ac07ad392ee0c9086b1218029906c076f472d337adL428) [[3]](diffhunk://#diff-bafe44fc868cf6bfe48d74ac07ad392ee0c9086b1218029906c076f472d337adL453) [[4]](diffhunk://#diff-bafe44fc868cf6bfe48d74ac07ad392ee0c9086b1218029906c076f472d337adL478)

#### Explorer commands:
* Removed `argv` logging in the handlers for `explorer deploy` and `explorer destroy` commands in `src/commands/explorer.ts`. [[1]](diffhunk://#diff-1e98e31967fc6e63e1e65eb39a2b1c00e5d007a95067861acbde89787f995098L630) [[2]](diffhunk://#diff-1e98e31967fc6e63e1e65eb39a2b1c00e5d007a95067861acbde89787f995098L654)

#### Mirror-node commands:
* Removed `argv` logging in the handlers for `mirror-node deploy` and `mirror-node destroy` commands in `src/commands/mirror-node.ts`. [[1]](diffhunk://#diff-8a32942c66b48f26bafe6bbc26f6592a6704a9794b3a0fc48048a0389af4f692L988) [[2]](diffhunk://#diff-8a32942c66b48f26bafe6bbc26f6592a6704a9794b3a0fc48048a0389af4f692L1017)

#### Network commands:
* Removed `argv` logging in the handlers for `network deploy` and `network destroy` commands in `src/commands/network.ts`. [[1]](diffhunk://#diff-78a2daa5946cea6ec984eab3d9e0e650ccfea147c8a7bd7f9f8a6f1791490c93L1375) [[2]](diffhunk://#diff-78a2daa5946cea6ec984eab3d9e0e650ccfea147c8a7bd7f9f8a6f1791490c93L1400)

#### Relay commands:
* Removed `argv` logging in the handler for `relay deploy` command in `src/commands/relay.ts`.

#### Core command handling:
* Removed `argv` logging in the generic command handler in `src/core/yargs-command.ts`.

### Minor adjustment to string formatting:
* Updated the string formatting in the `RelayCommand` class to use single quotes consistently for the `list` method in `src/commands/relay.ts`.

### Related Issues

* Closes #
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
