### PR TITLE
chore: fixed a typo in the bash cleanup command by removing an unnecessary semicolon in two places in `step-by-step-guide.template.md`

### DIFF
--- a/docs/site/content/en/templates/step-by-step-guide.template.md
+++ b/docs/site/content/en/templates/step-by-step-guide.template.md
@@ -104,7 +104,7 @@ You should see output showing the latest version which should match our NPM pack
 The team is presently working on a number of fixes and automation that will relegate the need for this, but currently as deployed Solo can be finnicky with artifacts from prior installs. A quick command to prep your station for a new install is a good idea.
 
 ```bash
-for cluster in $(kind get clusters);do;kind delete cluster -n $cluster;done
+for cluster in $(kind get clusters);do kind delete cluster -n $cluster;done
 rm -Rf ~/.solo
 ```
 
@@ -677,7 +677,7 @@ When you're done with your test network:
 To quickly clean up your Solo network and remove all resources (all Kind clusters!), you can use the following commands, be aware you will lose all your logs and data from prior runs:
 
 ```bash
-for cluster in $(kind get clusters);do;kind delete cluster -n $cluster;done
+for cluster in $(kind get clusters);do kind delete cluster -n $cluster;done
 rm -Rf ~/.solo
 ```
 

--- a/src/commands/cluster/tasks.ts
+++ b/src/commands/cluster/tasks.ts
@@ -256,6 +256,7 @@ export class ClusterCommandTasks {
 
         // If all are already present or not wanted, skip installation
         if (!context_.config.deployPrometheusStack && !context_.config.deployMinio) {
+          // TODO: I think this will skip installing the RBAC role
           context_.isChartInstalled = true;
           return;
         }


### PR DESCRIPTION
## Description

This pull request includes minor documentation fixes and a code comment to clarify behavior in the cluster command tasks. The documentation changes correct a bash command, and the code change adds a TODO comment about RBAC role installation.

Documentation fixes:

* Fixed a typo in the bash cleanup command by removing an unnecessary semicolon in two places in `step-by-step-guide.template.md`. [[1]](diffhunk://#diff-92de30b75d48fa7e325a6b3f0e491e75c7e0d0bc0bccf7f1f26961296bd41d7eL107-R107) [[2]](diffhunk://#diff-92de30b75d48fa7e325a6b3f0e491e75c7e0d0bc0bccf7f1f26961296bd41d7eL680-R680)

Code clarification:

* Added a TODO comment in `ClusterCommandTasks` noting that skipping installation may also skip installing the RBAC role.

### Related Issues

* Closes #
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
