### PR TITLE
feat(env): alias environment variable names for config-schema fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,14 @@ The layered config system (`EnvironmentConfigSource`, prefix `SOLO`) allows envi
 
 This is **not** the same as plain `UPPER_SNAKE_CASE` — dashes within a segment represent camelCase word boundaries, not underscores.
 
+**Environment variable aliases.** Because the generated names are awkward (embedded dashes) and cannot
+match legacy fixed names, a field may also declare one or more fixed alias env var names with the
+`@EnvironmentAliasRegistry.alias('SOLO_TSS_READY_MAX_ATTEMPTS')` property decorator (see
+`src/data/schema/decorators/environment-alias-registry.ts`). The generated `SOLO_*` name always takes
+precedence; the alias applies only when the generated name is absent, and using an alias logs a notice.
+Aliases may only be placed on a uniquely-typed schema field (a reused type such as `HelmChartSchema`
+fails fast). When adding/removing an alias, keep this section and any env var docs in sync.
+
 ## Architecture and Design
 
 Before implementing a new feature or undertaking a major refactor, review the architecture and

--- a/src/core/dependency-injection/container-init.ts
+++ b/src/core/dependency-injection/container-init.ts
@@ -66,7 +66,8 @@ import {ComponentFactory} from '../config/remote/component-factory.js';
 import {RemoteConfigValidator} from '../config/remote/remote-config-validator.js';
 import {type ConfigProvider} from '../../data/configuration/api/config-provider.js';
 import {DefaultConfigSource} from '../../data/configuration/impl/default-config-source.js';
-import {type SoloConfigSchema} from '../../data/schema/model/solo/solo-config-schema.js';
+import {SoloConfigSchema} from '../../data/schema/model/solo/solo-config-schema.js';
+import {EnvironmentAliasRegistry} from '../../data/schema/decorators/environment-alias-registry.js';
 import {SoloConfigSchemaDefinition} from '../../data/schema/migration/impl/solo/solo-config-schema-definition.js';
 import {BeanFactorySupplier} from './bean-factory-supplier.js';
 import {DefaultOneShotCommand} from '../../commands/one-shot/default-one-shot.js';
