### PR TITLE
fix: retry Kubernetes API requests throttled with HTTP 429 Too Many Requests

### DIFF
--- a/src/integration/kube/k8-client/k8-client-api-factory.ts
+++ b/src/integration/kube/k8-client/k8-client-api-factory.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  type ApiConstructor,
+  type ApiType,
+  type Cluster,
+  type Configuration,
+  type KubeConfig,
+  createConfiguration,
+  IsomorphicFetchHttpLibrary,
+  ServerConfiguration,
+  wrapHttpLibrary,
+} from '@kubernetes/client-node';
+import {RetryingHttpLibrary} from './retrying-http-library.js';
+import {MissingActiveClusterError} from '../errors/missing-active-cluster-error.js';
+
+/**
+ * Creates Kubernetes API clients backed by the throttling-aware {@link RetryingHttpLibrary}, mirroring
+ * {@link KubeConfig.makeApiClient}, which offers no hook for customizing the HTTP library.
+ */
+export class K8ClientApiFactory {
+  /**
+   * Creates an API client of the requested type for the current cluster of the supplied kube config.
+   * @throws MissingActiveClusterError - if the kube config has no current cluster.
+   */
+  public static makeApiClient<T extends ApiType>(kubeConfig: KubeConfig, apiClientType: ApiConstructor<T>): T {
+    const cluster: Cluster = kubeConfig.getCurrentCluster();
+    if (!cluster) {
+      throw new MissingActiveClusterError();
+    }
+
+    const configuration: Configuration = createConfiguration({
+      baseServer: new ServerConfiguration<Record<string, string>>(cluster.server, {}),
+      authMethods: {default: kubeConfig},
+      httpApi: wrapHttpLibrary(new RetryingHttpLibrary(new IsomorphicFetchHttpLibrary())),
+    });
+
+    return new apiClientType(configuration);
+  }
+}

--- a/src/integration/kube/k8-client/k8-client.ts
+++ b/src/integration/kube/k8-client/k8-client.ts
@@ -29,6 +29,7 @@ import {K8ClientIngresses} from './resources/ingress/k8-client-ingresses.js';
 import {type Crds} from '../resources/crd/crds.js';
 import {K8ClientCrds} from './resources/crd/k8-client-crds.js';
 import {KubeConfig} from '@kubernetes/client-node';
+import {K8ClientApiFactory} from './k8-client-api-factory.js';
 import {MissingActiveClusterError} from '../errors/missing-active-cluster-error.js';
 import {MissingActiveContextError} from '../errors/missing-active-context-error.js';
 import {type Optional} from '../../../types/index.js';
@@ -91,12 +92,12 @@ export class K8Client implements K8 {
       throw new MissingActiveClusterError();
     }
 
-    this.kubeClient = this.kubeConfig.makeApiClient(k8s.CoreV1Api);
-    this.networkingApi = this.kubeConfig.makeApiClient(k8s.NetworkingV1Api);
-    this.coordinationApiClient = this.kubeConfig.makeApiClient(k8s.CoordinationV1Api);
-    this.extensionApi = this.kubeConfig.makeApiClient(k8s.ApiextensionsV1Api);
-    this.rbacApi = this.kubeConfig.makeApiClient(k8s.RbacAuthorizationV1Api);
-    this.k8sObjectApi = this.kubeConfig.makeApiClient(k8s.KubernetesObjectApi);
+    this.kubeClient = K8ClientApiFactory.makeApiClient(this.kubeConfig, k8s.CoreV1Api);
+    this.networkingApi = K8ClientApiFactory.makeApiClient(this.kubeConfig, k8s.NetworkingV1Api);
+    this.coordinationApiClient = K8ClientApiFactory.makeApiClient(this.kubeConfig, k8s.CoordinationV1Api);
+    this.extensionApi = K8ClientApiFactory.makeApiClient(this.kubeConfig, k8s.ApiextensionsV1Api);
+    this.rbacApi = K8ClientApiFactory.makeApiClient(this.kubeConfig, k8s.RbacAuthorizationV1Api);
+    this.k8sObjectApi = K8ClientApiFactory.makeApiClient(this.kubeConfig, k8s.KubernetesObjectApi);
 
     this.k8Clusters = new K8ClientClusters(this.kubeConfig);
     this.k8ConfigMaps = new K8ClientConfigMaps(this.kubeClient);

