### PR TITLE
fix(one-shot): remove --num-consensus-nodes from single deploy

### DIFF
--- a/docs/site/content/en/templates/solo-user-guide.template.md
+++ b/docs/site/content/en/templates/solo-user-guide.template.md
@@ -204,10 +204,10 @@ The deployment takes a few minutes. When complete, your network is ready to use.
 
 {{< details summary="For testing consensus scenarios (click to expand)" >}}
 
-For testing consensus scenarios or multi-node behavior, you can deploy multiple consensus nodes by specifying the `--num-consensus-nodes` flag:
+For testing consensus scenarios or multi-node behavior, use the `multi` subcommand with the `--num-consensus-nodes` flag:
 
 ```bash
-solo one-shot single deploy --num-consensus-nodes 3
+solo one-shot multi deploy --num-consensus-nodes 3
 ```
 
 This deploys 3 consensus nodes along with the same components as the single-node setup (mirror node, explorer, relay).
@@ -217,7 +217,7 @@ This deploys 3 consensus nodes along with the same components as the single-node
 When finished:
 
 ```bash
-solo one-shot single destroy
+solo one-shot multi destroy
 ```
 
 {{< /details >}}

--- a/src/commands/command-definitions/one-shot-command-definition.ts
+++ b/src/commands/command-definitions/one-shot-command-definition.ts
@@ -86,7 +86,7 @@ export class OneShotCommandDefinition extends BaseCommandDefinition {
               'Deploys all required components for the selected multiple node one shot configuration.',
               this.oneShotCommand,
               this.oneShotCommand.deploy,
-              DefaultOneShotCommand.DEPLOY_FLAGS_LIST,
+              DefaultOneShotCommand.MULTI_DEPLOY_FLAGS_LIST,
               [...constants.BASE_DEPENDENCIES],
               true,
             ),

--- a/src/commands/one-shot/default-one-shot.ts
+++ b/src/commands/one-shot/default-one-shot.ts
@@ -80,7 +80,6 @@ export class DefaultOneShotCommand extends BaseCommand implements OneShotCommand
     required: [],
     optional: [
       flags.quiet,
-      flags.numberOfConsensusNodes,
       flags.force,
       flags.deployment,
       flags.namespace,
@@ -88,6 +87,11 @@ export class DefaultOneShotCommand extends BaseCommand implements OneShotCommand
       flags.minimalSetup,
       flags.rollback,
     ],
+  };
+
+  public static readonly MULTI_DEPLOY_FLAGS_LIST: CommandFlags = {
+    required: [],
+    optional: [...DefaultOneShotCommand.DEPLOY_FLAGS_LIST.optional, flags.numberOfConsensusNodes],
   };
 
   public static readonly DESTROY_FLAGS_LIST: CommandFlags = {


### PR DESCRIPTION
The one-shot single deploy command should always provision exactly one consensus node. Remove the flag from single deploy and create a separate MULTI_DEPLOY_FLAGS_LIST for multi deploy that retains it. Update docs to use one-shot multi deploy for multi-node examples.

Refs: #3777

## Description

This pull request changes the following:

* TBD

### Related Issues

* Closes #3777
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* Ran local single and multi deploys without issues.

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
