### PR TITLE
fix: replace 2 second sleep with sync after remote copyFiles

### DIFF
--- a/src/core/platform-installer.ts
+++ b/src/core/platform-installer.ts
@@ -115,7 +115,7 @@ export class PlatformInstaller {
 
       const container = k8Containers.readByRef(containerReference);
 
-      await container.execContainer('fsync'); // ensure the script is synced to disk
+      await container.execContainer('sync'); // ensure all writes are flushed before executing the script
       await container.execContainer(`chmod +x ${extractScript}`);
       await container.execContainer(`chown root:root ${extractScript}`);
       await container.execContainer([extractScript, tag]);

--- a/src/core/platform-installer.ts
+++ b/src/core/platform-installer.ts
@@ -16,7 +16,6 @@ import chalk from 'chalk';
 
 import {type SoloLogger} from './logging/solo-logger.js';
 import {type NodeAlias} from '../types/aliases.js';
-import {Duration} from './time/duration.js';
 import {inject, injectable} from 'tsyringe-neo';
 import {patchInject} from './dependency-injection/container-helper.js';
 import {NamespaceName} from '../types/namespace/namespace-name.js';
@@ -26,7 +25,6 @@ import {SecretType} from '../integration/kube/resources/secret/secret-type.js';
 import {InjectTokens} from './dependency-injection/inject-tokens.js';
 import {type ConsensusNode} from './model/consensus-node.js';
 import {PathEx} from '../business/utils/path-ex.js';
-import {sleep} from './helpers.js';
 
 /** PlatformInstaller install platform code in the root-container of a network pod */
 @injectable()

--- a/src/core/platform-installer.ts
+++ b/src/core/platform-installer.ts
@@ -110,9 +110,6 @@ export class PlatformInstaller {
       const sourcePath = PathEx.joinWithRealPath(constants.RESOURCES_DIR, scriptName); // script source path
       await this.copyFiles(podReference, [sourcePath], constants.HEDERA_USER_HOME_DIR, undefined, context);
 
-      // wait for files to exist before calling the script to avoid "No such file" error
-      await this.waitForFiles(podReference, [sourcePath], constants.HEDERA_USER_HOME_DIR, undefined, context);
-
       const extractScript = `${constants.HEDERA_USER_HOME_DIR}/${scriptName}`; // inside the container
       const containerReference = ContainerReference.of(podReference, constants.ROOT_CONTAINER);
 
@@ -120,6 +117,7 @@ export class PlatformInstaller {
 
       const container = k8Containers.readByRef(containerReference);
 
+      await container.execContainer('fsync'); // ensure the script is synced to disk
       await container.execContainer(`chmod +x ${extractScript}`);
       await container.execContainer(`chown root:root ${extractScript}`);
       await container.execContainer([extractScript, tag]);
@@ -181,58 +179,6 @@ export class PlatformInstaller {
       return copiedFiles;
     } catch (error) {
       throw new SoloError(`failed to copy files to pod '${podReference.name}': ${error.message}`, error);
-    }
-  }
-
-  /**
-   * Wait for files to appear in the container
-   * @param podReference - pod reference
-   * @param fileNames - list of file names to wait for
-   * @param directory - directory where the files should appear
-   * @param [container] - name of the container
-   * @param [context] - k8s context
-   */
-  async waitForFiles(
-    podReference: PodReference,
-    fileNames: string[],
-    directory: string,
-    container = constants.ROOT_CONTAINER,
-    context?: string,
-  ) {
-    // if empty fileNames, throw an error
-    if (!fileNames || fileNames.length === 0) {
-      throw new MissingArgumentError('fileNames is required and cannot be empty');
-    }
-
-    const timeoutMS: number = 20_000; // 20 seconds timeout
-    const startTime: number = Date.now();
-    try {
-      while (true) {
-        const containerReference: ContainerReference = ContainerReference.of(podReference, container);
-        const k8Containers = this.k8Factory.getK8(context).containers();
-
-        // map file names to existence flags
-        const fileExistenceMap: Record<string, boolean> = {};
-        for (const fileName of fileNames) {
-          if (fileName && fileName.trim() !== '') {
-            const filePath: string = PathEx.join(directory, fileName);
-            fileExistenceMap[fileName] = await k8Containers.readByRef(containerReference).hasFile(filePath);
-          }
-        }
-
-        // check if all files exist is set to true
-        if (Object.values(fileExistenceMap).every(Boolean)) {
-          return; // all files exist, exit the loop
-        }
-
-        // Check timeout
-        if (Date.now() - startTime > timeoutMS) {
-          throw new SoloError('Wait time exceeds timeout.');
-        }
-        await sleep(Duration.ofSeconds(1)); // wait before checking again
-      }
-    } catch (error) {
-      throw new SoloError(`failed to wait for files in pod '${podReference.name}': ${error.message}`, error);
     }
   }
 


### PR DESCRIPTION
## Description

This pull request changes the following:

- Adds a `sync` prior to calling the `extract-platform.sh` script
- Removes the `sleep for 2 seconds` from the `fetchPlatform` method in favor of `sync` prior to executing the `extract-platform.sh` script.

### Related Issues

* Closes #2503

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[x] This PR added no TODOs or commented out code
* \[x] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[x] All related issues have been linked to this PR
* \[x] All changes in this PR are included in the description
* \[x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[x] These changes required manual testing that is documented below
* \[x] Anything not tested is documented

The following manual testing was done:

* `task test`

The following was not tested:

* No additional tests were written as this conformed with the level of testing associated with `copyFiles`.
