### PR TITLE
fix(perf): report peak memory snapshot in performance test

### DIFF
--- a/test/e2e/commands/performance.test.ts
+++ b/test/e2e/commands/performance.test.ts
@@ -129,15 +129,11 @@ const endToEndTestSuite: EndToEndTestSuite = new EndToEndTestSuiteBuilder()
 
           // save the file with the max CPU metrics and inject the peak memory value
           const maxCpuFileName: string = `${maxCpuFile}.json`;
-          fs.copyFileSync(
-            PathEx.join(tartgetDirectory, maxCpuFileName),
-            PathEx.join(tartgetDirectory, `${namespace}.json`),
-          );
-
-          const namespacePath: string = PathEx.join(tartgetDirectory, `${namespace}.json`);
-          const namespaceJson: Record<string, unknown> = JSON.parse(fs.readFileSync(namespacePath, 'utf8'));
-          namespaceJson.peakMemoryInMebibytes = maxMemoryMetrics;
-          fs.writeFileSync(namespacePath, JSON.stringify(namespaceJson), 'utf8');
+          const namespaceJson: Record<string, unknown> = {
+            ...(allMetrics[maxCpuFile] as unknown as Record<string, unknown>),
+            peakMemoryInMebibytes: maxMemoryMetrics,
+          };
+          fs.writeFileSync(PathEx.join(tartgetDirectory, `${namespace}.json`), JSON.stringify(namespaceJson), 'utf8');
 
           // remove all files except the aggregated and max CPU files
           const filesToKeep: Set<string> = new Set([maxCpuFileName, aggregatedMetricsFileName]);

--- a/test/e2e/commands/performance.test.ts
+++ b/test/e2e/commands/performance.test.ts
@@ -135,7 +135,7 @@ const endToEndTestSuite: EndToEndTestSuite = new EndToEndTestSuiteBuilder()
           );
 
           const namespacePath: string = PathEx.join(tartgetDirectory, `${namespace}.json`);
-          const namespaceJson = JSON.parse(fs.readFileSync(namespacePath, 'utf8'));
+          const namespaceJson: Record<string, unknown> = JSON.parse(fs.readFileSync(namespacePath, 'utf8'));
           namespaceJson.peakMemoryInMebibytes = maxMemoryMetrics;
           fs.writeFileSync(namespacePath, JSON.stringify(namespaceJson), 'utf8');
 

--- a/test/e2e/commands/performance.test.ts
+++ b/test/e2e/commands/performance.test.ts
@@ -120,12 +120,24 @@ const endToEndTestSuite: EndToEndTestSuite = new EndToEndTestSuiteBuilder()
             }
           }
 
-          // save the file with the max CPU metrics
+          let maxMemoryMetrics: number = 0;
+          for (const metrics of Object.values(allMetrics)) {
+            if (metrics.memoryInMebibytes > maxMemoryMetrics) {
+              maxMemoryMetrics = metrics.memoryInMebibytes;
+            }
+          }
+
+          // save the file with the max CPU metrics and inject the peak memory value
           const maxCpuFileName: string = `${maxCpuFile}.json`;
           fs.copyFileSync(
             PathEx.join(tartgetDirectory, maxCpuFileName),
             PathEx.join(tartgetDirectory, `${namespace}.json`),
           );
+
+          const namespacePath: string = PathEx.join(tartgetDirectory, `${namespace}.json`);
+          const namespaceJson = JSON.parse(fs.readFileSync(namespacePath, 'utf8'));
+          namespaceJson.peakMemoryInMebibytes = maxMemoryMetrics;
+          fs.writeFileSync(namespacePath, JSON.stringify(namespaceJson), 'utf8');
 
           // remove all files except the aggregated and max CPU files
           const filesToKeep: Set<string> = new Set([maxCpuFileName, aggregatedMetricsFileName]);


### PR DESCRIPTION
## Description

The after-hook previously selected the snapshot with the highest CPU and used it for the PR comment and memory threshold check. Peak CPU and peak memory don't necessarily coincide, so the reported memory could be misleading.
                                                                                                                                                                                    
Find the peak memory across all snapshots and inject peakMemoryInMebibytes into the existing metrics JSON file, making it visible in the PR comment
### Related Issues

* Closes #3630 

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
