### PR TITLE
fix: provide a banner to the user when there is a new version of Solo available on NPMJS

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -18,6 +18,8 @@ import 'dotenv/config';
 import {type AnyListrContext, type NodeAlias} from '../types/aliases.js';
 import {type ListrBaseClassOptions} from 'listr2';
 
+export const PACKAGE_NAME: string = '@hiero-ledger/solo';
+
 export const SOLO_SILENT_MODE: boolean = getEnvironmentVariable('SOLO_SILENT_MODE') === 'true' || false;
 
 // eslint-disable-next-line solo/no-exported-function

--- a/src/core/version-update-notifier.ts
+++ b/src/core/version-update-notifier.ts
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from 'node:fs';
+import chalk from 'chalk';
+import * as constants from './constants.js';
+import {PACKAGE_NAME} from './constants.js';
+import {type SoloLogger} from './logging/solo-logger.js';
+import {PathEx} from '../business/utils/path-ex.js';
+import {SemanticVersion} from '../business/utils/semantic-version.js';
+import {getSoloVersion} from '../../version.js';
+import {Duration} from './time/duration.js';
+
+/**
+ * Shape of the on-disk cache used to avoid hitting the npm registry on every invocation.
+ */
+interface UpdateCheckCache {
+  lastCheckEpochMilliseconds: number;
+  latestVersion: string;
+}
+
+/**
+ * Notifies the user when a newer version of Solo is available on npmjs.com.
+ *
+ * The check is best-effort: it is skipped for non-interactive sessions,
+ * caches the latest known version for a day to avoid a
+ * network round-trip on every command, and never surfaces errors to the user.
+ */
+export class VersionUpdateNotifier {
+  private static readonly REGISTRY_URL: string = `https://registry.npmjs.org/${PACKAGE_NAME}/latest`;
+
+  /** Published documentation for the latest release, including install/upgrade instructions. */
+  private static readonly UPGRADE_GUIDE_URL: string = 'https://solo.hiero.org/docs/simple-solo-setup/upgrading-solo/';
+
+  /** GitHub releases page listing the changelog for every published version. */
+  private static readonly RELEASE_NOTES_URL: string = 'https://github.com/hiero-ledger/solo/releases';
+
+  /** How long a cached latest-version lookup is considered fresh (24 hours). */
+  private static readonly CHECK_INTERVAL_MILLISECONDS: number = Duration.ofHours(24).toMinutes();
+
+  private static readonly FETCH_TIMEOUT_MILLISECONDS: number = 2000;
+
+  /** Location of the cache file within the Solo cache directory. */
+  private static readonly CACHE_FILE_PATH: string = PathEx.join(constants.SOLO_CACHE_DIR, 'update-check.json');
+
+  /**
+   * Displays an upgrade banner when a newer Solo version exists on npmjs.com.
+   * Silently returns without a banner when disabled, non-interactive, offline, or already current.
+   */
+  public static async notifyIfUpdateAvailable(logger: SoloLogger): Promise<void> {
+    try {
+      if (!VersionUpdateNotifier.isEnabled()) {
+        return;
+      }
+
+      const latestVersion: string | undefined = await VersionUpdateNotifier.resolveLatestVersion(logger);
+      if (!latestVersion) {
+        return;
+      }
+
+      const currentVersion: string = getSoloVersion();
+      if (!VersionUpdateNotifier.isNewer(latestVersion, currentVersion)) {
+        return;
+      }
+
+      VersionUpdateNotifier.displayBanner(logger, currentVersion, latestVersion);
+    } catch (error) {
+      logger.debug('Skipping update notification: ', error);
+    }
+  }
+
+  /** Skips non-TTY sessions */
+  private static isEnabled(): boolean {
+    return process.stdout.isTTY;
+  }
+
+  /**
+   * Returns the latest published version, preferring a fresh cache entry and falling
+   * back to a stale cache entry when the network is unavailable.
+   */
+  private static async resolveLatestVersion(logger: SoloLogger): Promise<string | undefined> {
+    const cache: UpdateCheckCache | undefined = VersionUpdateNotifier.readCache();
+    const now: number = Date.now();
+
+    if (cache && now - cache.lastCheckEpochMilliseconds < VersionUpdateNotifier.CHECK_INTERVAL_MILLISECONDS) {
+      return cache.latestVersion;
+    }
+
+    const fetchedVersion: string | undefined = await VersionUpdateNotifier.fetchLatestVersion();
+    if (fetchedVersion) {
+      VersionUpdateNotifier.writeCache(logger, {lastCheckEpochMilliseconds: now, latestVersion: fetchedVersion});
+      return fetchedVersion;
+    }
+
+    // network failed: fall back to any previously cached value so we can still notify offline.
+    return cache?.latestVersion;
+  }
+
+  /** Fetches the latest published version from the npm registry, or undefined on any failure. */
+  private static async fetchLatestVersion(): Promise<string | undefined> {
+    const controller: AbortController = new AbortController();
+    const timeoutHandle: ReturnType<typeof setTimeout> = setTimeout((): void => {
+      controller.abort();
+    }, VersionUpdateNotifier.FETCH_TIMEOUT_MILLISECONDS);
+
+    try {
+      const response: Response = await fetch(VersionUpdateNotifier.REGISTRY_URL, {
+        signal: controller.signal,
+        headers: {'User-Agent': constants.SOLO_USER_AGENT_HEADER},
+      });
+      if (!response.ok) {
+        return undefined;
+      }
+      const payload: {version?: string} = (await response.json()) as {version?: string};
+      return payload.version;
+    } catch {
+      // best-effort: offline, DNS failure, timeout/abort, or malformed response all fall back to no update.
+      return undefined;
+    } finally {
+      clearTimeout(timeoutHandle);
+    }
+  }
+
+  /** Reads and parses the cache file, returning undefined when it is absent or unreadable. */
+  private static readCache(): UpdateCheckCache | undefined {
+    try {
+      const raw: string = fs.readFileSync(VersionUpdateNotifier.CACHE_FILE_PATH, 'utf8');
+      const parsed: UpdateCheckCache = JSON.parse(raw) as UpdateCheckCache;
+      if (typeof parsed.latestVersion === 'string' && typeof parsed.lastCheckEpochMilliseconds === 'number') {
+        return parsed;
+      }
+      return undefined;
+    } catch {
+      // best-effort: a missing or corrupt cache simply triggers a fresh registry lookup.
+      return undefined;
+    }
+  }
+
+  /** Persists the latest-version cache, ignoring write failures. */
+  private static writeCache(logger: SoloLogger, cache: UpdateCheckCache): void {
+    try {
+      fs.mkdirSync(constants.SOLO_CACHE_DIR, {recursive: true});
+      fs.writeFileSync(VersionUpdateNotifier.CACHE_FILE_PATH, JSON.stringify(cache), 'utf8');
+    } catch (error) {
+      // best-effort: an unwritable cache only means we re-check on the next invocation.
+      logger.debug('Unable to persist update-check cache: ', error);
+    }
+  }
+
+  /** Compares two versions, returning true when {@link latestVersion} is strictly newer. */
+  private static isNewer(latestVersion: string, currentVersion: string): boolean {
+    try {
+      const latest: SemanticVersion<string> = new SemanticVersion(latestVersion);
+      const current: SemanticVersion<string> = new SemanticVersion(currentVersion);
+      return latest.greaterThan(current);
+    } catch {
+      // best-effort: unparseable versions are treated as "no update" rather than erroring.
+      return false;
+    }
+  }
+
+  /** Prints the upgrade banner with the download link and install command. */
+  private static displayBanner(logger: SoloLogger, currentVersion: string, latestVersion: string): void {
+    const width: number = 80;
+    logger.showUser(chalk.yellow('\n' + '='.repeat(width)));
+    logger.showUser(
+      chalk.yellow('  A new version of Solo is available:'),
+      chalk.dim(currentVersion),
+      chalk.yellow('→'),
+      chalk.green(latestVersion),
+    );
+
+    logger.showUser(chalk.yellow('  Upgrade guide:'), chalk.cyan(VersionUpdateNotifier.UPGRADE_GUIDE_URL));
+    logger.showUser(chalk.yellow('  Release notes:'), chalk.cyan(VersionUpdateNotifier.RELEASE_NOTES_URL));
+    logger.showUser(chalk.yellow('='.repeat(width) + '\n'));
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {container} from 'tsyringe-neo';
 import {ListrLogger} from 'listr2';
 
 import * as constants from './core/constants.js';
+import {type AnyObject} from './types/aliases.js';
 import {CustomProcessOutput} from './core/process-output.js';
 import {type SoloLogger} from './core/logging/solo-logger.js';
 import {Container} from './core/dependency-injection/container-init.js';
@@ -16,6 +17,7 @@ import {SoloErrors} from './core/errors/solo-errors.js';
 import {type SoloError} from './core/errors/solo-error.js';
 import {SilentBreak} from './core/errors/silent-break.js';
 import {ArgumentProcessor} from './argument-processor.js';
+import {VersionUpdateNotifier} from './core/version-update-notifier.js';
 import {getSoloVersion} from '../version.js';
 
 if (!process.stdout.isTTY) {
@@ -109,5 +111,7 @@ export async function main(argv: string[], context?: {logger: SoloLogger}): Prom
     throw new SilentBreak('displayed version information, exiting');
   }
 
-  return await ArgumentProcessor.process(argv);
+  const result: AnyObject = await ArgumentProcessor.process(argv);
+  await VersionUpdateNotifier.notifyIfUpdateAvailable(logger);
+  return result;
 }

--- a/test/unit/core/version-update-notifier.test.ts
+++ b/test/unit/core/version-update-notifier.test.ts
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from 'node:fs';
+import {expect} from 'chai';
+import {describe, it, beforeEach, afterEach} from 'mocha';
+import sinon, {type SinonStub} from 'sinon';
+
+import {VersionUpdateNotifier} from '../../../src/core/version-update-notifier.js';
+import {PACKAGE_NAME} from '../../../src/core/constants.js';
+import {type SoloLogger} from '../../../src/core/logging/solo-logger.js';
+
+/** A version guaranteed to be newer than any real Solo version, so the banner should always fire. */
+const NEWER_VERSION: string = '999.999.999';
+
+/** A version guaranteed to be older than any real Solo version, so the banner should never fire. */
+const OLDER_VERSION: string = '0.0.1';
+
+const ONE_DAY_MILLISECONDS: number = 24 * 60 * 60 * 1000;
+const STALE_AGE_MILLISECONDS: number = ONE_DAY_MILLISECONDS + 60 * 60 * 1000;
+
+/** Minimal logger surface exercised by the notifier. */
+interface FakeLogger {
+  showUser: SinonStub;
+  debug: SinonStub;
+}
+
+describe('VersionUpdateNotifier', (): void => {
+  const originalReadFileSync: typeof fs.readFileSync = fs.readFileSync.bind(fs);
+
+  let fetchStub: SinonStub;
+  let writeFileSyncStub: SinonStub;
+  let logger: FakeLogger;
+  let originalIsTty: boolean;
+
+  /** Content returned for a cache read; `undefined` simulates a missing cache file. */
+  let cacheContent: string | undefined;
+
+  beforeEach((): void => {
+    originalIsTty = process.stdout.isTTY;
+    process.stdout.isTTY = true;
+    cacheContent = undefined;
+
+    fetchStub = sinon.stub(globalThis, 'fetch' as never);
+    writeFileSyncStub = sinon.stub(fs, 'writeFileSync');
+    sinon.stub(fs, 'mkdirSync');
+
+    // Route cache reads to the test-controlled content while letting getSoloVersion() read the real package.json.
+    sinon
+      .stub(fs, 'readFileSync')
+      .callsFake((path: fs.PathOrFileDescriptor, options?: BufferEncoding | object): string => {
+        const pathString: string = String(path);
+        if (pathString.includes('update-check.json')) {
+          if (cacheContent === undefined) {
+            throw new Error('ENOENT: no such file or directory');
+          }
+          return cacheContent;
+        }
+        return originalReadFileSync(path, options) as string;
+      });
+
+    logger = {showUser: sinon.stub(), debug: sinon.stub()};
+  });
+
+  afterEach((): void => {
+    process.stdout.isTTY = originalIsTty;
+    sinon.restore();
+  });
+
+  /** Seeds the controlled cache file with the given version and age. */
+  function seedCache(latestVersion: string, ageMilliseconds: number): void {
+    cacheContent = JSON.stringify({
+      lastCheckEpochMilliseconds: Date.now() - ageMilliseconds,
+      latestVersion,
+    });
+  }
+
+  /** Stubs a successful registry response returning the given version. */
+  function stubFetchVersion(version: string): void {
+    fetchStub.resolves({ok: true, json: async (): Promise<{version: string}> => ({version})});
+  }
+
+  /** Concatenates every argument passed to logger.showUser into a single searchable string. */
+  function bannerText(): string {
+    return logger.showUser
+      .getCalls()
+      .map((call): string => call.args.join(' '))
+      .join('\n');
+  }
+
+  async function notify(): Promise<void> {
+    await VersionUpdateNotifier.notifyIfUpdateAvailable(logger as unknown as SoloLogger);
+  }
+
+  it('does nothing when the session is not a TTY', async (): Promise<void> => {
+    process.stdout.isTTY = false;
+
+    await notify();
+
+    expect(fetchStub).to.not.have.been.called;
+    expect(logger.showUser).to.not.have.been.called;
+  });
+
+  it('shows the banner from a fresh cache without hitting the network', async (): Promise<void> => {
+    seedCache(NEWER_VERSION, 0);
+
+    await notify();
+
+    expect(fetchStub).to.not.have.been.called;
+    expect(logger.showUser).to.have.been.called;
+    expect(bannerText()).to.include(NEWER_VERSION);
+  });
+
+  it('includes the install command and package link in the banner', async (): Promise<void> => {
+    seedCache(NEWER_VERSION, 0);
+
+    await notify();
+
+    const output: string = bannerText();
+    expect(output).to.include(`npm install -g ${PACKAGE_NAME}@latest`);
+    expect(output).to.include('https://hiero-ledger.github.io/solo/latest/');
+    expect(output).to.include('https://github.com/hiero-ledger/solo/releases');
+  });
+
+  it('does not show the banner when the cached version is not newer', async (): Promise<void> => {
+    seedCache(OLDER_VERSION, 0);
+
+    await notify();
+
+    expect(fetchStub).to.not.have.been.called;
+    expect(logger.showUser).to.not.have.been.called;
+  });
+
+  it('fetches from the registry, persists the cache, and shows the banner when a cache is absent', async (): Promise<void> => {
+    stubFetchVersion(NEWER_VERSION);
+
+    await notify();
+
+    expect(fetchStub).to.have.been.calledOnce;
+    const requestedUrl: string = fetchStub.firstCall.args[0] as string;
+    expect(requestedUrl).to.include('registry.npmjs.org');
+    expect(requestedUrl).to.include(PACKAGE_NAME);
+
+    expect(writeFileSyncStub).to.have.been.called;
+    const persisted: string = writeFileSyncStub.firstCall.args[1] as string;
+    expect(persisted).to.include(NEWER_VERSION);
+
+    expect(bannerText()).to.include(NEWER_VERSION);
+  });
+
+  it('refreshes from the registry when the cache is stale', async (): Promise<void> => {
+    seedCache(OLDER_VERSION, STALE_AGE_MILLISECONDS);
+    stubFetchVersion(NEWER_VERSION);
+
+    await notify();
+
+    expect(fetchStub).to.have.been.calledOnce;
+    expect(bannerText()).to.include(NEWER_VERSION);
+  });
+
+  it('falls back to a stale cached version when the network is unavailable', async (): Promise<void> => {
+    seedCache(NEWER_VERSION, STALE_AGE_MILLISECONDS);
+    fetchStub.rejects(new Error('network failure'));
+
+    await notify();
+
+    expect(fetchStub).to.have.been.calledOnce;
+    expect(logger.showUser).to.have.been.called;
+    expect(bannerText()).to.include(NEWER_VERSION);
+  });
+
+  it('stays silent when the network fails and there is no cache', async (): Promise<void> => {
+    fetchStub.rejects(new Error('network failure'));
+
+    await notify();
+
+    expect(logger.showUser).to.not.have.been.called;
+    expect(writeFileSyncStub).to.not.have.been.called;
+  });
+
+  it('stays silent when the registry responds with a non-OK status', async (): Promise<void> => {
+    fetchStub.resolves({ok: false, status: 500});
+
+    await notify();
+
+    expect(logger.showUser).to.not.have.been.called;
+  });
+
+  it('never rejects even when the registry returns malformed data', async (): Promise<void> => {
+    fetchStub.resolves({
+      ok: true,
+      json: async (): Promise<never> => {
+        throw new Error('invalid json');
+      },
+    });
+
+    await notify();
+
+    expect(logger.showUser).to.not.have.been.called;
+  });
+});

--- a/test/unit/core/version-update-notifier.test.ts
+++ b/test/unit/core/version-update-notifier.test.ts
@@ -110,14 +110,13 @@ describe('VersionUpdateNotifier', (): void => {
     expect(bannerText()).to.include(NEWER_VERSION);
   });
 
-  it('includes the install command and package link in the banner', async (): Promise<void> => {
+  it('includes the upgrade guide and release notes links in the banner', async (): Promise<void> => {
     seedCache(NEWER_VERSION, 0);
 
     await notify();
 
     const output: string = bannerText();
-    expect(output).to.include(`npm install -g ${PACKAGE_NAME}@latest`);
-    expect(output).to.include('https://hiero-ledger.github.io/solo/latest/');
+    expect(output).to.include('https://solo.hiero.org/docs/simple-solo-setup/upgrading-solo/');
     expect(output).to.include('https://github.com/hiero-ledger/solo/releases');
   });
 


### PR DESCRIPTION
## Description

Provide a banner to the user when there is a new version of Solo available on NPMJS and provide the link and install command for it

```logs
================================================================================
  A new version of Solo is available: 0.80.0 → 0.81.0
  Upgrade guide: https://solo.hiero.org/docs/simple-solo-setup/upgrading-solo/
  Release notes: https://github.com/hiero-ledger/solo/releases
================================================================================
```

### Related Issues

* Closes # https://github.com/hiero-ledger/solo/issues/2799
