### PR TITLE
fix: update TSS wraps artifacts path to data/keys subdirectory

### DIFF
--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -1850,7 +1850,7 @@ export class NetworkCommand extends BaseCommand {
                 consensusNode.name,
               );
 
-              await rootContainer.copyTo(extractedDirectory, constants.HEDERA_HAPI_PATH);
+              await rootContainer.copyTo(extractedDirectory, `${constants.HEDERA_HAPI_PATH}/data/keys`);
             }
           },
         },

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -3452,7 +3452,7 @@ export class NodeCommandTasks {
             consensusNode.name,
           );
 
-          const targetWrapsPath: string = `${constants.HEDERA_HAPI_PATH}/${wraps.directoryName}`;
+          const targetWrapsPath: string = `${constants.HEDERA_HAPI_PATH}/data/keys/${wraps.directoryName}`;
 
           const attempts: number = CHECK_WRAPS_DIRECTORY_MAX_ATTEMPTS;
           let attempt: number = 0;
@@ -3476,7 +3476,7 @@ export class NodeCommandTasks {
             continue;
           }
 
-          await rootContainer.copyTo(extractedDirectory, constants.HEDERA_HAPI_PATH);
+          await rootContainer.copyTo(extractedDirectory, `${constants.HEDERA_HAPI_PATH}/data/keys`);
         }
       },
     };

--- a/src/data/schema/migration/impl/solo/solo-config-v1-migration.ts
+++ b/src/data/schema/migration/impl/solo/solo-config-v1-migration.ts
@@ -51,11 +51,11 @@ export class SoloConfigV1Migration implements SchemaMigration {
       readyMaxAttempts: 60,
       readyBackoffSeconds: 3,
       wraps: {
-        artifactsFolderName: 'wraps-v0.2.0',
-        directoryName: 'wraps-v0.2.0',
+        artifactsFolderName: 'data/keys/wraps-v1.0.0',
+        directoryName: 'wraps-v1.0.0',
         allowedKeyFiles: 'decider_pp.bin,decider_vp.bin,nova_pp.bin,nova_vp.bin',
         // IMPORTANT: libraryDownloadUrl must be kept consistent with directoryName.
-        libraryDownloadUrl: 'https://builds.hedera.com/tss/hiero/wraps/v0.2/wraps-v0.2.0.tar.gz',
+        libraryDownloadUrl: 'https://builds.hedera.com/tss/hiero/wraps/v1.0/wraps-v1.0.0.tar.gz',
       },
     };
   }

--- a/src/data/schema/model/solo/wraps-schema.ts
+++ b/src/data/schema/model/solo/wraps-schema.ts
@@ -24,10 +24,10 @@ export class WrapsSchema {
     allowedKeyFiles?: string,
     libraryDownloadUrl?: string,
   ) {
-    this.artifactsFolderName = artifactsFolderName ?? 'wraps-v0.2.0';
-    this.directoryName = directoryName ?? 'wraps-v0.2.0';
+    this.artifactsFolderName = artifactsFolderName ?? 'data/keys/wraps-v1.0.0';
+    this.directoryName = directoryName ?? 'wraps-v1.0.0';
     this.allowedKeyFiles = allowedKeyFiles ?? 'decider_pp.bin,decider_vp.bin,nova_pp.bin,nova_vp.bin';
     this.libraryDownloadUrl =
-      libraryDownloadUrl ?? 'https://builds.hedera.com/tss/hiero/wraps/v0.2/wraps-v0.2.0.tar.gz';
+      libraryDownloadUrl ?? 'https://builds.hedera.com/tss/hiero/wraps/v1.0/wraps-v1.0.0.tar.gz';
   }
 }

--- a/test/unit/commands/wraps-key-path.test.ts
+++ b/test/unit/commands/wraps-key-path.test.ts
@@ -35,7 +35,7 @@ describe('NodeCommandTasks.addWrapsLib', (): void => {
 
   beforeEach(async (): Promise<void> => {
     sourceDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'wraps-test-'));
-    extractedDirectory = PathEx.join(constants.SOLO_CACHE_DIR, 'wraps-v0.2.0');
+    extractedDirectory = PathEx.join(constants.SOLO_CACHE_DIR, 'wraps-v1.0.0');
 
     // Ensure parent cache directory exists
     if (!fs.existsSync(constants.SOLO_CACHE_DIR)) {
@@ -172,10 +172,10 @@ describe('NodeCommandTasks.addWrapsLib', (): void => {
 describe('TssSchema WRAPS defaults', (): void => {
   it('allowedKeyFiles default should contain the expected file names', (): void => {
     const wraps: WrapsSchema = new WrapsSchema(
-      'wraps-v0.2.0',
-      'wraps-v0.2.0',
+      'data/keys/wraps-v1.0.0',
+      'wraps-v1.0.0',
       'decider_pp.bin,decider_vp.bin,nova_pp.bin,nova_vp.bin',
-      'https://builds.hedera.com/tss/hiero/wraps/v0.2/wraps-v0.2.0.tar.gz',
+      'https://builds.hedera.com/tss/hiero/wraps/v1.0/wraps-v1.0.0.tar.gz',
     );
     const tss: TssSchema = new TssSchema(undefined, undefined, undefined, undefined, undefined, wraps);
     const files: string[] = (tss.wraps?.allowedKeyFiles ?? '').split(',');


### PR DESCRIPTION
## Description

This pull request changes the following:

* Updates the default `tss.wraps.artifactsFolderName` from `wraps-v0.2.0` to `data/keys/wraps-v1.0.0` so that `TSS_LIB_WRAPS_ARTIFACTS_PATH` is set to `/opt/hgcapp/services-hedera/HapiApp2.0/data/keys/wraps-v1.0.0`, as required by the updated consensus node configuration.
* Updates the default `tss.wraps.directoryName` and `libraryDownloadUrl` to v1.0.0.
* Changes the `copyTo` target in both `network.ts` and `node/tasks.ts` from `HEDERA_HAPI_PATH` to `HEDERA_HAPI_PATH/data/keys` so the wraps directory is placed at the correct path inside the container.
* Updates unit tests to match the new defaults.

### Related Issues

* Closes #4658

### Pull request (PR) checklist

* [x] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [ ] Any technical debt has been documented as a separate issue and linked to this PR
* [x] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [x] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [ ] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* Unit tests updated and passing (`npx mocha 'test/unit/commands/wraps-key-path.test.ts'` — 6/6 pass)

The following was not tested:

* Full E2E wraps-enabled network deployment (requires a CN build that reads `TSS_LIB_WRAPS_ARTIFACTS_PATH`)