### PR TITLE
fix: tolerate Helm OCI status output

### DIFF
--- a/src/integration/helm/execution/helm-execution.ts
+++ b/src/integration/helm/execution/helm-execution.ts
@@ -167,6 +167,86 @@ export class HelmExecution {
     return this.errOutput.join('');
   }
 
+  private static parseJsonOutput(output: string): unknown {
+    let lastParseError: unknown;
+
+    for (let index: number = 0; index < output.length; index++) {
+      if (output[index] !== '{' && output[index] !== '[') {
+        continue;
+      }
+
+      try {
+        return JSON.parse(HelmExecution.extractJsonOutput(output, index));
+      } catch (error) {
+        lastParseError = error;
+      }
+    }
+
+    if (lastParseError) {
+      throw lastParseError;
+    }
+
+    return JSON.parse(output);
+  }
+
+  private static extractJsonOutput(output: string, jsonStart: number): string {
+    const stack: string[] = [];
+    let inString: boolean = false;
+    let escaped: boolean = false;
+
+    for (let index: number = jsonStart; index < output.length; index++) {
+      const character: string = output[index];
+
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+          continue;
+        }
+
+        if (character === '\\') {
+          escaped = true;
+          continue;
+        }
+
+        if (character === '"') {
+          inString = false;
+        }
+
+        continue;
+      }
+
+      if (character === '"') {
+        inString = true;
+        continue;
+      }
+
+      if (character === '{') {
+        stack.push('}');
+        continue;
+      }
+
+      if (character === '[') {
+        stack.push(']');
+        continue;
+      }
+
+      if (character !== '}' && character !== ']') {
+        continue;
+      }
+
+      const expectedCharacter: string | undefined = stack.pop();
+      if (character !== expectedCharacter) {
+        return output.slice(jsonStart);
+      }
+
+      if (stack.length === 0) {
+        return output.slice(jsonStart, index + 1);
+      }
+    }
+
+    return output.slice(jsonStart);
+  }
+
   /**
    * Gets the response as a parsed object.
    * @param responseClass The class to parse the response into
@@ -212,12 +292,15 @@ export class HelmExecution {
 
     const output: string = this.standardOutput();
     try {
-      const parsed: any = JSON.parse(output);
+      const parsed: any = HelmExecution.parseJsonOutput(output);
       const result: T = new responseClass();
       Object.assign(result, parsed);
       return result;
-    } catch {
-      throw new HelmParserException(HelmExecution.MSG_DESERIALIZATION_ERROR.replace('%s', responseClass.name));
+    } catch (error) {
+      throw new HelmParserException(
+        HelmExecution.MSG_DESERIALIZATION_ERROR.replace('%s', responseClass.name),
+        error as Error,
+      );
     }
   }
 
@@ -263,9 +346,12 @@ export class HelmExecution {
 
     const output: string = this.standardOutput();
     try {
-      return JSON.parse(output) as T[];
-    } catch {
-      throw new HelmParserException(HelmExecution.MSG_LIST_DESERIALIZATION_ERROR.replace('%s', responseClass.name));
+      return HelmExecution.parseJsonOutput(output) as T[];
+    } catch (error) {
+      throw new HelmParserException(
+        HelmExecution.MSG_LIST_DESERIALIZATION_ERROR.replace('%s', responseClass.name),
+        error as Error,
+      );
     }
   }
 

--- a/test/unit/core/helm/execution/helm-execution.test.ts
+++ b/test/unit/core/helm/execution/helm-execution.test.ts
@@ -4,6 +4,7 @@ import {HelmExecution} from '../../../../../src/integration/helm/execution/helm-
 import {HelmExecutionException} from '../../../../../src/integration/helm/helm-execution-exception.js';
 import {HelmParserException} from '../../../../../src/integration/helm/helm-parser-exception.js';
 import {Repository} from '../../../../../src/integration/helm/model/repository.js';
+import {Release} from '../../../../../src/integration/helm/model/chart/release.js';
 import {Duration} from '../../../../../src/core/time/duration.js';
 import {expect} from 'chai';
 import sinon from 'sinon';
@@ -50,6 +51,42 @@ describe('HelmExecution', (): void => {
     } catch (error) {
       expect(error).to.be.instanceOf(HelmParserException);
     }
+  });
+
+  it('deserializes object output after Helm OCI pull status lines', async (): Promise<void> => {
+    const releaseOutput: string = JSON.stringify({
+      name: 'solo-shared-resources',
+      info: {
+        description: 'Install {complete}',
+        status: 'deployed',
+      },
+      chart: {
+        metadata: {
+          version: '0.63.3',
+        },
+      },
+    });
+
+    const execution: HelmExecution = createNodeExecution(
+      'Pulled: ghcr.io/hashgraph/solo-charts/solo-shared-resources:0.63.3\n' +
+        'Digest: sha256:06f98926e0f2a875b0b1f97c2e3bc99feac2276580d5d4de1a8f3e9efa0a3ae4\n' +
+        releaseOutput,
+    );
+
+    const release: Release = await execution.responseAs(Release);
+
+    expect(release.name).to.equal('solo-shared-resources');
+    expect(release.info.description).to.equal('Install {complete}');
+    expect(release.chart.metadata.version).to.equal('0.63.3');
+  });
+
+  it('deserializes list output after Helm status lines', async (): Promise<void> => {
+    const listOutput: string = JSON.stringify([{name: 'solo', url: 'https://example.com/charts'}]);
+    const execution: HelmExecution = createNodeExecution(`[INFO] Update Complete.\n${listOutput}\nignored suffix`);
+
+    const repositories: Repository[] = await execution.responseAsList(Repository);
+
+    expect(repositories).to.deep.equal([{name: 'solo', url: 'https://example.com/charts'}]);
   });
 
   describe('redactCommand', (): void => {
@@ -134,3 +171,10 @@ describe('HelmExecution', (): void => {
     });
   });
 });
+
+function createNodeExecution(output: string): HelmExecution {
+  return new HelmExecution({
+    commandPathOrName: process.execPath,
+    commandArguments: ['-e', `process.stdout.write(${JSON.stringify(output)});`],
+  });
+}


### PR DESCRIPTION
## Summary

- tolerate non-JSON Helm status lines before/surrounding `--output json` payloads
- keep JSON extraction balanced so braces inside strings do not truncate the payload
- add HelmExecution coverage for object and list outputs with Helm status prefixes

Fixes #4645.

## Root cause

Helm 4.2.1 can emit OCI pull status lines such as `Pulled:` and `Digest:` to stdout before the JSON release payload. Solo previously parsed the entire stdout with `JSON.parse(output)`, so deserialization failed before `Release` could be populated. Helm 4.0.5 and older Helm 3.14.2 paths commonly return clean JSON for this command shape, which is why they did not trip the parser.

## Validation

- `task build`
- `task format`
- `task check`
- `npx mocha 'test/unit/core/helm/execution/helm-execution.test.ts'`
