### PR TITLE
fix: delay one-shot mirror pinger deployment

### DIFF
--- a/src/commands/one-shot/one-shot-single-deploy-config-class.ts
+++ b/src/commands/one-shot/one-shot-single-deploy-config-class.ts
@@ -29,6 +29,7 @@ export interface OneShotSingleDeployConfigClass {
   quiet: boolean;
   rollback: boolean;
   parallelDeploy: boolean;
+  pinger: boolean;
   externalAddress: string;
   edgeEnabled: boolean;
   versions: OneShotVersionsObject;

--- a/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
+++ b/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
@@ -688,7 +688,7 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
               invokeSoloCommand(
                 `solo ${MirrorCommandDefinition.ADD_COMMAND}`,
                 MirrorCommandDefinition.ADD_COMMAND,
-                (): string[] => DeployArgvBuilders.buildMirrorNodeArgv(getConfig()),
+                (): string[] => DeployArgvBuilders.buildMirrorNodeArgv(getConfig(), false),
                 this.taskList,
                 // Feature-flag short-circuit takes precedence; otherwise skip if already deployed (idempotency guard).
                 (): boolean =>
@@ -700,6 +700,24 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
                   ),
               ),
           }),
+          new OrchestratorPipelinePhase('Enable mirror pinger', {
+            asListrTask: (getConfig: () => OneShotSingleDeployConfigClass): SoloListrTask<OneShotSingleDeployContext> =>
+              invokeSoloCommand(
+                `solo ${MirrorCommandDefinition.UPGRADE_COMMAND}`,
+                MirrorCommandDefinition.UPGRADE_COMMAND,
+                (): string[] => DeployArgvBuilders.buildMirrorNodePingerUpgradeArgv(getConfig()),
+                this.taskList,
+                (): boolean => !getConfig().deployMirrorNode || !getConfig().pinger,
+              ),
+          })
+            .withWaitCondition(
+              SoloEventType.MirrorNodeDeployed,
+              Duration.ofMinutes(constants.MIRROR_NODE_DEPLOYED_EVENT_TIMEOUT_MINUTES),
+            )
+            .withWaitCondition(
+              SoloEventType.NodesStarted,
+              Duration.ofMinutes(constants.NODES_STARTED_EVENT_TIMEOUT_MINUTES),
+            ),
           new OrchestratorPipelinePhase('Deploy explorer', {
             asListrTask: (getConfig: () => OneShotSingleDeployConfigClass): SoloListrTask<OneShotSingleDeployContext> =>
               invokeSoloCommand(

--- a/src/commands/one-shot/orchestrator/deploy/deploy-argv-builders.ts
+++ b/src/commands/one-shot/orchestrator/deploy/deploy-argv-builders.ts
@@ -85,7 +85,7 @@ export class DeployArgvBuilders {
     return argvPushGlobalFlags(argv);
   }
 
-  public static buildMirrorNodeArgv(config: OneShotSingleDeployConfigClass): string[] {
+  public static buildMirrorNodeArgv(config: OneShotSingleDeployConfigClass, deployPinger: boolean = true): string[] {
     const argv: string[] = newArgv();
     argv.push(
       ...MirrorCommandDefinition.ADD_COMMAND.split(' '),
@@ -93,15 +93,46 @@ export class DeployArgvBuilders {
       config.deployment,
       optionFromFlag(Flags.clusterRef),
       config.clusterRef,
-      optionFromFlag(Flags.pinger),
       optionFromFlag(Flags.enableIngress),
       optionFromFlag(Flags.parallelDeploy),
       config.parallelDeploy.toString(),
     );
+    if (deployPinger && config.pinger) {
+      argv.push(optionFromFlag(Flags.pinger));
+    }
     if (constants.ONE_SHOT_WITH_BLOCK_NODE.toLowerCase() === 'true') {
       argv.push(optionFromFlag(Flags.forceBlockNodeIntegration));
     }
     // Append HikariCP limits file without mutating the shared config object.
+    const mirrorExistingValuesFile: string =
+      config.mirrorNodeConfiguration?.[Flags.getFormattedFlagKey(Flags.valuesFile)];
+    const mirrorLocalConfig: AnyObject = {
+      [optionFromFlag(Flags.mirrorNodeVersion)]: config.versions.mirror,
+      [optionFromFlag(Flags.soloChartVersion)]: config.versions.soloChart,
+      [optionFromFlag(Flags.externalAddress)]: config.externalAddress,
+      ...config.mirrorNodeConfiguration,
+      [Flags.getFormattedFlagKey(Flags.valuesFile)]: mirrorExistingValuesFile
+        ? `${mirrorExistingValuesFile},${constants.MIRROR_NODE_HIKARI_LIMITS_FILE}`
+        : constants.MIRROR_NODE_HIKARI_LIMITS_FILE,
+    };
+    appendConfigToArgv(argv, mirrorLocalConfig);
+    return argvPushGlobalFlags(argv, config.cacheDir);
+  }
+
+  public static buildMirrorNodePingerUpgradeArgv(config: OneShotSingleDeployConfigClass): string[] {
+    const argv: string[] = newArgv();
+    argv.push(
+      ...MirrorCommandDefinition.UPGRADE_COMMAND.split(' '),
+      optionFromFlag(Flags.deployment),
+      config.deployment,
+      optionFromFlag(Flags.clusterRef),
+      config.clusterRef,
+      optionFromFlag(Flags.pinger),
+      optionFromFlag(Flags.enableIngress),
+    );
+    if (constants.ONE_SHOT_WITH_BLOCK_NODE.toLowerCase() === 'true') {
+      argv.push(optionFromFlag(Flags.forceBlockNodeIntegration));
+    }
     const mirrorExistingValuesFile: string =
       config.mirrorNodeConfiguration?.[Flags.getFormattedFlagKey(Flags.valuesFile)];
     const mirrorLocalConfig: AnyObject = {

--- a/test/unit/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.test.ts
+++ b/test/unit/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.test.ts
@@ -66,6 +66,7 @@ function makeConfig(overrides: Partial<OneShotSingleDeployConfigClass> = {}): On
     quiet: false,
     rollback: true,
     parallelDeploy: false,
+    pinger: true,
     externalAddress: '',
     edgeEnabled: false,
     versions: {

--- a/test/unit/commands/one-shot/orchestrator/deploy/deploy-argv-builders.test.ts
+++ b/test/unit/commands/one-shot/orchestrator/deploy/deploy-argv-builders.test.ts
@@ -4,6 +4,7 @@ import {describe, it, afterEach} from 'mocha';
 import {expect} from 'chai';
 import sinon from 'sinon';
 import {ConsensusCommandDefinition} from '../../../../../../src/commands/command-definitions/consensus-command-definition.js';
+import {MirrorCommandDefinition} from '../../../../../../src/commands/command-definitions/mirror-command-definition.js';
 import * as constants from '../../../../../../src/core/constants.js';
 import * as version from '../../../../../../version.js';
 import {NamespaceName} from '../../../../../../src/types/namespace/namespace-name.js';
@@ -28,6 +29,7 @@ function makeConfig(overrides: Partial<OneShotSingleDeployConfigClass> = {}): On
     deployRelay: true,
     minimalSetup: false,
     predefinedAccounts: false,
+    pinger: true,
     versions: {explorer: '2.5.0', soloChart: '', consensus: '', mirror: '', relay: '', blockNode: ''},
     blockNodeConfiguration: {},
     mirrorNodeConfiguration: {},
@@ -102,6 +104,16 @@ describe('buildMirrorNodeArgv', (): void => {
     expect(argv).to.include(optionFromFlag(Flags.enableIngress));
   });
 
+  it('can omit pinger from initial mirror deployment', (): void => {
+    const argv: string[] = DeployArgvBuilders.buildMirrorNodeArgv(makeConfig(), false);
+    expect(argv).to.not.include(optionFromFlag(Flags.pinger));
+  });
+
+  it('omits pinger when pinger is disabled in config', (): void => {
+    const argv: string[] = DeployArgvBuilders.buildMirrorNodeArgv(makeConfig({pinger: false}));
+    expect(argv).to.not.include(optionFromFlag(Flags.pinger));
+  });
+
   it('includes the parallel-deploy flag', (): void => {
     const argv: string[] = DeployArgvBuilders.buildMirrorNodeArgv(makeConfig({parallelDeploy: true}));
     expect(argv).to.include(optionFromFlag(Flags.parallelDeploy));
@@ -131,6 +143,31 @@ describe('buildMirrorNodeArgv', (): void => {
     const mirrorNodeConfiguration: Record<string, string> = {[valuesFileFlagName]: originalFile};
     DeployArgvBuilders.buildMirrorNodeArgv(makeConfig({mirrorNodeConfiguration}));
     expect(mirrorNodeConfiguration[valuesFileFlagName]).to.equal(originalFile);
+  });
+});
+
+describe('buildMirrorNodePingerUpgradeArgv', (): void => {
+  it('builds a mirror node upgrade command with pinger enabled', (): void => {
+    const argv: string[] = DeployArgvBuilders.buildMirrorNodePingerUpgradeArgv(makeConfig());
+    for (const commandToken of MirrorCommandDefinition.UPGRADE_COMMAND.split(' ')) {
+      expect(argv).to.include(commandToken);
+    }
+    expect(argv).to.include(optionFromFlag(Flags.deployment));
+    expect(argv).to.include('test-deployment');
+    expect(argv).to.include(optionFromFlag(Flags.clusterRef));
+    expect(argv).to.include('test-cluster');
+    expect(argv).to.include(optionFromFlag(Flags.pinger));
+    expect(argv).to.include(optionFromFlag(Flags.enableIngress));
+  });
+
+  it('preserves mirror values file handling for the delayed pinger upgrade', (): void => {
+    const existingFile: string = '/path/to/custom.yaml';
+    const valuesFileFlagName: string = optionFromFlag(Flags.valuesFile);
+    const mirrorNodeConfiguration: Record<string, string> = {[valuesFileFlagName]: existingFile};
+    const argv: string[] = DeployArgvBuilders.buildMirrorNodePingerUpgradeArgv(makeConfig({mirrorNodeConfiguration}));
+    const valueIndex: number = argv.indexOf(optionFromFlag(Flags.valuesFile));
+    expect(valueIndex).to.be.greaterThan(-1);
+    expect(argv[valueIndex + 1]).to.equal(`${existingFile},${constants.MIRROR_NODE_HIKARI_LIMITS_FILE}`);
   });
 });
 


### PR DESCRIPTION
## Description

This pull request changes the following:

* Delays enabling the mirror node pinger during one-shot deploy until after the mirror node is deployed and consensus nodes have started.
* Keeps one-shot parallel deployment enabled for the rest of the deploy flow by installing mirror node initially without `--pinger`, then running a later `mirror node upgrade --pinger` phase.
* Adds unit coverage for omitting pinger during initial mirror deployment and preserving mirror values-file handling during the delayed pinger upgrade.

Root cause: #4712 correctly writes the ClusterIP service endpoint into the address book, but the Windows one-shot path can still start pinger before that NodeUpdate completes. On Windows Kind/WSL2, hiero-sdk-go eager gRPC dialing can hang against the bootstrap service FQDN, keeping pinger unready until the one-shot wait times out.

### Related Issues

* Closes #4761
* Related to #4712

### Pull request (PR) checklist

* [x] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [x] Any technical debt has been documented as a separate issue and linked to this PR
* [x] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [x] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [ ] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* `npx mocha 'test/unit/commands/one-shot/orchestrator/deploy/deploy-argv-builders.test.ts' 'test/unit/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.test.ts'`
* `npx tsc --noEmit`
* `npx eslint src/commands/one-shot/orchestrator/deploy/deploy-argv-builders.ts src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts src/commands/one-shot/one-shot-single-deploy-config-class.ts test/unit/commands/one-shot/orchestrator/deploy/deploy-argv-builders.test.ts test/unit/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.test.ts`
* `npx prettier --check src/commands/one-shot/orchestrator/deploy/deploy-argv-builders.ts src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts src/commands/one-shot/one-shot-single-deploy-config-class.ts test/unit/commands/one-shot/orchestrator/deploy/deploy-argv-builders.test.ts test/unit/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.test.ts`
* `git diff --check`

The following was not tested:

* A full Windows one-shot GitHub Actions rerun. The PR is draft so the Windows check can validate the sequencing on GitHub-hosted Windows.

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                          | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                       |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