@@ -274,6 +275,10 @@ export class Container {
         InjectTokens.ConfigProvider,
         (container: DependencyContainer): ConfigProvider => {
           const objectMapper: ClassToObjectMapper = container.resolve<ClassToObjectMapper>(InjectTokens.ObjectMapper);
+
+          // Register the root schema so environment variable aliases
+          // can be resolved by the EnvironmentConfigSource.
+          EnvironmentAliasRegistry.registerRootSchema(SoloConfigSchema);
 
           const helmChartConfigSource: DefaultConfigSource<SoloConfigSchema> =
             new DefaultConfigSource<SoloConfigSchema>(

--- a/src/data/backend/impl/environment-storage-backend.ts
+++ b/src/data/backend/impl/environment-storage-backend.ts
@@ -91,6 +91,22 @@ export class EnvironmentStorageBackend implements StorageBackend {
     return Buffer.from(value, 'utf8');
   }
 
+  /**
+   * Reads a fixed/legacy environment variable by its exact name,
+   * without applying the `SOLO_` prefix or key formatting.
+   * Returns undefined when the variable is missing or blank.
+   * Used to resolve environment variable aliases.
+   */
+  public readRawValue(name: string): string | undefined {
+    let environment: NodeJS.ProcessEnv = process.env;
+    if (!environment) {
+      environment = {};
+    }
+
+    const value: string | undefined = environment[name];
+    return value && value.trim() !== '' ? value : undefined;
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public async writeBytes(_key: string, _data: Buffer): Promise<void> {
     throw new UnsupportedStorageOperationError('writeBytes is not supported by the environment storage backend');

--- a/src/data/configuration/impl/environment-config-source.ts
+++ b/src/data/configuration/impl/environment-config-source.ts
@@ -7,6 +7,7 @@ import {EnvironmentStorageBackend} from '../../backend/impl/environment-storage-
 import {type Refreshable} from '../spi/refreshable.js';
 import {ConfigurationError} from '../api/configuration-error.js';
 import {Forest} from '../../key/lexer/forest.js';
+import {EnvironmentAliasRegistry} from '../../schema/decorators/environment-alias-registry.js';
 
 /**
  * A {@link ConfigSource} that reads configuration data from the environment.
@@ -23,8 +24,13 @@ export class EnvironmentConfigSource extends LayeredConfigSource implements Conf
    */
   private readonly data: Map<string, string>;
 
+  /** Typed reference to the backend for reading fixed/legacy env var aliases verbatim. */
+  private readonly environmentBackend: EnvironmentStorageBackend;
+
   public constructor(mapper: ObjectMapper, prefix?: string) {
-    super(new EnvironmentStorageBackend(prefix), mapper, prefix);
+    const backend: EnvironmentStorageBackend = new EnvironmentStorageBackend(prefix);
+    super(backend, mapper, prefix);
+    this.environmentBackend = backend;
     this.data = new Map<string, string>();
   }
 
@@ -54,6 +60,34 @@ export class EnvironmentConfigSource extends LayeredConfigSource implements Conf
       }
     }
 
+    this.applyAliases();
+
     this.forest = Forest.from(this.data);
+  }
+
+  /**
+   * Applies fixed/legacy environment variable aliases.
+   * The generated `SOLO_*` name always wins,
+   * so an alias is only used when its canonical key
+   * was not already set from a generated name.
+   */
+  private applyAliases(): void {
+    for (const [legacyName, canonicalKey] of EnvironmentAliasRegistry.aliasMap()) {
+      if (this.data.has(canonicalKey)) {
+        continue;
+      }
+
+      const value: string | undefined = this.environmentBackend.readRawValue(legacyName);
+      if (value === undefined) {
+        continue;
+      }
+
+      this.data.set(canonicalKey, value);
+
+      console.warn(
+        `Using environment variable alias '${legacyName}' for config key '${canonicalKey}'; ` +
+          'the generated SOLO_* name takes precedence when both are set.',
+      );
+    }
   }
 }

--- a/src/data/schema/decorators/environment-alias-registry.ts
+++ b/src/data/schema/decorators/environment-alias-registry.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {ConfigurationError} from '../../configuration/api/configuration-error.js';
+import {type ClassConstructor} from '../../../business/utils/class-constructor.type.js';
+
+/**
+ * Registry and property decorator for aliasing a config-schema field to one or more fixed environment
+ * variable names, in addition to the dynamically generated `SOLO_*` name. This eases migration off of
+ * the fixed env vars read via `constants.ts` and lets users avoid the awkward hyphenated generated
+ * names (see GitHub issue #5058).
+ *
+ * <p>The generated `SOLO_*` name always takes precedence; an alias only applies when the generated
+ * name is absent (resolution happens in `EnvironmentConfigSource`).
+ */
+export class EnvironmentAliasRegistry {
+  /** Maps a schema prototype to its (propertyKey -> fixed env var names) declared via {@link alias}. */
+  private static readonly fieldAliases: Map<object, Map<string, string[]>> = new Map<object, Map<string, string[]>>();
+
+  /** Root schema classes whose field tree is walked to build the alias map. */
+  private static readonly rootSchemas: Set<ClassConstructor<object>> = new Set<ClassConstructor<object>>();
+
+  /** Memoized `fixed env var name` -> `dotted config key path` (e.g. `tss.readyMaxAttempts`). */
+  private static cachedAliasMap: Map<string, string> | undefined;
+
+  /**
+   * Property decorator that registers one or more fixed environment variable names for the annotated
+   * field. Usage: `@EnvironmentAliasRegistry.alias('SOLO_TSS_READY_MAX_ATTEMPTS') public readyMaxAttempts: number;`
+   */
+  public static alias(...legacyNames: string[]): PropertyDecorator {
+    return (target: object, propertyKey: string | symbol): void => {
+      let byKey: Map<string, string[]> | undefined = EnvironmentAliasRegistry.fieldAliases.get(target);
+      if (!byKey) {
+        byKey = new Map<string, string[]>();
+        EnvironmentAliasRegistry.fieldAliases.set(target, byKey);
+      }
+      byKey.set(propertyKey.toString(), legacyNames);
+      EnvironmentAliasRegistry.cachedAliasMap = undefined;
+    };
+  }
+
+  /** Registers a root schema class whose fields (and nested schemas) are scanned for aliases. */
+  public static registerRootSchema(rootClass: ClassConstructor<object>): void {
+    EnvironmentAliasRegistry.rootSchemas.add(rootClass);
+    EnvironmentAliasRegistry.cachedAliasMap = undefined;
+  }
+
+  /**
+   * Clears all registered root schemas and the memoized alias map. Intended for test isolation; the
+   * decorator-declared field aliases are left intact (they are registered once at class-load time).
+   */
+  public static resetRootSchemas(): void {
+    EnvironmentAliasRegistry.rootSchemas.clear();
+    EnvironmentAliasRegistry.cachedAliasMap = undefined;
+  }
+
+  /**
+   * Returns a memoized map of each fixed env var name to the dotted config key path it targets (the
+   * same key form the environment backend produces, e.g. `tss.readyMaxAttempts`). Built by walking
+   * every registered root schema.
+   * @throws ConfigurationError if a single alias would map to more than one config key (i.e. it was
+   *   placed on a schema type reused at multiple paths).
+   */
+  public static aliasMap(): ReadonlyMap<string, string> {
+    if (EnvironmentAliasRegistry.cachedAliasMap) {
+      return EnvironmentAliasRegistry.cachedAliasMap;
+    }
+
+    const result: Map<string, string> = new Map<string, string>();
+    for (const rootClass of EnvironmentAliasRegistry.rootSchemas) {
+      EnvironmentAliasRegistry.walk(new rootClass(), '', result);
+    }
+
+    EnvironmentAliasRegistry.cachedAliasMap = result;
+    return result;
+  }
+
+  /** Recursively collects aliases from a schema instance, building dotted config paths as it descends. */
+  private static walk(instance: object, prefix: string, result: Map<string, string>): void {
+    const declaredAliases: Map<string, string[]> | undefined = EnvironmentAliasRegistry.fieldAliases.get(
+      Object.getPrototypeOf(instance) as object,
+    );
+    if (declaredAliases) {
+      for (const [key, legacyNames] of declaredAliases) {
+        const path: string = prefix ? `${prefix}.${key}` : key;
+        for (const legacyName of legacyNames) {
+          const existing: string | undefined = result.get(legacyName);
+          if (existing !== undefined && existing !== path) {
+            throw new ConfigurationError(
+              `Environment alias '${legacyName}' maps to multiple config keys ('${existing}' and ` +
+                `'${path}'); an alias must target a uniquely-typed schema field.`,
+            );
+          }
+          result.set(legacyName, path);
+        }
+      }
+    }
+
+    for (const key of Object.keys(instance)) {
+      const value: unknown = (instance as Record<string, unknown>)[key];
+      if (EnvironmentAliasRegistry.isSchemaInstance(value)) {
+        EnvironmentAliasRegistry.walk(value, prefix ? `${prefix}.${key}` : key, result);
+      }
+    }
+  }
+
+  /** True for a nested class instance (a schema) as opposed to a primitive, array, or plain object. */
+  private static isSchemaInstance(value: unknown): value is object {
+    return typeof value === 'object' && value !== null && !Array.isArray(value) && value.constructor !== Object;
+  }
+}

--- a/src/data/schema/model/solo/tss-schema.ts
+++ b/src/data/schema/model/solo/tss-schema.ts
@@ -2,6 +2,7 @@
 
 import {Exclude, Expose, Type} from 'class-transformer';
 import {WrapsSchema} from './wraps-schema.js';
+import {EnvironmentAliasRegistry} from '../../decorators/environment-alias-registry.js';
 
 @Exclude()
 export class TssSchema {
@@ -12,12 +13,15 @@ export class TssSchema {
   public messageSizeHardLimitBytes: number;
 
   @Expose()
+  @EnvironmentAliasRegistry.alias('SOLO_TSS_TIMEOUT_AFTER_READY_SECONDS')
   public timeoutAfterReadySeconds: number;
 
   @Expose()
+  @EnvironmentAliasRegistry.alias('SOLO_TSS_READY_MAX_ATTEMPTS')
   public readyMaxAttempts: number;
 
   @Expose()
+  @EnvironmentAliasRegistry.alias('SOLO_TSS_READY_BACKOFF_SECONDS')
   public readyBackoffSeconds: number;
 
   @Expose()

--- a/src/data/schema/model/solo/wraps-schema.ts
+++ b/src/data/schema/model/solo/wraps-schema.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {Exclude, Expose} from 'class-transformer';
+import {EnvironmentAliasRegistry} from '../../decorators/environment-alias-registry.js';
 
 @Exclude()
 export class WrapsSchema {
@@ -16,6 +17,7 @@ export class WrapsSchema {
   // IMPORTANT: libraryDownloadUrl must be kept consistent with directoryName.
   // If directoryName is updated, update libraryDownloadUrl to match.
   @Expose()
+  @EnvironmentAliasRegistry.alias('SOLO_TSS_WRAPS_LIBRARY_DOWNLOAD_URL')
   public libraryDownloadUrl: string;
 
   public constructor(

--- a/test/unit/data/configuration/impl/environment-alias.test.ts
+++ b/test/unit/data/configuration/impl/environment-alias.test.ts
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {expect} from 'chai';
+import {afterEach, beforeEach, describe, it} from 'mocha';
+import {EnvironmentConfigSource} from '../../../../../src/data/configuration/impl/environment-config-source.js';
+import {ClassToObjectMapper} from '../../../../../src/data/mapper/impl/class-to-object-mapper.js';
+import {ConfigKeyFormatter} from '../../../../../src/data/key/config-key-formatter.js';
+import {SoloConfigSchema} from '../../../../../src/data/schema/model/solo/solo-config-schema.js';
+import {EnvironmentAliasRegistry} from '../../../../../src/data/schema/decorators/environment-alias-registry.js';
+import {ConfigurationError} from '../../../../../src/data/configuration/api/configuration-error.js';
+
+const mapper: ClassToObjectMapper = new ClassToObjectMapper(ConfigKeyFormatter.instance());
+
+function withEnvironment(variables: Record<string, string>, function_: () => Promise<void>): () => Promise<void> {
+  return async (): Promise<void> => {
+    const saved: NodeJS.ProcessEnv = {...process.env};
+    try {
+      for (const [k, v] of Object.entries(variables)) {
+        process.env[k] = v;
+      }
+      await function_();
+    } finally {
+      for (const k of Object.keys(variables)) {
+        if (k in saved) {
+          process.env[k] = saved[k];
+        } else {
+          delete process.env[k];
+        }
+      }
+    }
+  };
+}
+
+describe('EnvironmentAliasRegistry – alias resolution', (): void => {
+  beforeEach((): void => {
+    EnvironmentAliasRegistry.resetRootSchemas();
+    EnvironmentAliasRegistry.registerRootSchema(SoloConfigSchema);
+  });
+
+  afterEach((): void => {
+    EnvironmentAliasRegistry.resetRootSchemas();
+  });
+
+  it('reconstructs full config paths into canonical stripped keys', (): void => {
+    const aliasMap: ReadonlyMap<string, string> = EnvironmentAliasRegistry.aliasMap();
+    expect(aliasMap.get('SOLO_TSS_READY_MAX_ATTEMPTS')).to.equal('tss.readyMaxAttempts');
+    expect(aliasMap.get('SOLO_TSS_WRAPS_LIBRARY_DOWNLOAD_URL')).to.equal('tss.wraps.libraryDownloadUrl');
+  });
+
+  it(
+    'a fixed alias sets the field (SOLO_TSS_READY_MAX_ATTEMPTS -> tss.readyMaxAttempts)',
+    withEnvironment({SOLO_TSS_READY_MAX_ATTEMPTS: '99'}, async (): Promise<void> => {
+      const source: EnvironmentConfigSource = new EnvironmentConfigSource(mapper, 'SOLO');
+      await source.load();
+      const schema: SoloConfigSchema = source.asObject(SoloConfigSchema);
+      expect(schema?.tss?.readyMaxAttempts).to.equal(99);
+    }),
+  );
+
+  it(
+    'a nested fixed alias sets the field (SOLO_TSS_WRAPS_LIBRARY_DOWNLOAD_URL -> tss.wraps.libraryDownloadUrl)',
+    withEnvironment(
+      {SOLO_TSS_WRAPS_LIBRARY_DOWNLOAD_URL: 'https://example.com/wraps.tar.gz'},
+      async (): Promise<void> => {
+        const source: EnvironmentConfigSource = new EnvironmentConfigSource(mapper, 'SOLO');
+        await source.load();
+        const schema: SoloConfigSchema = source.asObject(SoloConfigSchema);
+        expect(schema?.tss?.wraps?.libraryDownloadUrl).to.equal('https://example.com/wraps.tar.gz');
+      },
+    ),
+  );
+
+  it(
+    'the generated SOLO_* name wins when both it and the alias are set',
+    withEnvironment(
+      {'SOLO_TSS_READY-MAX-ATTEMPTS': '5', SOLO_TSS_READY_MAX_ATTEMPTS: '99'},
+      async (): Promise<void> => {
+        const source: EnvironmentConfigSource = new EnvironmentConfigSource(mapper, 'SOLO');
+        await source.load();
+        const schema: SoloConfigSchema = source.asObject(SoloConfigSchema);
+        expect(schema?.tss?.readyMaxAttempts).to.equal(5);
+      },
+    ),
+  );
+});
+
+class ReusedLeafSchema {
+  @EnvironmentAliasRegistry.alias('DUP_ALIAS_FOR_TEST')
+  public value?: string;
+}
+
+class ReusedRootSchema {
+  public first: ReusedLeafSchema = new ReusedLeafSchema();
+  public second: ReusedLeafSchema = new ReusedLeafSchema();
+}
+
+describe('EnvironmentAliasRegistry – fail-fast on reused schema types', (): void => {
+  afterEach((): void => {
+    EnvironmentAliasRegistry.resetRootSchemas();
+  });
+
+  it('throws when one alias resolves to more than one config key', (): void => {
+    EnvironmentAliasRegistry.resetRootSchemas();
+    EnvironmentAliasRegistry.registerRootSchema(ReusedRootSchema);
+    expect((): ReadonlyMap<string, string> => EnvironmentAliasRegistry.aliasMap()).to.throw(ConfigurationError);
+  });
+});

--- a/test/unit/data/configuration/impl/solo-config-environment-variable-override.test.ts
+++ b/test/unit/data/configuration/impl/solo-config-environment-variable-override.test.ts
@@ -23,6 +23,7 @@
  */
 
 import {expect} from 'chai';
+import {before} from 'mocha';
 import {EnvironmentStorageBackend} from '../../../../../src/data/backend/impl/environment-storage-backend.js';
 import {EnvironmentConfigSource} from '../../../../../src/data/configuration/impl/environment-config-source.js';
 import {ClassToObjectMapper} from '../../../../../src/data/mapper/impl/class-to-object-mapper.js';
@@ -30,8 +31,15 @@ import {ConfigKeyFormatter} from '../../../../../src/data/key/config-key-formatt
 import {SoloConfigSchema} from '../../../../../src/data/schema/model/solo/solo-config-schema.js';
 import {Prefix} from '../../../../../src/data/key/prefix.js';
 import {EnvironmentKeyFormatter} from '../../../../../src/data/key/environment-key-formatter.js';
+import {EnvironmentAliasRegistry} from '../../../../../src/data/schema/decorators/environment-alias-registry.js';
 
 const mapper: ClassToObjectMapper = new ClassToObjectMapper(ConfigKeyFormatter.instance());
+
+// These tests verify the naming CONVENTION (env var -> config key) with environment aliases disabled,
+// so an all-underscore alias registered elsewhere cannot influence the pure-convention assertions.
+before((): void => {
+  EnvironmentAliasRegistry.resetRootSchemas();
+});
 
 // ---------------------------------------------------------------------------
 // Helper: save / restore process.env around each test


### PR DESCRIPTION
## Description

The layered config system derives an env var name for each schema field by convention
(`tss.wraps.libraryDownloadUrl` → `SOLO_TSS_WRAPS_LIBRARY-DOWNLOAD-URL`). Those generated names are
awkward (embedded dashes) and cannot match fixed/legacy names, making it hard to migrate off the env
vars read via `constants.ts`.

This adds a per-field alias capability: a schema field can declare one or more fixed environment
variable names via the `@EnvironmentAliasRegistry.alias('SOLO_TSS_READY_MAX_ATTEMPTS')` decorator, in
addition to the generated `SOLO_*` name.

- The generated `SOLO_*` name always takes precedence; an alias applies only when the generated name is
  absent, and using an alias logs a notice.
- Aliases must target a uniquely-typed schema field; placing one on a reused type (e.g. `HelmChartSchema`)
  fails fast.
- Seeds friendly all-underscore aliases on the TSS/WRAPS fields as concrete examples.

Resolution happens in `EnvironmentConfigSource` so alias values flow through the existing config
materialization onto the schema unchanged — no read sites change.

**Tests:** new unit tests cover alias resolution, nested paths, generated-name precedence, and the
reused-type fail-fast; the existing convention test is isolated so it keeps testing the pure naming
convention.

### Related Issues

* Closes # https://github.com/hiero-ledger/solo/issues/5058
