### PR TITLE
fix: restore extraEnv values file ordering so TSS_LIB_WRAPS_ARTIFACTS_PATH is always set

### DIFF
--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -486,12 +486,16 @@ export class NetworkCommand extends BaseCommand {
       // values file can replace array elements and drop fields like node labels/account IDs.
       const chartValues: HelmChartValues = valuesFiles[clusterReference].clone();
 
-      // Add per-cluster extraEnv values file if any extraEnv customizations are needed
-      if (perClusterExtraEnvironmentValuesFiles[clusterReference]) {
-        chartValues.file(perClusterExtraEnvironmentValuesFiles[clusterReference]);
-      }
-
       chartValues.add(clusterChartValues[clusterReference] ?? new HelmChartValues());
+
+      // Add per-cluster extraEnv values file last (after user files) so that Solo-injected
+      // env vars like TSS_LIB_WRAPS_ARTIFACTS_PATH are not wiped out by a user-provided
+      // values file that also defines hedera.nodes[*].root.extraEnv. The generated file
+      // already contains the user's extraEnv entries merged in via baseExtraEnvironmentVariables,
+      // so placing it last is safe.
+      if (perClusterExtraEnvironmentValuesFiles[clusterReference]) {
+        chartValues.userFile(perClusterExtraEnvironmentValuesFiles[clusterReference]);
+      }
 
       chartValuesMap[clusterReference] = chartValues;
       this.logger.debug(`Prepared helm chart values for cluster-ref: ${clusterReference}`, {

--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -456,6 +456,20 @@ export class NetworkCommand extends BaseCommand {
         // generated file can include them and avoid Helm array replacement silently dropping
         // env vars set by user-provided values files.
         const existingValuesFilePaths: string[] = valueFilePathsMap[clusterReference] ?? [];
+        const userValueFilePaths: string[] = valuesFiles[clusterReference]?.userValueFilePaths() ?? [];
+        const extraEnvironmentWarnings: string[] = helmValuesHelper.describeUserProvidedExtraEnvironmentWarnings(
+          userValueFilePaths,
+          clusterConsensusNodes,
+          {
+            wrapsEnabled: config.wrapsEnabled,
+            tss: this.soloConfig.tss,
+            debugNodeAlias: config.debugNodeAlias,
+            useJavaMainClass: config.app !== constants.HEDERA_APP_NAME,
+          },
+        );
+        for (const warning of extraEnvironmentWarnings) {
+          this.logger.showUserUnlessOneShot(chalk.yellow(warning));
+        }
 
         const clusterExtraEnvironmentValuesFile: string = helmValuesHelper.generateExtraEnvironmentValuesFile(
           clusterConsensusNodes,

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -3570,11 +3570,9 @@ export class NodeCommandTasks {
           configTxtPath,
         );
 
-        const extraEnvironmentChartValuesMap: Record<ClusterReferenceName, HelmChartValues> = {};
         const valuesFilesMap: Record<ClusterReferenceName, HelmChartValues> = {};
         const valueFilePathsMap: Record<ClusterReferenceName, string[]> = {};
         for (const [clusterReference] of clusterReferences) {
-          extraEnvironmentChartValuesMap[clusterReference] = new HelmChartValues();
           valuesFilesMap[clusterReference] = new HelmChartValues();
           valueFilePathsMap[clusterReference] = [];
         }
@@ -3648,11 +3646,11 @@ export class NodeCommandTasks {
               },
               constants.SOLO_CACHE_DIR,
             );
-            // Preserve the old effective Helm merge order for node transactions:
-            // generated extraEnv file first, node --set/--set-literal overrides second,
-            // and transaction/profile/user values files last.
-            extraEnvironmentChartValuesMap[clusterReference].file(extraEnvironmentValuesFile);
-            valueFilePathsMap[clusterReference].push(extraEnvironmentValuesFile);
+            // Place the generated extraEnv file last (after user files) so that Solo-injected
+            // env vars like TSS_LIB_WRAPS_ARTIFACTS_PATH are not wiped out by a user-provided
+            // values file that also defines hedera.nodes[*].root.extraEnv. The generated file
+            // already merges the user's extraEnv entries via baseExtraEnvironmentVariables.
+            valuesFilesMap[clusterReference].userFile(extraEnvironmentValuesFile);
           }
         }
 
@@ -3674,9 +3672,8 @@ export class NodeCommandTasks {
               'Solo chart version',
               MINIMUM_SOLO_CHART_VERSION,
             );
-            const chartValues: HelmChartValues = extraEnvironmentChartValuesMap[clusterReference]
+            const chartValues: HelmChartValues = nodeChartValuesMap[clusterReference]
               .clone()
-              .add(nodeChartValuesMap[clusterReference])
               .add(valuesFilesMap[clusterReference]);
 
             await this.chartManager.upgrade(

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -3610,6 +3610,7 @@ export class NodeCommandTasks {
             // Always include the chart's own defaults file so default JAVA_OPTS/heap vars
             // are preserved when no per-node override exists in the user-provided files.
             const existingValuesFilePaths: string[] = [constants.SOLO_DEPLOYMENT_VALUES_FILE];
+            const userValueFilePaths: string[] = valuesFilesMap[clusterReference]?.userValueFilePaths() ?? [];
             for (const filePath of valueFilePathsMap[clusterReference] ?? []) {
               if (!existingValuesFilePaths.includes(filePath)) {
                 existingValuesFilePaths.push(filePath);
@@ -3631,6 +3632,19 @@ export class NodeCommandTasks {
               ...indexedConsensusNodes.filter((node): node is ConsensusNode => node !== undefined),
               ...unindexedConsensusNodes,
             ];
+            const extraEnvironmentWarnings: string[] = helmValuesHelper.describeUserProvidedExtraEnvironmentWarnings(
+              userValueFilePaths,
+              clusterConsensusNodes,
+              {
+                wrapsEnabled: this.remoteConfig.configuration.state.wrapsEnabled,
+                tss: this.soloConfig.tss,
+                debugNodeAlias: config.debugNodeAlias,
+                useJavaMainClass: false,
+              },
+            );
+            for (const warning of extraEnvironmentWarnings) {
+              this.logger.showUserUnlessOneShot(chalk.yellow(warning));
+            }
 
             const extraEnvironmentValuesFile: string = helmValuesHelper.generateExtraEnvironmentValuesFile(
               clusterConsensusNodes,

--- a/src/core/helm-values-helper.ts
+++ b/src/core/helm-values-helper.ts
@@ -14,6 +14,17 @@ import {
 } from '../types/helm-values.js';
 import yaml from 'yaml';
 
+type ExtractedExtraEnvironmentAnalysis = {
+  environmentVariablesByNode: Record<NodeAlias, EnvironmentVariable[]>;
+  overwrittenVariableNamesByNode: Record<NodeAlias, Set<string>>;
+  ignoredEntryCount: number;
+};
+
+type ExtractedExtraEnvironmentArray = {
+  environmentVariables: EnvironmentVariable[];
+  ignoredEntryCount: number;
+};
+
 export class HelmValuesHelper {
   public constructor() {}
 
@@ -24,9 +35,9 @@ export class HelmValuesHelper {
     const hedera: PerNodeExtraEnvironmentValues['hedera'] = {nodes: []};
 
     for (const [nodeIndex, consensusNode] of consensusNodes.entries()) {
-      const extraEnvironmentVariables: EnvironmentVariable[] = [
-        ...(options.baseExtraEnvironmentVariables?.[consensusNode.name] ?? []),
-      ];
+      const extraEnvironmentVariables: EnvironmentVariable[] = (
+        options.baseExtraEnvironmentVariables?.[consensusNode.name] ?? []
+      ).map((environmentVariable): EnvironmentVariable => ({...environmentVariable}));
 
       if (options.useJavaMainClass) {
         this.setExtraEnvironmentVariable(extraEnvironmentVariables, 'JAVA_MAIN_CLASS', 'com.swirlds.platform.Browser');
@@ -164,50 +175,79 @@ export class HelmValuesHelper {
     filePaths: string[],
     consensusNodes: ConsensusNode[],
   ): Record<NodeAlias, EnvironmentVariable[]> {
-    const result: Record<NodeAlias, EnvironmentVariable[]> = {};
+    return this.extractExtraEnvironmentAnalysisFromValuesFiles(filePaths, consensusNodes).environmentVariablesByNode;
+  }
 
-    for (const filePath of filePaths) {
-      const parsedRecord: Record<string, unknown> | undefined = this.parseValuesFile(filePath);
-      if (!parsedRecord) {
-        continue;
+  public describeUserProvidedExtraEnvironmentWarnings(
+    filePaths: string[],
+    consensusNodes: ConsensusNode[],
+    options: PerNodeExtraEnvironmentOptions = {},
+  ): string[] {
+    if (filePaths.length === 0) {
+      return [];
+    }
+
+    const extractedAnalysis: ExtractedExtraEnvironmentAnalysis = this.extractExtraEnvironmentAnalysisFromValuesFiles(
+      filePaths,
+      consensusNodes,
+    );
+    const warnings: string[] = [];
+
+    if (extractedAnalysis.ignoredEntryCount > 0) {
+      const noun: string = extractedAnalysis.ignoredEntryCount === 1 ? 'entry' : 'entries';
+      warnings.push(
+        `Warning: Ignored ${extractedAnalysis.ignoredEntryCount} invalid extraEnv ${noun} from --values-file input because each entry must contain string name and value fields.`,
+      );
+    }
+
+    for (const consensusNode of consensusNodes) {
+      const overwrittenVariableNames: string[] = [
+        ...(extractedAnalysis.overwrittenVariableNamesByNode[consensusNode.name] ?? []),
+      ];
+      for (const variableName of overwrittenVariableNames) {
+        warnings.push(
+          `Warning: User-provided extraEnv ${variableName} for ${consensusNode.name} is defined multiple times across --values-file inputs; the last value wins.`,
+        );
       }
+    }
 
-      const defaultsSection: unknown = parsedRecord.defaults;
-      if (defaultsSection && typeof defaultsSection === 'object') {
-        const defaultsRootSection: unknown = (defaultsSection as Record<string, unknown>).root;
-        const defaultsEnvironmentVariables: EnvironmentVariable[] =
-          this.extractExtraEnvironmentArray(defaultsRootSection);
-        if (defaultsEnvironmentVariables.length > 0) {
-          for (const consensusNode of consensusNodes) {
-            this.mergeIntoResult(result, consensusNode.name, defaultsEnvironmentVariables);
-          }
-        }
-      }
+    const generatedValues: PerNodeExtraEnvironmentValues = this.buildPerNodeExtraEnvironmentValuesStructure(
+      consensusNodes,
+      {
+        ...options,
+        baseExtraEnvironmentVariables: extractedAnalysis.environmentVariablesByNode,
+      },
+    );
 
-      const hederaSection: unknown = parsedRecord.hedera;
-      if (!hederaSection || typeof hederaSection !== 'object') {
-        continue;
-      }
+    for (const [nodeIndex, consensusNode] of consensusNodes.entries()) {
+      const mergedEnvironmentVariables: EnvironmentVariable[] =
+        generatedValues.hedera.nodes[nodeIndex].root?.extraEnv ?? [];
+      const mergedValueByName: Map<string, string> = new Map(
+        mergedEnvironmentVariables.map((environmentVariable): [string, string] => [
+          environmentVariable.name,
+          environmentVariable.value,
+        ]),
+      );
 
-      const nodesArray: unknown = (hederaSection as Record<string, unknown>).nodes;
-      if (!Array.isArray(nodesArray)) {
-        continue;
-      }
+      for (const userEnvironmentVariable of extractedAnalysis.environmentVariablesByNode[consensusNode.name] ?? []) {
+        const mergedValue: string | undefined = mergedValueByName.get(userEnvironmentVariable.name);
 
-      for (const [helmNodeIndex, consensusNode] of consensusNodes.entries()) {
-        const nodeEntry: unknown = nodesArray[helmNodeIndex];
-        if (!nodeEntry || typeof nodeEntry !== 'object') {
+        if (mergedValue === undefined) {
+          warnings.push(
+            `Warning: User-provided extraEnv ${userEnvironmentVariable.name} for ${consensusNode.name} was filtered out during Solo's generated extraEnv merge.`,
+          );
           continue;
         }
-        const nodeRootSection: unknown = (nodeEntry as Record<string, unknown>).root;
-        const nodeEnvironmentVariables: EnvironmentVariable[] = this.extractExtraEnvironmentArray(nodeRootSection);
-        if (nodeEnvironmentVariables.length > 0) {
-          this.mergeIntoResult(result, consensusNode.name, nodeEnvironmentVariables);
+
+        if (mergedValue !== userEnvironmentVariable.value) {
+          warnings.push(
+            `Warning: User-provided extraEnv ${userEnvironmentVariable.name} for ${consensusNode.name} was overwritten during Solo's generated extraEnv merge. Final value: ${mergedValue}`,
+          );
         }
       }
     }
 
-    return result;
+    return warnings;
   }
 
   public extractPerNodeBlockNodesJsonFromValuesFile(
@@ -296,47 +336,124 @@ export class HelmValuesHelper {
     }
   }
 
-  private mergeIntoResult(
+  private extractExtraEnvironmentAnalysisFromValuesFiles(
+    filePaths: string[],
+    consensusNodes: ConsensusNode[],
+  ): ExtractedExtraEnvironmentAnalysis {
+    const environmentVariablesByNode: Record<NodeAlias, EnvironmentVariable[]> = {};
+    const overwrittenVariableNamesByNode: Record<NodeAlias, Set<string>> = {};
+    let ignoredEntryCount: number = 0;
+
+    for (const filePath of filePaths) {
+      const parsedRecord: Record<string, unknown> | undefined = this.parseValuesFile(filePath);
+      if (!parsedRecord) {
+        continue;
+      }
+
+      const defaultsSection: unknown = parsedRecord.defaults;
+      if (defaultsSection && typeof defaultsSection === 'object') {
+        const defaultsRootSection: unknown = (defaultsSection as Record<string, unknown>).root;
+        const defaultsExtraction: ExtractedExtraEnvironmentArray =
+          this.extractExtraEnvironmentArray(defaultsRootSection);
+        ignoredEntryCount += defaultsExtraction.ignoredEntryCount;
+        if (defaultsExtraction.environmentVariables.length > 0) {
+          for (const consensusNode of consensusNodes) {
+            this.mergeIntoAnalysis(
+              environmentVariablesByNode,
+              overwrittenVariableNamesByNode,
+              consensusNode.name,
+              defaultsExtraction.environmentVariables,
+            );
+          }
+        }
+      }
+
+      const hederaSection: unknown = parsedRecord.hedera;
+      if (!hederaSection || typeof hederaSection !== 'object') {
+        continue;
+      }
+
+      const nodesArray: unknown = (hederaSection as Record<string, unknown>).nodes;
+      if (!Array.isArray(nodesArray)) {
+        continue;
+      }
+
+      for (const [helmNodeIndex, consensusNode] of consensusNodes.entries()) {
+        const nodeEntry: unknown = nodesArray[helmNodeIndex];
+        if (!nodeEntry || typeof nodeEntry !== 'object') {
+          continue;
+        }
+        const nodeRootSection: unknown = (nodeEntry as Record<string, unknown>).root;
+        const nodeExtraction: ExtractedExtraEnvironmentArray = this.extractExtraEnvironmentArray(nodeRootSection);
+        ignoredEntryCount += nodeExtraction.ignoredEntryCount;
+        if (nodeExtraction.environmentVariables.length > 0) {
+          this.mergeIntoAnalysis(
+            environmentVariablesByNode,
+            overwrittenVariableNamesByNode,
+            consensusNode.name,
+            nodeExtraction.environmentVariables,
+          );
+        }
+      }
+    }
+
+    return {
+      environmentVariablesByNode,
+      overwrittenVariableNamesByNode,
+      ignoredEntryCount,
+    };
+  }
+
+  private mergeIntoAnalysis(
     result: Record<NodeAlias, EnvironmentVariable[]>,
+    overwrittenVariableNamesByNode: Record<NodeAlias, Set<string>>,
     nodeAlias: NodeAlias,
     environmentVariables: EnvironmentVariable[],
   ): void {
     if (!result[nodeAlias]) {
       result[nodeAlias] = [];
     }
+
+    overwrittenVariableNamesByNode[nodeAlias] ??= new Set<string>();
+
     for (const environmentVariable of environmentVariables) {
       const existingIndex: number = result[nodeAlias].findIndex(
         (variable): boolean => variable.name === environmentVariable.name,
       );
       const environmentVariableClone: EnvironmentVariable = {...environmentVariable};
+
       if (existingIndex === -1) {
         result[nodeAlias].push(environmentVariableClone);
       } else {
+        overwrittenVariableNamesByNode[nodeAlias].add(environmentVariable.name);
         result[nodeAlias][existingIndex] = environmentVariableClone;
       }
     }
   }
 
-  private extractExtraEnvironmentArray(rootSection: unknown): EnvironmentVariable[] {
+  private extractExtraEnvironmentArray(rootSection: unknown): ExtractedExtraEnvironmentArray {
     if (!rootSection || typeof rootSection !== 'object') {
-      return [];
+      return {environmentVariables: [], ignoredEntryCount: 0};
     }
     const extraEnvironmentArray: unknown = (rootSection as Record<string, unknown>).extraEnv;
     if (!Array.isArray(extraEnvironmentArray)) {
-      return [];
+      return {environmentVariables: [], ignoredEntryCount: 0};
     }
     const environmentVariables: EnvironmentVariable[] = [];
+    let ignoredEntryCount: number = 0;
     for (const entry of extraEnvironmentArray) {
       if (!entry || typeof entry !== 'object') {
+        ignoredEntryCount += 1;
         continue;
       }
       const entryRecord: Record<string, unknown> = entry;
       if (typeof entryRecord.name !== 'string' || typeof entryRecord.value !== 'string') {
+        ignoredEntryCount += 1;
         continue;
       }
       environmentVariables.push({name: entryRecord.name, value: entryRecord.value});
     }
-    return environmentVariables;
+    return {environmentVariables, ignoredEntryCount};
   }
 }
 

--- a/src/integration/helm/model/values.ts
+++ b/src/integration/helm/model/values.ts
@@ -59,6 +59,11 @@ export class HelmChartValues {
     return [...this._arguments, ...this._userArguments];
   }
 
+  /** Returns only the user-supplied values file paths, in the order they were added. */
+  public userValueFilePaths(): string[] {
+    return this.extractValueFilePaths(this._userArguments);
+  }
+
   public isEmpty(): boolean {
     return this._arguments.length === 0 && this._userArguments.length === 0;
   }
@@ -128,5 +133,17 @@ export class HelmChartValues {
     }
 
     return this;
+  }
+
+  private extractValueFilePaths(arguments_: string[]): string[] {
+    const filePaths: string[] = [];
+
+    for (let argumentIndex: number = 0; argumentIndex < arguments_.length; argumentIndex += 2) {
+      if (arguments_[argumentIndex] === '--values' && arguments_[argumentIndex + 1]) {
+        filePaths.push(arguments_[argumentIndex + 1]);
+      }
+    }
+
+    return filePaths;
   }
 }

--- a/test/unit/core/helpers.test.ts
+++ b/test/unit/core/helpers.test.ts
@@ -256,6 +256,82 @@ describe('Helpers', (): void => {
     });
   });
 
+  describe('describeUserProvidedExtraEnvironmentWarnings', (): void => {
+    it('warns when Solo overwrites a user-provided extraEnv value during wraps merge', (): void => {
+      const node: ConsensusNode = makeConsensusNode('node1', 0);
+      const temporaryDirectory: string = fs.mkdtempSync(path.join(os.tmpdir(), 'test-helpers-'));
+      const userValuesFilePath: string = path.join(temporaryDirectory, 'user-values.yaml');
+      fs.writeFileSync(
+        userValuesFilePath,
+        [
+          'hedera:',
+          '  nodes:',
+          '    - root:',
+          '        extraEnv:',
+          '          - name: TSS_LIB_WRAPS_ARTIFACTS_PATH',
+          '            value: /user/path',
+        ].join('\n'),
+        'utf8',
+      );
+
+      try {
+        const warnings: string[] = helmValuesHelper.describeUserProvidedExtraEnvironmentWarnings(
+          [userValuesFilePath],
+          [node],
+          {
+            wrapsEnabled: true,
+            tss: {
+              wraps: {
+                artifactsFolderName: 'data/keys/wraps-v1.0.0',
+              },
+            },
+          },
+        );
+
+        expect(warnings).to.deep.equal([
+          `Warning: User-provided extraEnv TSS_LIB_WRAPS_ARTIFACTS_PATH for node1 was overwritten during Solo's generated extraEnv merge. Final value: ${constants.HEDERA_HAPI_PATH}/data/keys/wraps-v1.0.0`,
+        ]);
+      } finally {
+        fs.rmSync(temporaryDirectory, {recursive: true, force: true});
+      }
+    });
+
+    it('warns when invalid or duplicate user-provided extraEnv entries are ignored', (): void => {
+      const node: ConsensusNode = makeConsensusNode('node1', 0);
+      const temporaryDirectory: string = fs.mkdtempSync(path.join(os.tmpdir(), 'test-helpers-'));
+      const userValuesFilePath: string = path.join(temporaryDirectory, 'user-values.yaml');
+      fs.writeFileSync(
+        userValuesFilePath,
+        [
+          'hedera:',
+          '  nodes:',
+          '    - root:',
+          '        extraEnv:',
+          '          - name: DUPLICATE_ENV',
+          '            value: first-value',
+          '          - name: DUPLICATE_ENV',
+          '            value: second-value',
+          '          - name: INVALID_ENV',
+        ].join('\n'),
+        'utf8',
+      );
+
+      try {
+        const warnings: string[] = helmValuesHelper.describeUserProvidedExtraEnvironmentWarnings(
+          [userValuesFilePath],
+          [node],
+        );
+
+        expect(warnings).to.deep.equal([
+          'Warning: Ignored 1 invalid extraEnv entry from --values-file input because each entry must contain string name and value fields.',
+          'Warning: User-provided extraEnv DUPLICATE_ENV for node1 is defined multiple times across --values-file inputs; the last value wins.',
+        ]);
+      } finally {
+        fs.rmSync(temporaryDirectory, {recursive: true, force: true});
+      }
+    });
+  });
+
   describe('extractPerNodeBlockNodesJsonFromValuesFile', (): void => {
     it('should extract blockNodesJson per node from a YAML values file', (): void => {
       const node: ConsensusNode = makeConsensusNode('node1', 0);

--- a/test/unit/core/helpers.test.ts
+++ b/test/unit/core/helpers.test.ts
@@ -136,6 +136,51 @@ describe('Helpers', (): void => {
   });
 
   describe('generateExtraEnvironmentValuesFile', (): void => {
+    it('should preserve user-provided hedera.nodes root extraEnv entries when wraps injects TSS_LIB_WRAPS_ARTIFACTS_PATH', (): void => {
+      const node: ConsensusNode = makeConsensusNode('node1', 0);
+      const temporaryDirectory: string = fs.mkdtempSync(path.join(os.tmpdir(), 'test-helpers-'));
+      const userValuesFilePath: string = path.join(temporaryDirectory, 'user-values.yaml');
+      fs.writeFileSync(
+        userValuesFilePath,
+        [
+          'hedera:',
+          '  nodes:',
+          '    - root:',
+          '        extraEnv:',
+          '          - name: USER_ENV',
+          '            value: user-value',
+        ].join('\n'),
+        'utf8',
+      );
+
+      try {
+        const result: {hedera: {nodes: {root?: {extraEnv: {name: string; value: string}[]}}[]}} = generateAndParse(
+          [node],
+          {
+            wrapsEnabled: true,
+            tss: {
+              wraps: {
+                artifactsFolderName: 'data/keys/wraps-v1.0.0',
+              },
+            },
+            baseExtraEnvironmentVariables: helmValuesHelper.extractExtraEnvironmentFromValuesFiles(
+              [userValuesFilePath],
+              [node],
+            ),
+          },
+        );
+        expect(result.hedera.nodes[0].root?.extraEnv).to.deep.equal([
+          {name: 'USER_ENV', value: 'user-value'},
+          {
+            name: 'TSS_LIB_WRAPS_ARTIFACTS_PATH',
+            value: `${constants.HEDERA_HAPI_PATH}/data/keys/wraps-v1.0.0`,
+          },
+        ]);
+      } finally {
+        fs.rmSync(temporaryDirectory, {recursive: true, force: true});
+      }
+    });
+
     it('should sanitize -Xms/-Xmx from JAVA_OPTS coming from baseExtraEnvironmentVariables', (): void => {
       const node: ConsensusNode = makeConsensusNode('node1', 0);
       const result: {hedera: {nodes: {root?: {extraEnv: {name: string; value: string}[]}}[]}} = generateAndParse(

--- a/test/unit/integration/helm/model/values.test.ts
+++ b/test/unit/integration/helm/model/values.test.ts
@@ -118,6 +118,18 @@ describe('HelmChartValues', (): void => {
     });
   });
 
+  describe('userValueFilePaths()', (): void => {
+    it('returns only user-supplied values files in insertion order', (): void => {
+      const values: HelmChartValues = new HelmChartValues()
+        .file('/solo/defaults.yaml')
+        .userFile('/user/a.yaml')
+        .set('key', 'value')
+        .userFile('/user/b.yaml');
+
+      expect(values.userValueFilePaths()).to.deep.equal(['/user/a.yaml', '/user/b.yaml']);
+    });
+  });
+
   describe('addFileForCluster() / addUserFileForCluster()', (): void => {
     it('addFileForCluster routes to _arguments (Solo slot)', (): void => {
       const chartValuesMap: Record<string, HelmChartValues> = {};


### PR DESCRIPTION
## Description

This pull request changes the following:

* Fixes a regression introduced by #4765 where `TSS_LIB_WRAPS_ARTIFACTS_PATH` was silently lost when a user-provided `--values-file` also defined `hedera.nodes[*].root.extraEnv`.

**Root cause:** PR #4765 moved user-supplied `--values-file` entries into `_userArguments` so they override Solo defaults. However the generated per-cluster extraEnv values file (which injects `TSS_LIB_WRAPS_ARTIFACTS_PATH` when `--wraps` is enabled) was still added via `.file()` into `_arguments`. Since `toArguments()` returns `[..._arguments, ..._userArguments]`, user files now came last, and Helm's array-replacement semantics silently wiped out `TSS_LIB_WRAPS_ARTIFACTS_PATH` whenever the user's values file also defined the `hedera.nodes[*].root.extraEnv` array.

**Before #4765** the Helm values order was:
```
[chart defaults, base, profile, user files, generated extraEnv, --set flags]
```
The generated extraEnv file came **after** user files → `TSS_LIB_WRAPS_ARTIFACTS_PATH` was set ✓

**After #4765** the order became:
```
_arguments: [chart defaults, base, profile, generated extraEnv, --set flags]
_userArguments: [user files]
```
User files came **last** → Helm array replacement wiped out `TSS_LIB_WRAPS_ARTIFACTS_PATH` ✗

**Fix:** Add the generated extraEnv file via `.userFile()` so it lands in `_userArguments` **after** the user files. The generated file already merges the user's extraEnv entries via `extractExtraEnvironmentFromValuesFiles` / `baseExtraEnvironmentVariables`, so placing it last is safe. Applied to both the `network deploy` path (`network.ts`) and the `node update/add` path (`node/tasks.ts`). The `node/tasks.ts` change also removes the now-redundant `extraEnvironmentChartValuesMap` wrapper.

### Related Issues

* Closes #4941

### Pull request (PR) checklist

* [ ] This PR added tests (unit, integration, and/or end-to-end)
* [x] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [ ] Any technical debt has been documented as a separate issue and linked to this PR
* [x] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [ ] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [x] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* Verified `TSS_LIB_WRAPS_ARTIFACTS_PATH` was the missing env var via CN logs from the perf test environment (issue #4941).
* Traced the Helm values file ordering through `HelmChartValues._arguments` / `_userArguments` / `toArguments()` to confirm the regression and the fix.

The following was not tested:

* End-to-end wraps deploy with `--values-file` override — requires a full Kind cluster with a CN version >= v0.73.0 that checks for the env var.