### PR TITLE
fix: mount small-memory patches directory from SOLO_CACHE staging

### DIFF
--- a/src/core/cluster-task-manager.ts
+++ b/src/core/cluster-task-manager.ts
@@ -338,10 +338,56 @@ export class ClusterTaskManager extends ShellRunner {
   private getConfigFilePath(useSmallMemoryCluster: boolean): string {
     let kindConfigFilePath: string = constants.KIND_CLUSTER_CONFIG_FILE;
     if (useSmallMemoryCluster && kindConfigFilePath === constants.DEFAULT_KIND_CLUSTER_CONFIG_FILE) {
-      kindConfigFilePath = path.join(constants.RESOURCES_DIR, 'templates', 'small-memory', 'kind-config.yaml');
+      kindConfigFilePath = this.renderSmallMemoryClusterConfig();
       this.logger.info(`Using small memory cluster configuration: ${kindConfigFilePath}`);
     }
     return kindConfigFilePath;
+  }
+
+  /**
+   * Stages the small-memory Kind configuration and its patches directory under the Solo cache
+   * directory (`~/.solo/cache`) and rewrites the patches `hostPath` to an absolute path.
+   *
+   * The bundled `kind-config.yaml` mounts the patches directory with a relative `hostPath`, which
+   * Kind resolves against the process working directory. Under a Homebrew install that can resolve
+   * to `/opt/homebrew/Cellar/...`, a path Docker Desktop does not share by default, so the bind
+   * mount is denied; when it resolves elsewhere the (non-existent) directory is silently mounted
+   * empty and the patches are never applied. Mounting from `~/.solo/cache`, which lives under the
+   * user home directory that Docker Desktop shares by default, makes the mount deterministic and
+   * ensures the patches are actually present inside the cluster.
+   *
+   * @returns the absolute path to the rendered small-memory Kind configuration file.
+   */
+  private renderSmallMemoryClusterConfig(): string {
+    const sourceConfigFilePath: string = path.join(
+      constants.RESOURCES_DIR,
+      'templates',
+      'small-memory',
+      'kind-config.yaml',
+    );
+    const sourcePatchesDirectory: string = path.join(constants.RESOURCES_DIR, 'templates', 'small-memory', 'patches');
+
+    const stagedDirectory: string = path.join(constants.SOLO_CACHE_DIR, 'templates', 'small-memory');
+    const stagedPatchesDirectory: string = path.join(stagedDirectory, 'patches');
+    const stagedConfigFilePath: string = path.join(stagedDirectory, 'kind-config.yaml');
+
+    fs.mkdirSync(stagedDirectory, {recursive: true});
+    fs.cpSync(sourcePatchesDirectory, stagedPatchesDirectory, {recursive: true, force: true});
+
+    const kindConfig: Record<string, AnyObject> = yaml.parse(fs.readFileSync(sourceConfigFilePath, 'utf8')) as Record<
+      string,
+      AnyObject
+    >;
+    for (const node of (kindConfig.nodes ?? []) as AnyObject[]) {
+      for (const extraMount of (node.extraMounts ?? []) as AnyObject[]) {
+        if (extraMount.containerPath === '/patches') {
+          extraMount.hostPath = stagedPatchesDirectory;
+        }
+      }
+    }
+
+    fs.writeFileSync(stagedConfigFilePath, yaml.stringify(kindConfig), 'utf8');
+    return stagedConfigFilePath;
   }
 
   public setupLocalClusterTasks(useSmallMemoryCluster: boolean = false): SoloListrTask<InitContext>[] {

--- a/src/core/cluster-task-manager.ts
+++ b/src/core/cluster-task-manager.ts
@@ -348,14 +348,6 @@ export class ClusterTaskManager extends ShellRunner {
    * Stages the small-memory Kind configuration and its patches directory under the Solo cache
    * directory (`~/.solo/cache`) and rewrites the patches `hostPath` to an absolute path.
    *
-   * The bundled `kind-config.yaml` mounts the patches directory with a relative `hostPath`, which
-   * Kind resolves against the process working directory. Under a Homebrew install that can resolve
-   * to `/opt/homebrew/Cellar/...`, a path Docker Desktop does not share by default, so the bind
-   * mount is denied; when it resolves elsewhere the (non-existent) directory is silently mounted
-   * empty and the patches are never applied. Mounting from `~/.solo/cache`, which lives under the
-   * user home directory that Docker Desktop shares by default, makes the mount deterministic and
-   * ensures the patches are actually present inside the cluster.
-   *
    * @returns the absolute path to the rendered small-memory Kind configuration file.
    */
   private renderSmallMemoryClusterConfig(): string {

--- a/test/unit/core/cluster-task-manager.test.ts
+++ b/test/unit/core/cluster-task-manager.test.ts
@@ -3,6 +3,8 @@
 import {expect} from 'chai';
 import {before, describe, it} from 'mocha';
 import path from 'node:path';
+import fs from 'node:fs';
+import * as yaml from 'yaml';
 import {ClusterTaskManager} from '../../../src/core/cluster-task-manager.js';
 import * as constants from '../../../src/core/constants.js';
 import {resetForTest} from '../../test-container.js';
@@ -51,12 +53,30 @@ describe('ClusterTaskManager', (): void => {
     expect(getConfigFilePath(manager, false)).to.equal(constants.KIND_CLUSTER_CONFIG_FILE);
   });
 
-  it('should resolve small-memory kind config to an absolute path', (): void => {
+  it('should stage small-memory kind config under the shared cache directory with an absolute patches hostPath', (): void => {
     const manager: ClusterTaskManager = createClusterTaskManager();
     const configPath: string = getConfigFilePath(manager, true);
 
+    // The rendered config must live under SOLO_CACHE_DIR (~/.solo/cache), a path Docker Desktop
+    // shares by default, rather than the install directory (e.g. /opt/homebrew/Cellar).
+    const expectedStagedDirectory: string = path.join(constants.SOLO_CACHE_DIR, 'templates', 'small-memory');
     expect(path.isAbsolute(configPath)).to.equal(true);
-    expect(configPath).to.equal(path.join(constants.RESOURCES_DIR, 'templates', 'small-memory', 'kind-config.yaml'));
-    expect(configPath).to.not.equal('resources/templates/small-memory/kind-config.yaml');
+    expect(configPath).to.equal(path.join(expectedStagedDirectory, 'kind-config.yaml'));
+    expect(fs.existsSync(configPath)).to.equal(true);
+
+    // The patches directory must be staged alongside the rendered config.
+    const expectedPatchesDirectory: string = path.join(expectedStagedDirectory, 'patches');
+    expect(fs.existsSync(expectedPatchesDirectory)).to.equal(true);
+
+    // The patches mount must be rewritten to the absolute staged path (not the bundled relative one).
+    const renderedConfig: {nodes?: {extraMounts?: {hostPath?: string; containerPath?: string}[]}[]} = yaml.parse(
+      fs.readFileSync(configPath, 'utf8'),
+    );
+    const patchesMount: {hostPath?: string; containerPath?: string} | undefined = renderedConfig.nodes
+      ?.flatMap((node): {hostPath?: string; containerPath?: string}[] => node.extraMounts ?? [])
+      .find((mount): boolean => mount.containerPath === '/patches');
+    expect(patchesMount, 'patches mount should be present').to.not.equal(undefined);
+    expect(patchesMount?.hostPath).to.equal(expectedPatchesDirectory);
+    expect(path.isAbsolute(patchesMount?.hostPath ?? '')).to.equal(true);
   });
 });


### PR DESCRIPTION
## Description

`solo one-shot single deploy` uses the small-memory Kind config, which mounts a `patches` directory via a relative hostPath (./resources/templates/small-memory/patches). Kind resolves this against the process working directory, causing two bugs:

1. Mount denied (the reported failure in the issue): With a Homebrew install, the path can resolve under `/opt/homebrew/Cellar/...`, which Docker Desktop does not share by default, which results in a mount being denied.

2. When the path resolves elsewhere (e.g. under /Users), the non-existent directory is auto-created and mounted empty, so the `kube-apiserver` memory patch configuration was never applied even on the cluster.

`ClusterTaskManager` now stages the small-memory kind-config.yaml and its patches directory under `SOLO_CACHE`, which is under `/Users`, a directory in the shared files of Docker Desktop by default, and rewrites the patch hostPath to that absolute path before passing the config to Kind. This makes the mount deterministic regardless of the working directory or install location.

### Related Issues

* Closes #4672
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