--- a/src/integration/kube/k8-client/resources/context/k8-client-contexts.ts
+++ b/src/integration/kube/k8-client/resources/context/k8-client-contexts.ts
@@ -2,6 +2,7 @@
 
 import {type Contexts} from '../../../resources/context/contexts.js';
 import {type KubeConfig, CoreV1Api, type V1NamespaceList} from '@kubernetes/client-node';
+import {K8ClientApiFactory} from '../../k8-client-api-factory.js';
 import {NamespaceName} from '../../../../../types/namespace/namespace-name.js';
 
 export class K8ClientContexts implements Contexts {
@@ -33,7 +34,7 @@ export class K8ClientContexts implements Contexts {
     const originalContextName: string = this.readCurrent();
     this.kubeConfig.setCurrentContext(context);
 
-    const temporaryKubeClient: CoreV1Api = this.kubeConfig.makeApiClient(CoreV1Api);
+    const temporaryKubeClient: CoreV1Api = K8ClientApiFactory.makeApiClient(this.kubeConfig, CoreV1Api);
     try {
       const result: V1NamespaceList = await temporaryKubeClient.listNamespace();
       if (result?.items) {

--- a/src/integration/kube/k8-client/retrying-http-library.ts
+++ b/src/integration/kube/k8-client/retrying-http-library.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  type HttpLibrary,
+  type PromiseHttpLibrary,
+  type RequestContext,
+  type ResponseContext,
+} from '@kubernetes/client-node';
+import {StatusCodes} from 'http-status-codes';
+import {container} from 'tsyringe-neo';
+import {InjectTokens} from '../../../core/dependency-injection/inject-tokens.js';
+import {type SoloLogger} from '../../../core/logging/solo-logger.js';
+import {sleep} from '../../../core/helpers.js';
+import {Duration} from '../../../core/time/duration.js';
+
+/**
+ * Retries requests throttled by the Kubernetes API server with HTTP 429 (safe, as throttled requests are
+ * rejected before processing); the generated client fails on 429 immediately, ignoring `Retry-After`.
+ */
+export class RetryingHttpLibrary implements PromiseHttpLibrary {
+  /** The maximum number of times a throttled request is resent before the throttled response is returned. */
+  private static readonly MAX_RETRIES: number = 5;
+
+  /** The upper bound applied to the delay between retries, regardless of the `Retry-After` header value. */
+  private static readonly MAX_RETRY_DELAY_SECONDS: number = 15;
+
+  public constructor(private readonly delegate: HttpLibrary) {}
+
+  public async send(request: RequestContext): Promise<ResponseContext> {
+    let response: ResponseContext = await this.delegate.send(request).toPromise();
+
+    for (
+      let attempt: number = 1;
+      attempt <= RetryingHttpLibrary.MAX_RETRIES && response.httpStatusCode === StatusCodes.TOO_MANY_REQUESTS;
+      attempt++
+    ) {
+      await RetryingHttpLibrary.discardResponseBody(response);
+
+      const delay: Duration = RetryingHttpLibrary.resolveRetryDelay(response, attempt);
+      container
+        .resolve<SoloLogger>(InjectTokens.SoloLogger)
+        .info(
+          `Kubernetes API server throttled '${request.getHttpMethod()} ${request.getUrl()}' with HTTP ` +
+            `${StatusCodes.TOO_MANY_REQUESTS}, retrying in ${delay.seconds} seconds ` +
+            `(attempt ${attempt} of ${RetryingHttpLibrary.MAX_RETRIES})`,
+        );
+      await sleep(delay);
+
+      response = await this.delegate.send(request).toPromise();
+    }
+
+    return response;
+  }
+
+  /** The delay before resending: the `Retry-After` header when present, exponential backoff otherwise, capped. */
+  private static resolveRetryDelay(response: ResponseContext, attempt: number): Duration {
+    const retryAfterHeader: string = response.headers['retry-after'] ?? '';
+    const retryAfterSeconds: number = Number.parseInt(retryAfterHeader, 10);
+
+    const delaySeconds: number =
+      Number.isNaN(retryAfterSeconds) || retryAfterSeconds <= 0 ? 2 ** (attempt - 1) : retryAfterSeconds;
+
+    return Duration.ofSeconds(Math.min(delaySeconds, RetryingHttpLibrary.MAX_RETRY_DELAY_SECONDS));
+  }
+
+  /** Consumes a discarded response body so the underlying connection is released before resending. */
+  private static async discardResponseBody(response: ResponseContext): Promise<void> {
+    try {
+      await response.body.text();
+    } catch {
+      // best-effort: failing to read the discarded throttled response body must not prevent the retry
+    }
+  }
+}

--- a/test/unit/integration/kube/k8-client-api-factory.test.ts
+++ b/test/unit/integration/kube/k8-client-api-factory.test.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import http from 'node:http';
+import {type AddressInfo} from 'node:net';
+import {expect} from 'chai';
+import {after, before, describe, it} from 'mocha';
+// eslint-disable-next-line no-restricted-imports
+import {CoreV1Api, KubeConfig, type V1NamespaceList} from '@kubernetes/client-node';
+import {K8ClientApiFactory} from '../../../../src/integration/kube/k8-client/k8-client-api-factory.js';
+import {MissingActiveClusterError} from '../../../../src/integration/kube/errors/missing-active-cluster-error.js';
+import {resetForTest} from '../../../test-container.js';
+
+describe('K8ClientApiFactory', (): void => {
+  let server: http.Server;
+  let serverPort: number;
+  let requestCount: number;
+
+  before(async (): Promise<void> => {
+    resetForTest();
+
+    requestCount = 0;
+    server = http.createServer((request: http.IncomingMessage, response: http.ServerResponse): void => {
+      requestCount++;
+      if (requestCount === 1) {
+        response.writeHead(429, {'Content-Type': 'text/plain', 'Retry-After': '1'});
+        response.end('Too many requests, please try again later.\n');
+        return;
+      }
+      response.writeHead(200, {'Content-Type': 'application/json'});
+      response.end(JSON.stringify({apiVersion: 'v1', kind: 'NamespaceList', metadata: {}, items: []}));
+    });
+
+    await new Promise<void>((resolve: () => void): void => {
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    serverPort = (server.address() as AddressInfo).port;
+  });
+
+  after((): void => {
+    server?.close();
+  });
+
+  function buildKubeConfig(): KubeConfig {
+    const kubeConfig: KubeConfig = new KubeConfig();
+    kubeConfig.loadFromString(
+      JSON.stringify({
+        apiVersion: 'v1',
+        kind: 'Config',
+        clusters: [
+          {name: 'fake', cluster: {server: `http://127.0.0.1:${serverPort}`, 'insecure-skip-tls-verify': true}},
+        ],
+        users: [{name: 'fake', user: {token: 'fake-token'}}],
+        contexts: [{name: 'fake', context: {cluster: 'fake', user: 'fake'}}],
+        'current-context': 'fake',
+      }),
+    );
+    return kubeConfig;
+  }
+
+  it('creates a client that retries a request throttled by the API server', async function (): Promise<void> {
+    // The retry waits out the 1 second Retry-After delay on real timers.
+    this.timeout(10_000);
+
+    const client: CoreV1Api = K8ClientApiFactory.makeApiClient(buildKubeConfig(), CoreV1Api);
+
+    const namespaceList: V1NamespaceList = await client.listNamespace();
+
+    expect(requestCount, 'the throttled request must be resent once').to.equal(2);
+    expect(namespaceList.items).to.be.an('array').that.is.empty;
+  });
+
+  it('throws when the kube config has no current cluster', (): void => {
+    expect((): void => {
+      K8ClientApiFactory.makeApiClient(new KubeConfig(), CoreV1Api);
+    }).to.throw(MissingActiveClusterError);
+  });
+});

--- a/test/unit/integration/kube/retrying-http-library.test.ts
+++ b/test/unit/integration/kube/retrying-http-library.test.ts
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {expect} from 'chai';
+import {afterEach, before, beforeEach, describe, it} from 'mocha';
+import sinon, {type SinonFakeTimers} from 'sinon';
+// eslint-disable-next-line no-restricted-imports
+import {HttpMethod, Observable, RequestContext, ResponseContext, type HttpLibrary} from '@kubernetes/client-node';
+import {StatusCodes} from 'http-status-codes';
+import {RetryingHttpLibrary} from '../../../../src/integration/kube/k8-client/retrying-http-library.js';
+import {resetForTest} from '../../../test-container.js';
+
+type ResponseFactory = () => ResponseContext;
+
+/**
+ * A fake HTTP library that records every request and mints a fresh single-use response per request from
+ * queued factories (mirroring the real library), repeating the last factory once the queue is exhausted.
+ */
+class QueuedHttpLibrary implements HttpLibrary {
+  public readonly requests: RequestContext[] = [];
+
+  public constructor(private readonly responseFactories: ResponseFactory[]) {}
+
+  public send(request: RequestContext): Observable<ResponseContext> {
+    this.requests.push(request);
+    const responseIndex: number = Math.min(this.requests.length, this.responseFactories.length) - 1;
+    return new Observable<ResponseContext>(Promise.resolve(this.responseFactories[responseIndex]()));
+  }
+}
+
+function buildResponse(statusCode: number, headers: Record<string, string> = {}): ResponseContext {
+  let bodyConsumed: boolean = false;
+  return new ResponseContext(statusCode, headers, {
+    text: (): Promise<string> => {
+      if (bodyConsumed) {
+        return Promise.reject(new Error('body has already been consumed'));
+      }
+      bodyConsumed = true;
+      return Promise.resolve('');
+    },
+    binary: (): Promise<Buffer> => Promise.resolve(Buffer.alloc(0)),
+  });
+}
+
+function buildRequest(): RequestContext {
+  return new RequestContext('https://localhost:6443/api/v1/namespaces', HttpMethod.GET);
+}
+
+describe('RetryingHttpLibrary', (): void => {
+  let clock: SinonFakeTimers;
+
+  before((): void => {
+    resetForTest();
+  });
+
+  beforeEach((): void => {
+    clock = sinon.useFakeTimers();
+  });
+
+  afterEach((): void => {
+    sinon.restore();
+  });
+
+  it('returns the delegate response when the request is not throttled', async (): Promise<void> => {
+    const delegate: QueuedHttpLibrary = new QueuedHttpLibrary([(): ResponseContext => buildResponse(StatusCodes.OK)]);
+    const library: RetryingHttpLibrary = new RetryingHttpLibrary(delegate);
+
+    const response: ResponseContext = await library.send(buildRequest());
+
+    expect(response.httpStatusCode).to.equal(StatusCodes.OK);
+    expect(delegate.requests).to.have.lengthOf(1);
+  });
+
+  it('does not retry non-throttled error responses', async (): Promise<void> => {
+    const delegate: QueuedHttpLibrary = new QueuedHttpLibrary([
+      (): ResponseContext => buildResponse(StatusCodes.INTERNAL_SERVER_ERROR),
+    ]);
+    const library: RetryingHttpLibrary = new RetryingHttpLibrary(delegate);
+
+    const response: ResponseContext = await library.send(buildRequest());
+
+    expect(response.httpStatusCode).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(delegate.requests).to.have.lengthOf(1);
+  });
+
+  it('retries a throttled request honoring the Retry-After header', async (): Promise<void> => {
+    const delegate: QueuedHttpLibrary = new QueuedHttpLibrary([
+      (): ResponseContext => buildResponse(StatusCodes.TOO_MANY_REQUESTS, {'retry-after': '2'}),
+      (): ResponseContext => buildResponse(StatusCodes.OK),
+    ]);
+    const library: RetryingHttpLibrary = new RetryingHttpLibrary(delegate);
+
+    let resolved: boolean = false;
+    const resultPromise: Promise<ResponseContext> = library
+      .send(buildRequest())
+      .then((response: ResponseContext): ResponseContext => {
+        resolved = true;
+        return response;
+      });
+
+    await clock.tickAsync(1999);
+    expect(resolved, 'the request must not be resent before the Retry-After delay elapses').to.be.false;
+    expect(delegate.requests).to.have.lengthOf(1);
+
+    await clock.tickAsync(1);
+    const response: ResponseContext = await resultPromise;
+
+    expect(response.httpStatusCode).to.equal(StatusCodes.OK);
+    expect(delegate.requests).to.have.lengthOf(2);
+  });
+
+  it('falls back to exponential backoff when the Retry-After header is absent', async (): Promise<void> => {
+    const delegate: QueuedHttpLibrary = new QueuedHttpLibrary([
+      (): ResponseContext => buildResponse(StatusCodes.TOO_MANY_REQUESTS),
+      (): ResponseContext => buildResponse(StatusCodes.TOO_MANY_REQUESTS),
+      (): ResponseContext => buildResponse(StatusCodes.OK),
+    ]);
+    const library: RetryingHttpLibrary = new RetryingHttpLibrary(delegate);
+
+    const resultPromise: Promise<ResponseContext> = library.send(buildRequest());
+
+    await clock.tickAsync(999);
+    expect(delegate.requests, 'the first retry must wait the full 1 second backoff').to.have.lengthOf(1);
+    await clock.tickAsync(1);
+    expect(delegate.requests).to.have.lengthOf(2);
+
+    await clock.tickAsync(1999);
+    expect(delegate.requests, 'the second retry must wait the doubled 2 second backoff').to.have.lengthOf(2);
+    await clock.tickAsync(1);
+    const response: ResponseContext = await resultPromise;
+
+    expect(response.httpStatusCode).to.equal(StatusCodes.OK);
+    expect(delegate.requests).to.have.lengthOf(3);
+  });
+
+  it('falls back to exponential backoff when the Retry-After header is unparseable', async (): Promise<void> => {
+    const delegate: QueuedHttpLibrary = new QueuedHttpLibrary([
+      (): ResponseContext => buildResponse(StatusCodes.TOO_MANY_REQUESTS, {'retry-after': 'later'}),
+      (): ResponseContext => buildResponse(StatusCodes.OK),
+    ]);
+    const library: RetryingHttpLibrary = new RetryingHttpLibrary(delegate);
+
+    const resultPromise: Promise<ResponseContext> = library.send(buildRequest());
+
+    await clock.tickAsync(1000);
+    const response: ResponseContext = await resultPromise;
+
+    expect(response.httpStatusCode).to.equal(StatusCodes.OK);
+    expect(delegate.requests).to.have.lengthOf(2);
+  });
+
+  it('caps the retry delay regardless of the Retry-After header value', async (): Promise<void> => {
+    const delegate: QueuedHttpLibrary = new QueuedHttpLibrary([
+      (): ResponseContext => buildResponse(StatusCodes.TOO_MANY_REQUESTS, {'retry-after': '3600'}),
+      (): ResponseContext => buildResponse(StatusCodes.OK),
+    ]);
+    const library: RetryingHttpLibrary = new RetryingHttpLibrary(delegate);
+
+    const resultPromise: Promise<ResponseContext> = library.send(buildRequest());
+
+    await clock.tickAsync(14_999);
+    expect(delegate.requests, 'the retry must wait the full capped delay of 15 seconds').to.have.lengthOf(1);
+
+    await clock.tickAsync(1);
+    const response: ResponseContext = await resultPromise;
+
+    expect(response.httpStatusCode).to.equal(StatusCodes.OK);
+    expect(delegate.requests).to.have.lengthOf(2);
+  });
+
+  it('returns the throttled response after exhausting all retries', async (): Promise<void> => {
+    const delegate: QueuedHttpLibrary = new QueuedHttpLibrary([
+      (): ResponseContext => buildResponse(StatusCodes.TOO_MANY_REQUESTS, {'retry-after': '1'}),
+    ]);
+    const library: RetryingHttpLibrary = new RetryingHttpLibrary(delegate);
+
+    const resultPromise: Promise<ResponseContext> = library.send(buildRequest());
+
+    await clock.tickAsync(5000);
+    const response: ResponseContext = await resultPromise;
+
+    expect(response.httpStatusCode).to.equal(StatusCodes.TOO_MANY_REQUESTS);
+    expect(delegate.requests).to.have.lengthOf(6);
+  });
+
+  it('consumes the body of every discarded throttled response', async (): Promise<void> => {
+    const throttledResponse: ResponseContext = buildResponse(StatusCodes.TOO_MANY_REQUESTS, {'retry-after': '1'});
+    const textStub: sinon.SinonStub = sinon.stub(throttledResponse.body, 'text').resolves('');
+    const delegate: QueuedHttpLibrary = new QueuedHttpLibrary([
+      (): ResponseContext => throttledResponse,
+      (): ResponseContext => buildResponse(StatusCodes.OK),
+    ]);
+    const library: RetryingHttpLibrary = new RetryingHttpLibrary(delegate);
+
+    const resultPromise: Promise<ResponseContext> = library.send(buildRequest());
+
+    await clock.tickAsync(1000);
+    await resultPromise;
+
+    expect(textStub.calledOnce).to.be.true;
+  });
+
+  it('retries even when reading the discarded throttled response body fails', async (): Promise<void> => {
+    const throttledResponse: ResponseContext = buildResponse(StatusCodes.TOO_MANY_REQUESTS, {'retry-after': '1'});
+    sinon.stub(throttledResponse.body, 'text').rejects(new Error('stream already consumed'));
+    const delegate: QueuedHttpLibrary = new QueuedHttpLibrary([
+      (): ResponseContext => throttledResponse,
+      (): ResponseContext => buildResponse(StatusCodes.OK),
+    ]);
+    const library: RetryingHttpLibrary = new RetryingHttpLibrary(delegate);
+
+    const resultPromise: Promise<ResponseContext> = library.send(buildRequest());
+
+    await clock.tickAsync(1000);
+    const response: ResponseContext = await resultPromise;
+
+    expect(response.httpStatusCode).to.equal(StatusCodes.OK);
+    expect(delegate.requests).to.have.lengthOf(2);
+  });
+});


### PR DESCRIPTION
## Description

This pull request changes the following:

* Adds `RetryingHttpLibrary`, an HTTP-layer decorator for the Kubernetes client that automatically resends requests throttled by the API server with HTTP 429 (Too Many Requests). The `Retry-After` header is honored when present, with exponential backoff (1s/2s/4s/...) as fallback, each delay capped at 15 seconds, and at most 5 retries before the throttled response is surfaced. Retrying is safe because API Priority and Fairness rejects throttled requests before processing them.
* Adds `K8ClientApiFactory`, which mirrors `KubeConfig.makeApiClient` (the upstream method offers no hook for customizing the HTTP library) and injects the retrying library into the clients it creates.
* Wires the factory into all six API clients built by `K8Client.init` and the temporary client in `K8ClientContexts.testContextConnection`, so every Kubernetes API call made by Solo is protected — not just the lease read that crashed in the linked issue.

The root cause of the intermittent CI failures is that `@kubernetes/client-node` treats HTTP 429 as an unknown status code and throws `ApiException("Unknown API Status Code!")` immediately, ignoring the `Retry-After` header the API server sends. The retry therefore has to happen below the generated client, at the HTTP layer.

### Related Issues

* Closes #4906

### Pull request (PR) checklist

* \[x] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[x] This PR added no TODOs or commented out code
* \[x] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[x] All related issues have been linked to this PR
* \[x] All changes in this PR are included in the description
* \[x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[x] This PR added unit tests
* \[x] This PR added integration/end-to-end tests
* \[x] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* Reproduced the failure mode end-to-end: a local HTTP server returning two consecutive HTTP 429 responses with `Retry-After: 1` followed by a success; a real `CoreV1Api` client built via `K8ClientApiFactory` waited out both delays and completed the request. A trimmed version of this scenario is committed as `k8-client-api-factory.test.ts`.
* Unit tests cover retry-delay lower and upper bounds, `Retry-After` parsing (missing, unparseable, above the cap), retry exhaustion, non-429 pass-through, and resilience to a failing body read on the discarded response; the delay assertions were mutation-tested (changing the cap constant or the backoff formula fails the suite).
* Full unit test suite passes (1246 tests).

The following was not tested:

* Behavior against a real overloaded Kubernetes API server; the throttled responses are simulated based on the response captured in #4906 (`429` + `retry-after: 2`).
