### PR TITLE
fix: report platform status and recover port-forward on node ping fai…

### DIFF
--- a/src/core/account-manager.ts
+++ b/src/core/account-manager.ts
@@ -87,6 +87,8 @@ const DEFAULT_NODE_CLIENT_SELECTION: NodeClientSelection = {type: 'all'};
 export class AccountManager {
   private _portForwards: number[];
   private _forcePortForward: boolean = false;
+  private _portForwardCreationLock: Promise<void> = Promise.resolve();
+  private _nextPortForwardScanStart: number = 0;
   public _nodeClient: Optional<Client>;
 
   public constructor(
@@ -206,7 +208,29 @@ export class AccountManager {
 
     this._nodeClient = undefined;
     this._portForwards = [];
+    this._nextPortForwardScanStart = 0;
     this.logger.debug('node client and port forwards have been closed');
+  }
+
+  /**
+   * Serializes port-forward creation so that concurrent {@link configureNodeAccess} calls cannot race
+   * {@link Pod.portForward}'s available-port scan onto the same local port: a freshly spawned forwarder is not
+   * listening yet, so a concurrent scan would consider its port free and assign it to another node.
+   * @param action - the port-forward mutation to run while holding the lock
+   * @returns the result of the action
+   */
+  private async withPortForwardCreationLock<T>(action: () => Promise<T>): Promise<T> {
+    const previousLock: Promise<void> = this._portForwardCreationLock;
+    let releaseLock: () => void;
+    this._portForwardCreationLock = new Promise<void>((resolve): void => {
+      releaseLock = resolve;
+    });
+    await previousLock;
+    try {
+      return await action();
+    } finally {
+      releaseLock();
+    }
   }
 
   /**
@@ -370,6 +394,15 @@ export class AccountManager {
       });
       this.logger.debug(`configured node access for ${Object.keys(nodes).length} nodes`);
 
+      // a collision would silently drop nodes from the client's network map and route transactions to the wrong node
+      if (Object.keys(nodes).length !== configureNodeAccessPromiseArray.length) {
+        throw new SoloErrors.component.nodeAccessConfigFailed(
+          new Error(
+            `network endpoint collision: configured ${configureNodeAccessPromiseArray.length} nodes but resolved only ${Object.keys(nodes).length} distinct endpoints`,
+          ),
+        );
+      }
+
       let formattedNetworkConnection: string = '';
       for (const key of Object.keys(nodes)) {
         formattedNetworkConnection += `${key}:${nodes[key]}, `;
@@ -434,12 +467,19 @@ export class AccountManager {
 
       let forwardedPort: number = localPort;
       if (this._portForwards.length < totalNodes) {
-        forwardedPort = await this.k8Factory
-          .getK8(networkNodeService.context)
-          .pods()
-          .readByReference(PodReference.of(networkNodeService.namespace, networkNodeService.haProxyPodName))
-          .portForward(localPort, port);
-        this._portForwards.push(forwardedPort);
+        forwardedPort = await this.withPortForwardCreationLock(async (): Promise<number> => {
+          // start the available-port scan above every port already handed out, so ports occupied by stale
+          // forwarders from earlier refreshes cannot funnel concurrent creations onto the same fallback port
+          const scanStartPort: number = Math.max(localPort, this._nextPortForwardScanStart);
+          const newPort: number = await this.k8Factory
+            .getK8(networkNodeService.context)
+            .pods()
+            .readByReference(PodReference.of(networkNodeService.namespace, networkNodeService.haProxyPodName))
+            .portForward(scanStartPort, port);
+          this._nextPortForwardScanStart = newPort + 1;
+          this._portForwards.push(newPort);
+          return newPort;
+        });
         this.logger.debug(`using local host port forward: ${host}:${forwardedPort}`);
       }
 
@@ -501,22 +541,25 @@ export class AccountManager {
         // if the node itself is healthy and retries remain, the local port-forward tunnel is the likely culprit; recreate it
         if (lastPlatformStatus === NodeStatusEnums[NodeStatusCodes.ACTIVE] && currentRetry < maxRetries) {
           try {
-            const pod: Pod = this.k8Factory
-              .getK8(networkNodeService.context)
-              .pods()
-              .readByReference(PodReference.of(networkNodeService.namespace, networkNodeService.haProxyPodName));
-            await pod.stopPortForward(currentPort);
-            const newPort: number = await pod.portForward(currentPort, +networkNodeService.haProxyGrpcPort);
-            const index: number = this._portForwards.indexOf(currentPort);
-            if (index === -1) {
-              this._portForwards.push(newPort);
-            } else {
-              this._portForwards[index] = newPort;
-            }
-            if (newPort !== currentPort) {
-              object = {[`127.0.0.1:${newPort}` as SdkNetworkEndpoint]: accountId};
-              currentPort = newPort;
-            }
+            await this.withPortForwardCreationLock(async (): Promise<void> => {
+              const pod: Pod = this.k8Factory
+                .getK8(networkNodeService.context)
+                .pods()
+                .readByReference(PodReference.of(networkNodeService.namespace, networkNodeService.haProxyPodName));
+              await pod.stopPortForward(currentPort);
+              const newPort: number = await pod.portForward(currentPort, +networkNodeService.haProxyGrpcPort);
+              this._nextPortForwardScanStart = Math.max(this._nextPortForwardScanStart, newPort + 1);
+              const index: number = this._portForwards.indexOf(currentPort);
+              if (index === -1) {
+                this._portForwards.push(newPort);
+              } else {
+                this._portForwards[index] = newPort;
+              }
+              if (newPort !== currentPort) {
+                object = {[`127.0.0.1:${newPort}` as SdkNetworkEndpoint]: accountId};
+                currentPort = newPort;
+              }
+            });
           } catch (recreateError) {
             // best-effort recovery only: a failed port-forward recreation must not abort the remaining ping retries
             this.logger.warn(

--- a/src/core/account-manager.ts
+++ b/src/core/account-manager.ts
@@ -63,6 +63,8 @@ import {type RemoteConfigRuntimeStateApi} from '../business/runtime-state/api/re
 import {Secret} from '../integration/kube/resources/secret/secret.js';
 import {Address} from '../business/address/address.js';
 import {Numbers} from '../business/utils/numbers.js';
+import {type NetworkNodes} from './network-nodes.js';
+import {NodeStatusCodes, NodeStatusEnums} from './enumerations.js';
 
 // TODO - revisit and remove once we complete the cutover to BN and no longer need MN to pull from CN.
 // This should remove this dependency on @hiero-ledger/proto
@@ -92,11 +94,13 @@ export class AccountManager {
     @inject(InjectTokens.K8Factory) private readonly k8Factory?: K8Factory,
     @inject(InjectTokens.RemoteConfigRuntimeState) private readonly remoteConfig?: RemoteConfigRuntimeStateApi,
     @inject(InjectTokens.LocalConfigRuntimeState) private readonly localConfig?: LocalConfigRuntimeState,
+    @inject(InjectTokens.NetworkNodes) private readonly networkNodes?: NetworkNodes,
   ) {
     this.logger = patchInject(logger, InjectTokens.SoloLogger, this.constructor.name);
     this.k8Factory = patchInject(k8Factory, InjectTokens.K8Factory, this.constructor.name);
     this.remoteConfig = patchInject(remoteConfig, InjectTokens.RemoteConfigRuntimeState, this.constructor.name);
     this.localConfig = patchInject(localConfig, InjectTokens.LocalConfigRuntimeState, this.constructor.name);
+    this.networkNodes = patchInject(networkNodes, InjectTokens.NetworkNodes, this.constructor.name);
 
     this._portForwards = [];
     this._nodeClient = undefined;
@@ -427,69 +431,107 @@ export class AccountManager {
       }
       // if the load balancer IP is not set or the test connection fails, then we should use the local host port forward
       const host: string = '127.0.0.1';
-      const endpoint: SdkNetworkEndpoint = `${host}:${localPort}`;
 
+      let forwardedPort: number = localPort;
       if (this._portForwards.length < totalNodes) {
-        const portForward: number = await this.k8Factory
+        forwardedPort = await this.k8Factory
           .getK8(networkNodeService.context)
           .pods()
           .readByReference(PodReference.of(networkNodeService.namespace, networkNodeService.haProxyPodName))
           .portForward(localPort, port);
-        this._portForwards.push(portForward);
-        this.logger.debug(`using local host port forward: ${host}:${portForward}`);
+        this._portForwards.push(forwardedPort);
+        this.logger.debug(`using local host port forward: ${host}:${forwardedPort}`);
       }
 
+      const endpoint: SdkNetworkEndpoint = `${host}:${forwardedPort}`;
       const object: Record<SdkNetworkEndpoint, AccountId> = {[endpoint]: accountId};
 
-      await this.testNodeClientConnection(object, accountId);
-
-      return object;
+      return await this.testNodeClientConnection(object, accountId, networkNodeService, forwardedPort);
     } catch (error) {
       throw new SoloErrors.component.nodeAccessConfigFailed(error);
     }
   }
 
   /**
-   * pings the network node to ensure that the connection is working
+   * pings the network node to ensure that the connection is working, retrying and recreating the local
+   * port-forward when the consensus node reports ACTIVE (indicating a broken tunnel rather than an unhealthy node)
    * @param object - the object containing the network node endpoint and account id
    * @param accountId - the account id to ping
-   * @throws {@link SoloError} if the ping fails
+   * @param networkNodeService - the services of the node being pinged, used for diagnostics and port-forward recovery
+   * @param localPort - the local port currently forwarded to the node's HAProxy grpc port
+   * @returns the (possibly re-keyed) endpoint-to-account map that succeeded
+   * @throws {@link SoloError} if the ping fails after all retries
    */
   private async testNodeClientConnection(
     object: Record<SdkNetworkEndpoint, AccountId>,
     accountId: AccountId,
-  ): Promise<void> {
+    networkNodeService: NetworkNodeServices,
+    localPort: number,
+  ): Promise<Record<SdkNetworkEndpoint, AccountId>> {
     const maxRetries: number = constants.NODE_CLIENT_SDK_PING_MAX_RETRIES;
     const sleepInterval: number = constants.NODE_CLIENT_SDK_PING_RETRY_INTERVAL;
 
     let currentRetry: number = 0;
-    let success: boolean = false;
+    let currentPort: number = localPort;
+    let lastError: Error | undefined;
+    let lastPlatformStatus: string | undefined;
 
-    try {
-      while (!success && currentRetry < maxRetries) {
-        try {
-          this.logger.debug(
-            `attempting to sdk ping network node: ${Object.keys(object)[0]}, attempt: ${currentRetry}, of ${maxRetries}`,
-          );
-          await this.sdkPingNetworkNode(object, accountId);
-          success = true;
+    while (currentRetry < maxRetries) {
+      try {
+        this.logger.debug(
+          `attempting to sdk ping network node: ${Object.keys(object)[0]}, attempt: ${currentRetry}, of ${maxRetries}`,
+        );
+        await this.sdkPingNetworkNode(object, accountId);
 
-          return;
-        } catch (error) {
-          this.logger.error(`failed to sdk ping network node: ${Object.keys(object)[0]}, ${error.message}`);
-          currentRetry++;
+        return object;
+      } catch (error) {
+        lastError = error;
+        currentRetry++;
+
+        // diagnostic: read the consensus node's platform status (metrics live in the ROOT_CONTAINER, not HAProxy)
+        lastPlatformStatus = await this.networkNodes.getNetworkNodePlatformStatusName(
+          PodReference.of(networkNodeService.namespace, networkNodeService.nodePodName),
+          networkNodeService.context,
+        );
+        this.logger.error(
+          `failed to sdk ping network node: ${Object.keys(object)[0]}, ${error.message}; ` +
+            `last consensus node platform status: ${lastPlatformStatus}`,
+        );
+
+        // if the node itself is healthy and retries remain, the local port-forward tunnel is the likely culprit; recreate it
+        if (lastPlatformStatus === NodeStatusEnums[NodeStatusCodes.ACTIVE] && currentRetry < maxRetries) {
+          try {
+            const pod: Pod = this.k8Factory
+              .getK8(networkNodeService.context)
+              .pods()
+              .readByReference(PodReference.of(networkNodeService.namespace, networkNodeService.haProxyPodName));
+            await pod.stopPortForward(currentPort);
+            const newPort: number = await pod.portForward(currentPort, +networkNodeService.haProxyGrpcPort);
+            const index: number = this._portForwards.indexOf(currentPort);
+            if (index === -1) {
+              this._portForwards.push(newPort);
+            } else {
+              this._portForwards[index] = newPort;
+            }
+            if (newPort !== currentPort) {
+              object = {[`127.0.0.1:${newPort}` as SdkNetworkEndpoint]: accountId};
+              currentPort = newPort;
+            }
+          } catch (recreateError) {
+            // best-effort recovery only: a failed port-forward recreation must not abort the remaining ping retries
+            this.logger.warn(
+              `failed to recreate port-forward for network node ${networkNodeService.nodeAlias}: ${recreateError.message}`,
+            );
+          }
+        }
+
+        if (currentRetry < maxRetries) {
           await sleep(Duration.ofMillis(sleepInterval));
         }
       }
-    } catch (error) {
-      throw new SoloErrors.component.sdkPingFailed(Object.keys(object)[0], maxRetries, error);
     }
 
-    if (currentRetry >= maxRetries) {
-      throw new SoloErrors.component.sdkPingFailed(Object.keys(object)[0], maxRetries);
-    }
-
-    return;
+    throw new SoloErrors.component.sdkPingFailed(Object.keys(object)[0], maxRetries, lastError, lastPlatformStatus);
   }
 
   /**

--- a/src/core/errors/classes/component/sdk-ping-failed-solo-error.ts
+++ b/src/core/errors/classes/component/sdk-ping-failed-solo-error.ts
@@ -15,10 +15,12 @@ export class SdkPingFailedSoloError extends SoloError {
   protected override readonly retryable: boolean = true;
   protected override readonly ownership: ErrorOwnership = ErrorOwnership.Infrastructure;
 
-  public constructor(nodeAlias: string, maxRetries: number, cause?: Error) {
+  public constructor(nodeAlias: string, maxRetries: number, cause?: Error, lastPlatformStatus?: string) {
     super(
       {
-        message: `SDK ping to network node ${nodeAlias} failed after ${maxRetries} retries`,
+        message:
+          `SDK ping to network node ${nodeAlias} failed after ${maxRetries} retries` +
+          (lastPlatformStatus ? `; last consensus node platform status: ${lastPlatformStatus}` : ''),
         code: ErrorCodeRegistry.SDK_PING_FAILED,
         troubleshootingSteps:
           'Check solo logs: tail -n 100 ~/.solo/logs/solo.log\n' +

--- a/src/core/network-nodes.ts
+++ b/src/core/network-nodes.ts
@@ -17,6 +17,7 @@ import {type Pod} from '../integration/kube/resources/pod/pod.js';
 import {PathEx} from '../business/utils/path-ex.js';
 import {K8} from '../integration/kube/k8.js';
 import {Container} from '../integration/kube/resources/container/container.js';
+import {NodeStatusEnums} from './enumerations.js';
 import chalk from 'chalk';
 
 /**
@@ -196,5 +197,19 @@ export class NetworkNodes {
         '-c',
         String.raw`curl -s http://localhost:9999/metrics | grep platform_PlatformStatus | grep -v \#`,
       ]);
+  }
+
+  public async getNetworkNodePlatformStatusName(podReference: PodReference, context?: string): Promise<string> {
+    try {
+      const response: string = await this.getNetworkNodePodStatus(podReference, context);
+      const statusLine: string | undefined = response
+        ?.split('\n')
+        .find((line: string): boolean => line.startsWith('platform_PlatformStatus'));
+      const statusNumber: number = Number.parseInt(statusLine?.split(' ').pop() ?? '', 10);
+      return NodeStatusEnums[statusNumber as keyof typeof NodeStatusEnums] ?? 'UNKNOWN';
+    } catch {
+      // best-effort diagnostic only: if the pod exec or metrics scrape fails, report UNKNOWN rather than mask the original ping failure
+      return 'UNKNOWN';
+    }
   }
 }

--- a/test/unit/core/errors.test.ts
+++ b/test/unit/core/errors.test.ts
@@ -8,6 +8,7 @@ import {ResourceNotFoundError} from '../../../src/core/errors/classes/system/res
 import {MissingArgumentError} from '../../../src/core/errors/classes/validation/missing-argument-error.js';
 import {IllegalArgumentError} from '../../../src/core/errors/classes/validation/illegal-argument-error.js';
 import {DataValidationError} from '../../../src/core/errors/classes/internal/data-validation-error.js';
+import {SdkPingFailedSoloError} from '../../../src/core/errors/classes/component/sdk-ping-failed-solo-error.js';
 
 describe('Errors', (): void => {
   const message: string = 'errorMessage';
@@ -63,5 +64,13 @@ describe('Errors', (): void => {
     );
     expect(error.cause).to.deep.equal({});
     expect(error.meta).to.deep.equal({expected, found});
+  });
+
+  it('should include the last consensus node platform status in SdkPingFailedSoloError', (): void => {
+    const error: SdkPingFailedSoloError = new SdkPingFailedSoloError('127.0.0.1:30213', 5, cause, 'STARTING_UP');
+    expect(error).to.be.instanceof(SoloError);
+    expect(error.message).to.equal(
+      'SDK ping to network node 127.0.0.1:30213 failed after 5 retries; last consensus node platform status: STARTING_UP',
+    );
   });
 });

--- a/test/unit/core/network-nodes.test.ts
+++ b/test/unit/core/network-nodes.test.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {expect} from 'chai';
+import {afterEach, beforeEach, describe, it} from 'mocha';
+import sinon from 'sinon';
+
+import {container} from 'tsyringe-neo';
+import {resetForTest} from '../../test-container.js';
+import {InjectTokens} from '../../../src/core/dependency-injection/inject-tokens.js';
+import {type NetworkNodes} from '../../../src/core/network-nodes.js';
+import {PodReference} from '../../../src/integration/kube/resources/pod/pod-reference.js';
+import {PodName} from '../../../src/integration/kube/resources/pod/pod-name.js';
+import {NamespaceName} from '../../../src/types/namespace/namespace-name.js';
+
+describe('NetworkNodes', (): void => {
+  let networkNodes: NetworkNodes;
+  const podReference: PodReference = PodReference.of(NamespaceName.of('namespace'), PodName.of('network-node1-0'));
+
+  beforeEach((): void => {
+    resetForTest();
+    networkNodes = container.resolve<NetworkNodes>(InjectTokens.NetworkNodes);
+  });
+
+  afterEach((): void => {
+    sinon.restore();
+  });
+
+  it('should map a platform status metric to its enum name', async (): Promise<void> => {
+    sinon
+      .stub(networkNodes, 'getNetworkNodePodStatus')
+      .resolves('# HELP platform_PlatformStatus\nplatform_PlatformStatus 2');
+    const status: string = await networkNodes.getNetworkNodePlatformStatusName(podReference);
+    expect(status).to.equal('ACTIVE');
+  });
+
+  it('should return UNKNOWN for an empty or garbage response', async (): Promise<void> => {
+    sinon.stub(networkNodes, 'getNetworkNodePodStatus').resolves('garbage without a status line');
+    const status: string = await networkNodes.getNetworkNodePlatformStatusName(podReference);
+    expect(status).to.equal('UNKNOWN');
+  });
+
+  it('should return UNKNOWN when the status fetch rejects', async (): Promise<void> => {
+    sinon.stub(networkNodes, 'getNetworkNodePodStatus').rejects(new Error('exec failed'));
+    const status: string = await networkNodes.getNetworkNodePlatformStatusName(podReference);
+    expect(status).to.equal('UNKNOWN');
+  });
+});


### PR DESCRIPTION
## Description

This pull request changes the following:

* Fixes a port mismatch in `AccountManager.configureNodeAccess`: the SDK endpoint was built from the *requested* local port, but `portForward()` may return a *different* port when the requested one is busy. When that happened, the SDK pinged a port nothing was listening on, guaranteeing the "failed to sdk ping network node ... after 5 retries" deployment failure. The endpoint is now built from the port actually returned by `portForward()`.
* Adds diagnostics to the SDK ping retry loop: on every failed attempt, the consensus node's `platform_PlatformStatus` is fetched from its metrics endpoint (new `NetworkNodes.getNetworkNodePlatformStatusName()`, reusing the existing `getNetworkNodePodStatus()` scrape) and included in the retry log line. The final `SdkPingFailedSoloError` message now reports the last observed platform status (e.g. `; last consensus node platform status: STARTING_UP`), so failures distinguish an unhealthy node from a broken tunnel.
* Adds self-recovery for broken port-forward tunnels: when the node reports `ACTIVE` but the ping still fails, the local port-forward is stopped and recreated between retries (best-effort — a failed recreation does not abort remaining retries). The `_portForwards` bookkeeping is updated in place and the endpoint is re-keyed if the recreated forward lands on a different port.
* Cleans up `testNodeClientConnection`: removes a vestigial outer try/catch that discarded the last ping error (the thrown error now carries the real cause), and skips the pointless sleep after the final failed attempt.

### Related Issues

* Closes #4591

### Pull request (PR) checklist

* [x] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [ ] Any technical debt has been documented as a separate issue and linked to this PR
* [ ] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [x] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [x] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* `npx tsc --noEmit` — clean
* `npx eslint` on all changed files — clean (one pre-existing `unicorn/no-null` warning in untouched code)
* `npx prettier --check` on all changed files — clean
* `npx mocha test/unit/core/network-nodes.test.ts test/unit/core/errors.test.ts test/unit/core/profile-manager.test.ts` — 19 passing (new `NetworkNodes` status-parsing tests, new `SdkPingFailedSoloError` message test, and the existing suite that exercises `AccountManager` construction via DI)

The following was not tested:

* End-to-end `node start` on a live Kind cluster (the port-forward recreation path requires a running cluster; covered by the existing e2e suites in CI)
* The pre-existing behavior where `_portForwards.length >= totalNodes` skips forward creation and assumes the port from a prior call — unchanged by this PR