### PR TITLE
fix: create the Solo home directory during container bootstrap

### DIFF
--- a/src/core/dependency-injection/container-init.ts
+++ b/src/core/dependency-injection/container-init.ts
@@ -23,6 +23,7 @@ import {IntervalLockRenewalService} from '../lock/interval-lock-renewal.js';
 import {LockManager} from '../lock/lock-manager.js';
 import {OneShotState} from '../one-shot-state.js';
 import {CertificateManager} from '../certificate-manager.js';
+import {mkdirSync} from 'node:fs';
 import os from 'node:os';
 import * as version from '../../../version.js';
 import {NetworkNodes} from '../network-nodes.js';
@@ -322,6 +323,9 @@ export class Container {
       container.resolve<SoloLogger>(InjectTokens.SoloLogger).debug('Container already initialized');
       return;
     }
+
+    // Services such as the local config storage backend require the home directory to exist at construction time.
+    mkdirSync(homeDirectory, {recursive: true});
 
     const singletonContainers: SingletonContainer[] = Container.singletonContainers();
 

--- a/test/unit/core/dependency-injection/container-init.test.ts
+++ b/test/unit/core/dependency-injection/container-init.test.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {expect} from 'chai';
+import {describe, it, beforeEach, afterEach} from 'mocha';
+import fs from 'node:fs';
+import os from 'node:os';
+import {container} from 'tsyringe-neo';
+import {Container} from '../../../../src/core/dependency-injection/container-init.js';
+import {InjectTokens} from '../../../../src/core/dependency-injection/inject-tokens.js';
+import * as constants from '../../../../src/core/constants.js';
+import {PathEx} from '../../../../src/business/utils/path-ex.js';
+import {type LocalConfigRuntimeState} from '../../../../src/business/runtime-state/config/local/local-config-runtime-state.js';
+
+describe('Container', (): void => {
+  let temporaryDirectory: string;
+
+  beforeEach((): void => {
+    temporaryDirectory = fs.mkdtempSync(PathEx.join(os.tmpdir(), 'container-init-'));
+  });
+
+  afterEach((): void => {
+    // Restore the container to the standard configuration so other suites are unaffected.
+    Container.getInstance().reset(constants.SOLO_HOME_DIR, constants.SOLO_CACHE_DIR, constants.SOLO_LOG_LEVEL);
+    fs.rmSync(temporaryDirectory, {recursive: true, force: true});
+  });
+
+  describe('init', (): void => {
+    it('should create a missing home directory so home-dependent services resolve on a fresh machine', (): void => {
+      const homeDirectory: string = PathEx.join(temporaryDirectory, 'missing-parent', 'solo-home');
+      expect(fs.existsSync(homeDirectory)).to.be.false;
+
+      Container.getInstance().reset(homeDirectory, PathEx.join(homeDirectory, 'cache'), constants.SOLO_LOG_LEVEL);
+
+      expect(fs.existsSync(homeDirectory)).to.be.true;
+      const localConfig: LocalConfigRuntimeState = container.resolve<LocalConfigRuntimeState>(
+        InjectTokens.LocalConfigRuntimeState,
+      );
+      expect(localConfig).to.not.be.undefined;
+    });
+
+    it('should initialize normally when the home directory already exists', (): void => {
+      Container.getInstance().reset(
+        temporaryDirectory,
+        PathEx.join(temporaryDirectory, 'cache'),
+        constants.SOLO_LOG_LEVEL,
+      );
+
+      expect(fs.existsSync(temporaryDirectory)).to.be.true;
+      expect((): LocalConfigRuntimeState => container.resolve(InjectTokens.LocalConfigRuntimeState)).to.not.throw();
+    });
+  });
+});


### PR DESCRIPTION
## Description

This pull request changes the following:

* Creates the Solo home directory in `Container.init` (recursive `mkdirSync`) before any DI registrations, so services that validate the directory at construction time (e.g. the local config file storage backend) resolve on a machine with no `~/.solo`. Previously this only worked as a side effect of the Pino logger creating the logs directory, and only for the default home path — a caller passing a custom `homeDirectory` to `Container.init` still crashed with a raw `StorageBackendError('basePath must exist and be valid')` at container-resolve time.
* If directory creation itself fails, the error propagates to `main()`, where it is wrapped in `InitSystemFilesFailedSoloError` and fails fast with the existing remediation steps (write permissions, disk space).
* Adds a regression unit test that initializes the container with a non-existent nested home directory and resolves `LocalConfigRuntimeState` — the exact crash path from the issue. The test fails without the `Container.init` change and passes with it.

### Related Issues

* Closes #5121

### Pull request (PR) checklist

* [x] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [ ] Any technical debt has been documented as a separate issue and linked to this PR
* [ ] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [x] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [x] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* With `SOLO_HOME` pointing at a non-existent directory, `solo deployment config list` runs cleanly and creates the home directory (`cache/`, `logs/`, `local-config.yaml`), satisfying the acceptance criteria of #5121.
* Reverting the `Container.init` change makes the new unit test fail with the `StorageBackendError` described in the issue; restoring it makes the test pass.

The following was not tested:

* The failure path where the home directory cannot be created (unwritable parent) on Windows.
