### PR TITLE
fix: surface relay error context when Initialize fails during one-shot deploy

### DIFF
--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -432,54 +432,60 @@ export class RelayCommand extends BaseCommand {
     return {
       title: 'Deploy JSON RPC Relay',
       task: async ({config}: RelayDeployContext | RelayUpgradeContext): Promise<void> => {
-        if (config.componentImage && this.isLocalImageAvailableInDocker(config.componentImage)) {
-          await this.kindLoadComponentImage(config.componentImage, config.context);
-        }
+        try {
+          if (config.componentImage && this.isLocalImageAvailableInDocker(config.componentImage)) {
+            await this.kindLoadComponentImage(config.componentImage, config.context);
+          }
 
-        await this.chartManager.upgrade(
-          config.namespace,
-          config.releaseName,
-          constants.JSON_RPC_RELAY_CHART,
-          config.relayChartDirectory || constants.JSON_RPC_RELAY_CHART,
-          config.relayChartDirectory ? '' : config.relayReleaseTag, // pin chart version to match image version
-          config.relayHelmChartValues,
-          config.context,
-          commandType !== RelayCommandType.ADD,
-          commandType === RelayCommandType.ADD,
-          false,
-          Boolean(config.relayChartDirectory),
-        );
-
-        showVersionBanner(this.logger, config.releaseName, config.relayReleaseTag);
-
-        // wait for the pod to destroy in case it was an upgrade
-        if (commandType === RelayCommandType.UPGRADE) {
-          await sleep(Duration.ofSeconds(40));
-
-          // update relay version in remote config after successful upgrade
-          this.remoteConfig.updateComponentVersion(
-            ComponentTypes.RelayNodes,
-            new SemanticVersion<string>(config.relayReleaseTag),
+          await this.chartManager.upgrade(
+            config.namespace,
+            config.releaseName,
+            constants.JSON_RPC_RELAY_CHART,
+            config.relayChartDirectory || constants.JSON_RPC_RELAY_CHART,
+            config.relayChartDirectory ? '' : config.relayReleaseTag, // pin chart version to match image version
+            config.relayHelmChartValues,
+            config.context,
+            commandType !== RelayCommandType.ADD,
+            commandType === RelayCommandType.ADD,
+            false,
+            Boolean(config.relayChartDirectory),
           );
 
-          await this.remoteConfig.persist();
-        }
+          showVersionBanner(this.logger, config.releaseName, config.relayReleaseTag);
 
-        // Add component to remote config
-        else if (commandType === RelayCommandType.ADD) {
-          this.remoteConfig.configuration.components.changeComponentPhase(
-            (config as RelayDeployConfigClass).newRelayComponent.metadata.id,
-            ComponentTypes.RelayNodes,
-            DeploymentPhase.DEPLOYED,
-          );
+          // wait for the pod to destroy in case it was an upgrade
+          if (commandType === RelayCommandType.UPGRADE) {
+            await sleep(Duration.ofSeconds(40));
 
-          // update relay version in remote config after successful deployment
-          this.remoteConfig.updateComponentVersion(
-            ComponentTypes.RelayNodes,
-            new SemanticVersion<string>(config.relayReleaseTag),
-          );
+            // update relay version in remote config after successful upgrade
+            this.remoteConfig.updateComponentVersion(
+              ComponentTypes.RelayNodes,
+              new SemanticVersion<string>(config.relayReleaseTag),
+            );
 
-          await this.remoteConfig.persist();
+            await this.remoteConfig.persist();
+          }
+
+          // Add component to remote config
+          else if (commandType === RelayCommandType.ADD) {
+            this.remoteConfig.configuration.components.changeComponentPhase(
+              (config as RelayDeployConfigClass).newRelayComponent.metadata.id,
+              ComponentTypes.RelayNodes,
+              DeploymentPhase.DEPLOYED,
+            );
+
+            // update relay version in remote config after successful deployment
+            this.remoteConfig.updateComponentVersion(
+              ComponentTypes.RelayNodes,
+              new SemanticVersion<string>(config.relayReleaseTag),
+            );
+
+            await this.remoteConfig.persist();
+          }
+        } catch (error) {
+          throw commandType === RelayCommandType.UPGRADE
+            ? new SoloErrors.component.relayUpgradeFailed(error)
+            : new SoloErrors.component.relayDeployFailed(error);
         }
       },
     };
@@ -591,75 +597,79 @@ export class RelayCommand extends BaseCommand {
         {
           title: 'Initialize',
           task: async (context_, task): Promise<Listr<AnyListrContext>> => {
-            await this.localConfig.load();
-            await this.loadRemoteConfigOrWarn(argv);
-            if (!this.oneShotState.isActive()) {
-              lease = await this.leaseManager.create();
+            try {
+              await this.localConfig.load();
+              await this.loadRemoteConfigOrWarn(argv);
+              if (!this.oneShotState.isActive()) {
+                lease = await this.leaseManager.create();
+              }
+              // reset nodeAlias
+              this.configManager.setFlag(flags.nodeAliasesUnparsed, '');
+
+              this.configManager.update(argv);
+
+              flags.disablePrompts(RelayCommand.DEPLOY_FLAGS_LIST.optional);
+
+              const allFlags: CommandFlag[] = [
+                ...RelayCommand.DEPLOY_FLAGS_LIST.required,
+                ...RelayCommand.DEPLOY_FLAGS_LIST.optional,
+              ];
+
+              await this.configManager.executePrompt(task, allFlags);
+
+              // prompt if inputs are empty and set it in the context
+              const config: RelayDeployConfigClass = this.configManager.getConfig(
+                RelayCommand.DEPLOY_CONFIGS_NAME,
+                allFlags,
+                ['nodeAliases'],
+              ) as RelayDeployConfigClass;
+
+              context_.config = config;
+
+              config.isLegacyChartInstalled = false;
+
+              config.namespace = await this.getNamespace(task);
+
+              config.nodeAliases = parseNodeAliases(
+                config.nodeAliasesUnparsed,
+                this.remoteConfig.getConsensusNodes(),
+                this.configManager,
+              );
+
+              config.clusterRef = this.getClusterReference();
+              config.context = this.getClusterContext(config.clusterRef);
+              config.releaseName = this.getReleaseName();
+
+              const nodeIds: NodeId[] = config.nodeAliases.map((nodeAlias: NodeAlias): number =>
+                Templates.nodeIdFromNodeAlias(nodeAlias),
+              );
+
+              const {mirrorNodeId, mirrorNamespace, mirrorNodeReleaseName} = await this.inferMirrorNodeData(
+                config.namespace,
+                config.context,
+              );
+
+              config.mirrorNodeId = mirrorNodeId;
+              config.mirrorNamespace = mirrorNamespace;
+              config.mirrorNodeReleaseName = mirrorNodeReleaseName;
+
+              config.newRelayComponent = this.componentFactory.createNewRelayComponent(
+                config.clusterRef,
+                config.namespace,
+                nodeIds,
+              );
+
+              config.newRelayComponent.metadata.phase = DeploymentPhase.REQUESTED;
+
+              config.id = config.newRelayComponent.metadata.id;
+
+              if (!this.oneShotState.isActive()) {
+                return ListrLock.newAcquireLockTask(lease, task);
+              }
+              return ListrLock.newSkippedLockTask(task);
+            } catch (error) {
+              throw new SoloErrors.component.relayDeployFailed(error);
             }
-            // reset nodeAlias
-            this.configManager.setFlag(flags.nodeAliasesUnparsed, '');
-
-            this.configManager.update(argv);
-
-            flags.disablePrompts(RelayCommand.DEPLOY_FLAGS_LIST.optional);
-
-            const allFlags: CommandFlag[] = [
-              ...RelayCommand.DEPLOY_FLAGS_LIST.required,
-              ...RelayCommand.DEPLOY_FLAGS_LIST.optional,
-            ];
-
-            await this.configManager.executePrompt(task, allFlags);
-
-            // prompt if inputs are empty and set it in the context
-            const config: RelayDeployConfigClass = this.configManager.getConfig(
-              RelayCommand.DEPLOY_CONFIGS_NAME,
-              allFlags,
-              ['nodeAliases'],
-            ) as RelayDeployConfigClass;
-
-            context_.config = config;
-
-            config.isLegacyChartInstalled = false;
-
-            config.namespace = await this.getNamespace(task);
-
-            config.nodeAliases = parseNodeAliases(
-              config.nodeAliasesUnparsed,
-              this.remoteConfig.getConsensusNodes(),
-              this.configManager,
-            );
-
-            config.clusterRef = this.getClusterReference();
-            config.context = this.getClusterContext(config.clusterRef);
-            config.releaseName = this.getReleaseName();
-
-            const nodeIds: NodeId[] = config.nodeAliases.map((nodeAlias: NodeAlias): number =>
-              Templates.nodeIdFromNodeAlias(nodeAlias),
-            );
-
-            const {mirrorNodeId, mirrorNamespace, mirrorNodeReleaseName} = await this.inferMirrorNodeData(
-              config.namespace,
-              config.context,
-            );
-
-            config.mirrorNodeId = mirrorNodeId;
-            config.mirrorNamespace = mirrorNamespace;
-            config.mirrorNodeReleaseName = mirrorNodeReleaseName;
-
-            config.newRelayComponent = this.componentFactory.createNewRelayComponent(
-              config.clusterRef,
-              config.namespace,
-              nodeIds,
-            );
-
-            config.newRelayComponent.metadata.phase = DeploymentPhase.REQUESTED;
-
-            config.id = config.newRelayComponent.metadata.id;
-
-            if (!this.oneShotState.isActive()) {
-              return ListrLock.newAcquireLockTask(lease, task);
-            }
-            return ListrLock.newSkippedLockTask(task);
           },
         },
         this.addRelayComponent(),
@@ -686,7 +696,11 @@ export class RelayCommand extends BaseCommand {
       try {
         await tasks.run();
       } catch (error) {
-        throw new SoloErrors.component.relayDeployFailed(error);
+        // Tasks wrap their own errors with relay context so it also survives nested one-shot runs;
+        // avoid stacking a second identical wrapper here.
+        throw error instanceof SoloErrors.component.relayDeployFailed
+          ? error
+          : new SoloErrors.component.relayDeployFailed(error);
       } finally {
         if (lease && !this.oneShotState.isActive()) {
           await lease.release();
@@ -711,76 +725,78 @@ export class RelayCommand extends BaseCommand {
         {
           title: 'Initialize',
           task: async (context_, task): Promise<Listr<AnyListrContext>> => {
-            await this.localConfig.load();
-            await this.remoteConfig.loadAndValidate(argv);
-            if (!this.oneShotState.isActive()) {
-              lease = await this.leaseManager.create();
+            try {
+              await this.localConfig.load();
+              await this.remoteConfig.loadAndValidate(argv);
+              if (!this.oneShotState.isActive()) {
+                lease = await this.leaseManager.create();
+              }
+              // reset nodeAlias
+              this.configManager.setFlag(flags.nodeAliasesUnparsed, '');
+
+              this.configManager.update(argv);
+
+              flags.disablePrompts(RelayCommand.UPGRADE_FLAGS_LIST.optional);
+
+              const allFlags: CommandFlag[] = [
+                ...RelayCommand.UPGRADE_FLAGS_LIST.required,
+                ...RelayCommand.UPGRADE_FLAGS_LIST.optional,
+              ];
+
+              await this.configManager.executePrompt(task, allFlags);
+
+              // prompt if inputs are empty and set it in the context
+              const config: RelayUpgradeConfigClass = this.configManager.getConfig(
+                RelayCommand.UPGRADE_CONFIGS_NAME,
+                allFlags,
+                [],
+              ) as RelayUpgradeConfigClass;
+
+              context_.config = config;
+
+              config.namespace = await this.getNamespace(task);
+
+              config.nodeAliases = parseNodeAliases(
+                config.nodeAliasesUnparsed,
+                this.remoteConfig.getConsensusNodes(),
+                this.configManager,
+              );
+
+              config.clusterRef = this.getClusterReference();
+              config.context = this.getClusterContext(config.clusterRef);
+
+              const {id, isLegacyChartInstalled, isChartInstalled, releaseName, nodeAliases} =
+                await this.inferRelayData(config.namespace, config.context);
+
+              config.id = id;
+              config.isLegacyChartInstalled = isLegacyChartInstalled;
+              config.isChartInstalled = isChartInstalled;
+              config.releaseName = releaseName;
+              config.nodeAliases = nodeAliases;
+
+              const {mirrorNodeId, mirrorNamespace, mirrorNodeReleaseName} = await this.inferMirrorNodeData(
+                config.namespace,
+                config.context,
+              );
+
+              config.mirrorNodeId = mirrorNodeId;
+              config.mirrorNamespace = mirrorNamespace;
+              config.mirrorNodeReleaseName = mirrorNodeReleaseName;
+
+              assertUpgradeVersionNotOlder(
+                'Relay',
+                config.relayReleaseTag,
+                this.remoteConfig.getComponentVersion(ComponentTypes.RelayNodes),
+                optionFromFlag(flags.relayVersion),
+              );
+
+              if (!this.oneShotState.isActive()) {
+                return ListrLock.newAcquireLockTask(lease, task);
+              }
+              return ListrLock.newSkippedLockTask(task);
+            } catch (error) {
+              throw new SoloErrors.component.relayUpgradeFailed(error);
             }
-            // reset nodeAlias
-            this.configManager.setFlag(flags.nodeAliasesUnparsed, '');
-
-            this.configManager.update(argv);
-
-            flags.disablePrompts(RelayCommand.UPGRADE_FLAGS_LIST.optional);
-
-            const allFlags: CommandFlag[] = [
-              ...RelayCommand.UPGRADE_FLAGS_LIST.required,
-              ...RelayCommand.UPGRADE_FLAGS_LIST.optional,
-            ];
-
-            await this.configManager.executePrompt(task, allFlags);
-
-            // prompt if inputs are empty and set it in the context
-            const config: RelayUpgradeConfigClass = this.configManager.getConfig(
-              RelayCommand.UPGRADE_CONFIGS_NAME,
-              allFlags,
-              [],
-            ) as RelayUpgradeConfigClass;
-
-            context_.config = config;
-
-            config.namespace = await this.getNamespace(task);
-
-            config.nodeAliases = parseNodeAliases(
-              config.nodeAliasesUnparsed,
-              this.remoteConfig.getConsensusNodes(),
-              this.configManager,
-            );
-
-            config.clusterRef = this.getClusterReference();
-            config.context = this.getClusterContext(config.clusterRef);
-
-            const {id, isLegacyChartInstalled, isChartInstalled, releaseName, nodeAliases} = await this.inferRelayData(
-              config.namespace,
-              config.context,
-            );
-
-            config.id = id;
-            config.isLegacyChartInstalled = isLegacyChartInstalled;
-            config.isChartInstalled = isChartInstalled;
-            config.releaseName = releaseName;
-            config.nodeAliases = nodeAliases;
-
-            const {mirrorNodeId, mirrorNamespace, mirrorNodeReleaseName} = await this.inferMirrorNodeData(
-              config.namespace,
-              config.context,
-            );
-
-            config.mirrorNodeId = mirrorNodeId;
-            config.mirrorNamespace = mirrorNamespace;
-            config.mirrorNodeReleaseName = mirrorNodeReleaseName;
-
-            assertUpgradeVersionNotOlder(
-              'Relay',
-              config.relayReleaseTag,
-              this.remoteConfig.getComponentVersion(ComponentTypes.RelayNodes),
-              optionFromFlag(flags.relayVersion),
-            );
-
-            if (!this.oneShotState.isActive()) {
-              return ListrLock.newAcquireLockTask(lease, task);
-            }
-            return ListrLock.newSkippedLockTask(task);
           },
         },
         this.prepareChartValuesTask(),
@@ -798,7 +814,10 @@ export class RelayCommand extends BaseCommand {
       try {
         await tasks.run();
       } catch (error) {
-        throw new SoloErrors.component.relayUpgradeFailed(error);
+        // Avoid stacking a second identical wrapper on errors the tasks already wrapped.
+        throw error instanceof SoloErrors.component.relayUpgradeFailed
+          ? error
+          : new SoloErrors.component.relayUpgradeFailed(error);
       } finally {
         if (!this.oneShotState.isActive()) {
           await lease?.release();
@@ -823,52 +842,54 @@ export class RelayCommand extends BaseCommand {
         {
           title: 'Initialize',
           task: async (context_, task): Promise<Listr<AnyListrContext>> => {
-            await this.localConfig.load();
-            await this.remoteConfig.loadAndValidate(argv);
-            if (!this.oneShotState.isActive()) {
-              lease = await this.leaseManager.create();
+            try {
+              await this.localConfig.load();
+              await this.remoteConfig.loadAndValidate(argv);
+              if (!this.oneShotState.isActive()) {
+                lease = await this.leaseManager.create();
+              }
+              // reset nodeAlias
+              this.configManager.setFlag(flags.nodeAliasesUnparsed, '');
+              this.configManager.update(argv);
+
+              flags.disablePrompts([flags.clusterRef, flags.id, flags.nodeAliasesUnparsed]);
+
+              const allFlags: CommandFlag[] = [
+                ...RelayCommand.DESTROY_FLAGS_LIST.required,
+                ...RelayCommand.DESTROY_FLAGS_LIST.optional,
+              ];
+
+              await this.configManager.executePrompt(task, allFlags);
+
+              const clusterReference: ClusterReferenceName = this.getClusterReference();
+              const context: Context = this.getClusterContext(clusterReference);
+              const namespace: NamespaceName = await this.getNamespace(task);
+
+              const {id, isLegacyChartInstalled, isChartInstalled, releaseName, nodeAliases} =
+                await this.inferRelayData(namespace, context);
+
+              const config: RelayDestroyConfigClass = {
+                chartDirectory: this.configManager.getFlag(flags.chartDirectory),
+                namespace,
+                nodeAliases,
+                clusterRef: clusterReference,
+                id,
+                isLegacyChartInstalled,
+                isChartInstalled,
+                releaseName,
+                deployment: this.configManager.getFlag<DeploymentName>(flags.deployment),
+                context,
+              };
+
+              context_.config = config;
+
+              if (!this.oneShotState.isActive()) {
+                return ListrLock.newAcquireLockTask(lease, task);
+              }
+              return ListrLock.newSkippedLockTask(task);
+            } catch (error) {
+              throw new SoloErrors.component.relayDestroyFailed(error);
             }
-            // reset nodeAlias
-            this.configManager.setFlag(flags.nodeAliasesUnparsed, '');
-            this.configManager.update(argv);
-
-            flags.disablePrompts([flags.clusterRef, flags.id, flags.nodeAliasesUnparsed]);
-
-            const allFlags: CommandFlag[] = [
-              ...RelayCommand.DESTROY_FLAGS_LIST.required,
-              ...RelayCommand.DESTROY_FLAGS_LIST.optional,
-            ];
-
-            await this.configManager.executePrompt(task, allFlags);
-
-            const clusterReference: ClusterReferenceName = this.getClusterReference();
-            const context: Context = this.getClusterContext(clusterReference);
-            const namespace: NamespaceName = await this.getNamespace(task);
-
-            const {id, isLegacyChartInstalled, isChartInstalled, releaseName, nodeAliases} = await this.inferRelayData(
-              namespace,
-              context,
-            );
-
-            const config: RelayDestroyConfigClass = {
-              chartDirectory: this.configManager.getFlag(flags.chartDirectory),
-              namespace,
-              nodeAliases,
-              clusterRef: clusterReference,
-              id,
-              isLegacyChartInstalled,
-              isChartInstalled,
-              releaseName,
-              deployment: this.configManager.getFlag<DeploymentName>(flags.deployment),
-              context,
-            };
-
-            context_.config = config;
-
-            if (!this.oneShotState.isActive()) {
-              return ListrLock.newAcquireLockTask(lease, task);
-            }
-            return ListrLock.newSkippedLockTask(task);
           },
         },
         {
@@ -902,7 +923,10 @@ export class RelayCommand extends BaseCommand {
       try {
         await tasks.run();
       } catch (error) {
-        throw new SoloErrors.component.relayDestroyFailed(error);
+        // Avoid stacking a second identical wrapper on errors the tasks already wrapped.
+        throw error instanceof SoloErrors.component.relayDestroyFailed
+          ? error
+          : new SoloErrors.component.relayDestroyFailed(error);
       } finally {
         if (!this.oneShotState.isActive()) {
           await lease?.release();

--- a/src/core/logging/solo-pino-logger.ts
+++ b/src/core/logging/solo-pino-logger.ts
@@ -276,16 +276,25 @@ export class SoloPinoLogger implements SoloLogger {
       lines.push(...errorMessage.split('\n').map((line: string): string => chalk.red(line)));
     }
 
-    if (error instanceof SoloError) {
-      const documentUrl: string | undefined = error.getDocumentUrl();
-      if (!this.developmentMode) {
-        const troubleshootingSteps: ReadonlyArray<string> | undefined = error.getTroubleshootingSteps();
-        if (troubleshootingSteps && troubleshootingSteps.length > 0) {
-          for (const step of troubleshootingSteps) {
-            lines.push(chalk.cyan('  →') + ' ' + step);
-          }
+    if (!this.developmentMode) {
+      // The outermost error is often a generic wrapper (e.g. one-shot deploy failed); the deepest
+      // SoloError in the cause chain carries the most specific troubleshooting guidance. The chain is
+      // ordered outermost-first, so the last qualifying entry is the deepest one.
+      let troubleshootingSource: SoloError | undefined;
+      for (const entry of causeChain) {
+        if (entry instanceof SoloError && (entry.getTroubleshootingSteps()?.length ?? 0) > 0) {
+          troubleshootingSource = entry;
         }
       }
+      const troubleshootingSteps: ReadonlyArray<string> | undefined = troubleshootingSource?.getTroubleshootingSteps();
+      if (troubleshootingSteps && troubleshootingSteps.length > 0) {
+        for (const step of troubleshootingSteps) {
+          lines.push(chalk.cyan('  →') + ' ' + step);
+        }
+      }
+    }
+    if (error instanceof SoloError) {
+      const documentUrl: string | undefined = error.getDocumentUrl();
       if (documentUrl) {
         lines.push('', chalk.cyan(`Learn more: ${documentUrl}`));
       }
@@ -347,10 +356,12 @@ export class SoloPinoLogger implements SoloLogger {
       level: 'ERROR',
       message: this.getFormattedCode(error) + error.message,
       stack: error.stack,
-      causes: causeChain.slice(1).map((cause: Error): Record<string, unknown> => ({
-        message: this.getFormattedCode(cause) + cause.message,
-        stack: cause.stack,
-      })),
+      causes: causeChain.slice(1).map(
+        (cause: Error): Record<string, unknown> => ({
+          message: this.getFormattedCode(cause) + cause.message,
+          stack: cause.stack,
+        }),
+      ),
     };
   }
 

--- a/src/core/logging/solo-pino-logger.ts
+++ b/src/core/logging/solo-pino-logger.ts
@@ -356,12 +356,10 @@ export class SoloPinoLogger implements SoloLogger {
       level: 'ERROR',
       message: this.getFormattedCode(error) + error.message,
       stack: error.stack,
-      causes: causeChain.slice(1).map(
-        (cause: Error): Record<string, unknown> => ({
-          message: this.getFormattedCode(cause) + cause.message,
-          stack: cause.stack,
-        }),
-      ),
+      causes: causeChain.slice(1).map((cause: Error): Record<string, unknown> => ({
+        message: this.getFormattedCode(cause) + cause.message,
+        stack: cause.stack,
+      })),
     };
   }
 

--- a/test/e2e/standard/account.test.ts
+++ b/test/e2e/standard/account.test.ts
@@ -447,11 +447,19 @@ endToEndTestSuite(testName, argv, {containerOverrides: overrides}, (bootstrapRes
 
       it('Create client from network config and submit topic/message should succeed', async (): Promise<void> => {
         try {
-          // Setup network configuration
-          const networkConfig: Record<string, AccountId> = {
-            ['127.0.0.1:30212']: AccountId.fromString('0.0.3'),
-            ['127.0.0.1:30213']: AccountId.fromString('0.0.4'),
-          };
+          // Setup network configuration from the live node client's actual forwarded endpoints;
+          // hard-coded local ports break when an earlier port-forward recovery shifts the allocation
+          await accountManager.loadNodeClient(
+            namespace,
+            remoteConfig.getClusterRefs(),
+            argv.getArg<DeploymentName>(flags.deployment),
+            argv.getArg<boolean>(flags.forcePortForward),
+          );
+          const clientNetwork: Record<string, string | AccountId> = accountManager._nodeClient.network;
+          const networkConfig: Record<string, AccountId> = {};
+          for (const endpoint of Object.keys(clientNetwork)) {
+            networkConfig[endpoint] = AccountId.fromString(clientNetwork[endpoint].toString());
+          }
 
           // Instantiate SDK client
           const sdkClient: Client = Client.fromConfig({network: networkConfig, scheduleNetworkUpdate: false});
@@ -472,6 +480,7 @@ endToEndTestSuite(testName, argv, {containerOverrides: overrides}, (bootstrapRes
           expect(submitReceipt.status).to.deep.equal(Status.Success);
         } catch (error) {
           testLogger.showUserError(error);
+          expect.fail();
         }
       }).timeout(Duration.ofMinutes(2).toMillis());
 

--- a/test/unit/commands/relay.test.ts
+++ b/test/unit/commands/relay.test.ts
@@ -9,6 +9,8 @@ import {Flags as flags} from '../../../src/commands/flags.js';
 import {NamespaceName} from '../../../src/types/namespace/namespace-name.js';
 import {resetForTest} from '../../test-container.js';
 import {type HelmChartValues} from '../../../src/integration/helm/model/values.js';
+import {SoloErrors} from '../../../src/core/errors/solo-errors.js';
+import {type ArgvStruct} from '../../../src/types/aliases.js';
 
 interface RelayCommandInternal {
   prepareNetworkJsonString: (nodeAliases: string[], namespace: NamespaceName, deployment: string) => Promise<string>;
@@ -152,6 +154,19 @@ describe('RelayCommand unit tests', (): void => {
       expect.fail('Expected prepareHelmChartValuesForRelay to throw');
     } catch (error) {
       expect(error.message).to.include('Invalid image reference format: latest');
+    }
+  });
+
+  it('wraps an add() Initialize failure in RelayDeployFailedSoloError exactly once', async (): Promise<void> => {
+    sinon.stub(relayCommand.localConfig, 'load').rejects(new Error('boom'));
+
+    try {
+      await relayCommand.add({_: []} as unknown as ArgvStruct);
+      expect.fail('Expected add() to throw');
+    } catch (error) {
+      expect(error).to.be.instanceOf(SoloErrors.component.relayDeployFailed);
+      expect(error.message).to.equal('Error deploying relay: boom');
+      expect(error.cause.message).to.equal('boom');
     }
   });
 });

--- a/test/unit/core/logging/solo-pino-logger.test.ts
+++ b/test/unit/core/logging/solo-pino-logger.test.ts
@@ -5,6 +5,8 @@ import {describe, it, beforeEach, afterEach} from 'mocha';
 import sinon, {type SinonStub} from 'sinon';
 import {SoloPinoLogger} from '../../../../src/core/logging/solo-pino-logger.js';
 import {OneShotState} from '../../../../src/core/one-shot-state.js';
+import {SoloErrors} from '../../../../src/core/errors/solo-errors.js';
+import {type SoloError} from '../../../../src/core/errors/solo-error.js';
 
 function lineLogged(stub: SinonStub, substring: string): boolean {
   return stub.getCalls().some((call): boolean => String(call.args[0]).includes(substring));
@@ -128,6 +130,35 @@ describe('SoloPinoLogger user-facing output', (): void => {
       expect(lineLogged(consoleLogStub, 'Some Title')).to.be.true;
       expect(lineLogged(consoleLogStub, 'alpha')).to.be.true;
       expect(lineLogged(consoleLogStub, '[ None ]')).to.be.false;
+    });
+  });
+
+  describe('showUserError troubleshooting steps', (): void => {
+    it('shows the steps of the deepest SoloError in the cause chain', (): void => {
+      const nonDevelopmentLogger: SoloPinoLogger = new SoloPinoLogger('debug', false, oneShotState);
+      const relayError: SoloError = new SoloErrors.component.relayDeployFailed(new Error('image pull failed'));
+      const oneShotError: SoloError = new SoloErrors.component.oneShotDeployFailed(
+        `Deploy failed: ${relayError.message}`,
+        relayError,
+      );
+
+      nonDevelopmentLogger.showUserError(oneShotError);
+
+      expect(lineLogged(consoleLogStub, 'Deploy failed:')).to.be.true;
+      expect(lineLogged(consoleLogStub, 'Inspect relay pods')).to.be.true;
+      expect(lineLogged(consoleLogStub, 'one-shot single destroy')).to.be.false;
+    });
+
+    it('falls back to the top-level error steps when no cause carries steps', (): void => {
+      const nonDevelopmentLogger: SoloPinoLogger = new SoloPinoLogger('debug', false, oneShotState);
+      const oneShotError: SoloError = new SoloErrors.component.oneShotDeployFailed(
+        'Deploy failed: boom',
+        new Error('boom'),
+      );
+
+      nonDevelopmentLogger.showUserError(oneShotError);
+
+      expect(lineLogged(consoleLogStub, 'clean up partial resources')).to.be.true;
     });
   });
 });


### PR DESCRIPTION
Relay add/upgrade/destroy tasks now wrap their own errors in the relay-specific SoloErrors so troubleshooting context survives nested one-shot execution, where the `isRoot()` catch never runs. The terminal error box now shows troubleshooting steps from the deepest SoloError in the cause chain instead of only the generic top-level wrapper.

## Description

This pull request changes the following:

* `src/commands/relay.ts` — the `Initialize` task bodies of `add()`, `upgrade()`, and `destroy()`, and the `Deploy JSON RPC Relay` task, now wrap their own errors in the matching relay SoloError (`RelayDeployFailedSoloError` / `RelayUpgradeFailedSoloError` / `RelayDestroyFailedSoloError`). Previously this wrapping only happened around `tasks.run()` inside the `if (tasks.isRoot())` branch, which never executes during `one-shot single deploy` because the relay task list is attached as a nested Listr child of the one-shot pipeline — so an `Initialize` failure propagated raw and the user saw only a ✖ with no error message, log reference, or actionable guidance.
* `src/commands/relay.ts` — the three existing outer `isRoot()` catches now rethrow errors that already carry the matching relay wrapper (`instanceof` guard) instead of wrapping a second time, so `Error deploying relay: Error deploying relay: ...` can never occur.
* `src/core/logging/solo-pino-logger.ts` — `buildContentLines()` now selects troubleshooting steps from the deepest `SoloError` in the cause chain that has steps, falling back to the top-level error. In one-shot flows the top-level error is the generic `OneShotDeployFailedSoloError`, which previously hid the relay-specific guidance (solo.log tail, `kubectl get pods`, `helm status`) buried in `cause`. The `Learn more:` documentation URL still comes from the top-level error.
* Unit tests: a regression test in `test/unit/commands/relay.test.ts` asserting an `add()` Initialize failure surfaces as `RelayDeployFailedSoloError` exactly once with the cause preserved, and two tests in `test/unit/core/logging/solo-pino-logger.test.ts` asserting the deepest error's troubleshooting steps are shown (and the generic one-shot steps suppressed) plus the fallback behavior.

Note for reviewers: the `relay.ts` diff stat is large (~474 lines) but is almost entirely re-indentation from wrapping the three `Initialize` task bodies in try/catch — `git diff -w` shows the actual logic changes are ~40 lines.

### Related Issues

* Closes #4963

### Pull request (PR) checklist

* [x] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [ ] Any technical debt has been documented as a separate issue and linked to this PR
* [ ] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [x] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [ ] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* None — behavior is covered by the new unit tests: the relay Initialize failure path (wrapping, single-wrap guarantee, cause preservation) and the error-box troubleshooting-step selection (deepest-error wins, top-level fallback).

The following was not tested:

* A full `solo one-shot single deploy` run with an injected relay `Initialize` failure on a live Kind cluster (the failure path is exercised at the unit level; the nested one-shot Listr attachment itself is unchanged).

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                       |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>