### PR TITLE
feat: add `solo deployment config import` to reconstruct local config from a cluster's remote config

### DIFF
--- a/docs/design/architecture/system/presentation_layer_cli_architecture.md
+++ b/docs/design/architecture/system/presentation_layer_cli_architecture.md
@@ -167,6 +167,7 @@ solo cluster-ref config connect --cluster-ref <name> --context <context>
 solo deployment config create --deployment <name> --namespace <name> 
 solo deployment config list
 solo deployment config info [--deployment <name>]
+solo deployment config import [--namespace <name>] [--context <context>] # Reconstructs the local config from an existing cluster's remote config
 solo deployment cluster attach --deployment <name> --cluster-ref <name> --num-consensus-nodes 3 
 solo keys consensus generate --deployment <name> --gossip-tls-keys --grpc-tls-keys
 solo block node add --deployment <name> --cluster-ref <name> 
@@ -475,7 +476,7 @@ operations associated with each resource.
 | **Info**       | `info`         | Displays deployment metadata, component versions, and port-forward status. If `--deployment` is omitted, it iterates all local deployments.  |
 | **Create**     | `create`       | Creates a new local deployment configuration.                                                                                                   |
 | **Delete**     | `delete`       | Removes a local deployment configuration.                                                                                                       |
-| **Import**     | `import`       | Imports deployment config from a file.                                                                                                          |
+| **Import**     | `import`       | Imports a deployment into the local configuration from an existing cluster's remote config.                                                     |
 
 <p align="right">
 :arrow_up_small: <a href="#table-of-contents">Back to top</a>

--- a/src/commands/command-definitions/deployment-command-definition.ts
+++ b/src/commands/command-definitions/deployment-command-definition.ts
@@ -58,6 +58,7 @@ export class DeploymentCommandDefinition extends BaseCommandDefinition {
   public static readonly CONFIG_DELETE: string = 'delete';
   public static readonly CONFIG_INFO: string = 'info';
   public static readonly CONFIG_PORTS: string = 'ports';
+  public static readonly CONFIG_IMPORT: string = 'import';
 
   public static readonly DIAGNOSTICS_ALL: string = 'all';
   public static readonly DIAGNOSTICS_ANALYZE: string = 'analyze';
@@ -169,6 +170,16 @@ export class DeploymentCommandDefinition extends BaseCommandDefinition {
               this.deploymentCommand,
               this.deploymentCommand.ports,
               DeploymentCommand.PORTS_FLAGS_LIST,
+              [],
+            ),
+          )
+          .addSubcommand(
+            new Subcommand(
+              DeploymentCommandDefinition.CONFIG_IMPORT,
+              "Imports a deployment into the local configuration from an existing cluster's remote config.",
+              this.deploymentCommand,
+              this.deploymentCommand.importConfig,
+              DeploymentCommand.IMPORT_FLAGS_LIST,
               [],
             ),
           ),

--- a/src/commands/deployment.ts
+++ b/src/commands/deployment.ts
@@ -2,7 +2,7 @@
 
 import {Listr} from 'listr2';
 import {ListrInquirerPromptAdapter} from '@listr2/prompt-adapter-inquirer';
-import {select as selectPrompt} from '@inquirer/prompts';
+import {confirm as confirmPrompt, select as selectPrompt} from '@inquirer/prompts';
 import {BaseCommand} from './base.js';
 import {Flags, Flags as flags} from './flags.js';
 import * as constants from '../core/constants.js';
@@ -33,7 +33,8 @@ import {Deployment} from '../business/runtime-state/config/local/deployment.js';
 import {CommandFlags} from '../types/flag-types.js';
 import {type ConfigMap} from '../integration/kube/resources/config-map/config-map.js';
 import {type FacadeArray} from '../business/runtime-state/collection/facade-array.js';
-import {remoteConfigsToDeploymentsTable} from '../core/helpers.js';
+import {Helpers, remoteConfigsToDeploymentsTable} from '../core/helpers.js';
+import {type ClusterSchema} from '../data/schema/model/common/cluster-schema.js';
 import {MessageLevel} from '../core/logging/message-level.js';
 import {PodReference} from '../integration/kube/resources/pod/pod-reference.js';
 import {PodName} from '../integration/kube/resources/pod/pod-name.js';
@@ -145,6 +146,11 @@ export class DeploymentCommand extends BaseCommand {
   public static PORTS_FLAGS_LIST: CommandFlags = {
     required: [flags.deployment],
     optional: [flags.clusterRef, flags.quiet, flags.output, flags.cacheDir],
+  };
+
+  public static IMPORT_FLAGS_LIST: CommandFlags = {
+    required: [],
+    optional: [flags.context, flags.deployment, flags.namespace, flags.quiet, flags.realm, flags.shard],
   };
 
   /**
@@ -543,6 +549,267 @@ export class DeploymentCommand extends BaseCommand {
       await tasks.run();
     } catch (error) {
       throw new SoloErrors.deployment.listFailed(error);
+    }
+
+    return true;
+  }
+
+  /**
+   * Reconstruct the local configuration for an existing deployment from a cluster's remote config.
+   */
+  public async importConfig(argv: ArgvStruct): Promise<boolean> {
+    interface Config {
+      quiet: boolean;
+      kubeContext: Context;
+      namespace: Optional<NamespaceName>;
+      deploymentFilter: Optional<DeploymentName>;
+      realm: Realm;
+      shard: Shard;
+      configMap: Optional<ConfigMap>;
+    }
+
+    interface ImportTaskContext {
+      config: Config;
+    }
+
+    interface DiscoveredDeployment {
+      configMap: ConfigMap;
+      deploymentName: string;
+    }
+
+    const tasks: ReturnType<typeof this.taskList.newTaskList> = this.taskList.newTaskList(
+      [
+        {
+          title: 'Initialize',
+          task: async (context_: ImportTaskContext): Promise<void> => {
+            await this.localConfig.load();
+
+            this.configManager.update(argv);
+
+            const namespaceValue: string = this.configManager.getFlag<string>(flags.namespace);
+
+            context_.config = {
+              quiet: this.configManager.getFlag<boolean>(flags.quiet),
+              kubeContext:
+                this.configManager.getFlag<Context>(flags.context) || this.k8Factory.default().contexts().readCurrent(),
+              namespace: namespaceValue ? NamespaceName.of(namespaceValue) : undefined,
+              deploymentFilter: this.configManager.getFlag<DeploymentName>(flags.deployment) || undefined,
+              realm: this.configManager.getFlag<Realm>(flags.realm) || (flags.realm.definition.defaultValue as Realm),
+              shard: this.configManager.getFlag<Shard>(flags.shard) || (flags.shard.definition.defaultValue as Shard),
+              configMap: undefined,
+            };
+          },
+        },
+        {
+          title: 'Discover Solo deployments in the cluster',
+          task: async (context_: ImportTaskContext, task): Promise<void> => {
+            const {kubeContext, namespace, deploymentFilter, quiet} = context_.config;
+
+            const labels: string[] = Templates.renderConfigMapRemoteConfigLabels();
+            const configMaps: ConfigMap[] = await (namespace
+              ? this.k8Factory.getK8(kubeContext).configMaps().list(namespace, labels)
+              : this.k8Factory.getK8(kubeContext).configMaps().listForAllNamespaces(labels));
+
+            let discovered: DiscoveredDeployment[] = configMaps
+              .map((configMap: ConfigMap): Optional<DiscoveredDeployment> => {
+                const deploymentName: Optional<string> = Helpers.extractRemoteConfigDeploymentNames(configMap)[0];
+                return deploymentName ? {configMap, deploymentName} : undefined;
+              })
+              .filter((entry: Optional<DiscoveredDeployment>): entry is DiscoveredDeployment => entry !== undefined);
+
+            if (deploymentFilter) {
+              discovered = discovered.filter(
+                (entry: DiscoveredDeployment): boolean => entry.deploymentName === deploymentFilter,
+              );
+            }
+
+            const searchScope: string =
+              `kube context '${kubeContext}'` + (namespace ? ` and namespace '${namespace.name}'` : '');
+
+            if (discovered.length === 0) {
+              throw new SoloErrors.deployment.importFailed(`no Solo deployment found in ${searchScope}`);
+            }
+
+            let selected: DiscoveredDeployment = discovered[0];
+            if (discovered.length > 1) {
+              if (quiet) {
+                const candidates: string = discovered
+                  .map((entry: DiscoveredDeployment): string => {
+                    return `${entry.configMap.namespace.name}:${entry.deploymentName}`;
+                  })
+                  .join(', ');
+                throw new SoloErrors.deployment.importFailed(
+                  `multiple Solo deployments found in ${searchScope} (${candidates}); narrow the selection with ` +
+                    `the ${Flags.getFormattedFlagKey(flags.deployment)} or ${Flags.getFormattedFlagKey(flags.namespace)} ` +
+                    `flag, or run without ${Flags.getFormattedFlagKey(flags.quiet)} to select interactively`,
+                );
+              }
+
+              const selectedIndex: number = (await task.prompt(ListrInquirerPromptAdapter).run(selectPrompt, {
+                message: 'Select the deployment to import:',
+                choices: discovered.map(
+                  (entry: DiscoveredDeployment, index: number): {name: string; value: number} => ({
+                    name: `${entry.deploymentName} (namespace: ${entry.configMap.namespace.name})`,
+                    value: index,
+                  }),
+                ),
+              })) as number;
+              selected = discovered[selectedIndex];
+            }
+
+            context_.config.configMap = selected.configMap;
+            task.title += `: found '${selected.deploymentName}' in namespace '${selected.configMap.namespace.name}'`;
+          },
+        },
+        {
+          title: 'Load remote configuration',
+          task: async (context_: ImportTaskContext): Promise<void> => {
+            const {configMap, kubeContext} = context_.config;
+            await this.remoteConfig.populateFromExisting(configMap.namespace, kubeContext);
+          },
+        },
+        {
+          title: 'Import deployment into local configuration',
+          task: async (context_: ImportTaskContext, task): Promise<void> => {
+            const {kubeContext, quiet, realm, shard} = context_.config;
+
+            const clusters: ReadonlyArray<Readonly<ClusterSchema>> = this.remoteConfig.configuration.clusters;
+            if (clusters.length === 0) {
+              throw new SoloErrors.deployment.importFailed('the remote config does not reference any clusters');
+            }
+
+            const deploymentName: DeploymentName = clusters[0].deployment as DeploymentName;
+            const namespaceName: string = clusters[0].namespace;
+
+            task.title = `Import deployment '${deploymentName}' into local configuration`;
+
+            const existing: Deployment = this.localConfig.configuration.deployments.find(
+              (candidate: Deployment): boolean => candidate.name === deploymentName,
+            );
+            if (existing) {
+              const matchesRemote: boolean =
+                existing.namespace === namespaceName &&
+                clusters.every((cluster: Readonly<ClusterSchema>): boolean =>
+                  existing.clusters.some(
+                    (clusterReference: StringFacade): boolean => clusterReference.toString() === cluster.name,
+                  ),
+                );
+
+              if (!matchesRemote) {
+                if (quiet) {
+                  throw new SoloErrors.deployment.importFailed(
+                    `deployment '${deploymentName}' already exists in the local config with different settings; ` +
+                      `run without ${Flags.getFormattedFlagKey(flags.quiet)} to confirm overwriting it`,
+                  );
+                }
+
+                const overwrite: boolean = await task.prompt(ListrInquirerPromptAdapter).run(confirmPrompt, {
+                  default: false,
+                  message:
+                    `Deployment '${deploymentName}' already exists in the local config ` +
+                    'with different settings. Overwrite it?',
+                });
+
+                if (!overwrite) {
+                  this.logger.showUser(chalk.yellow('Import aborted; local configuration left unchanged.'));
+                  return;
+                }
+
+                this.localConfig.configuration.deployments.remove(existing);
+              }
+            }
+
+            // Map cluster-refs to kube contexts without overwriting mappings that already exist locally.
+            for (const cluster of clusters) {
+              const clusterReference: ClusterReferenceName = cluster.name;
+              const mappedContext: Optional<string> = this.localConfig.configuration.clusterRefs
+                .get(clusterReference)
+                ?.toString();
+
+              if (mappedContext) {
+                if (mappedContext !== kubeContext) {
+                  this.logger.showUser(
+                    chalk.yellow(
+                      `Keeping existing mapping for cluster-ref '${clusterReference}' → '${mappedContext}'.`,
+                    ),
+                  );
+                }
+                continue;
+              }
+
+              if (clusters.length === 1) {
+                this.localConfig.configuration.clusterRefs.set(clusterReference, new StringFacade(kubeContext));
+                continue;
+              }
+
+              if (quiet) {
+                throw new SoloErrors.deployment.importFailed(
+                  `cluster-ref '${clusterReference}' is not mapped to a kube context in the local config; ` +
+                    `run without ${Flags.getFormattedFlagKey(flags.quiet)} to select the context interactively`,
+                );
+              }
+
+              const selectedContext: string = (await task.prompt(ListrInquirerPromptAdapter).run(selectPrompt, {
+                message: `Select the kube context for cluster-ref '${clusterReference}':`,
+                choices: this.k8Factory
+                  .default()
+                  .contexts()
+                  .list()
+                  .map((contextName: string): {name: string; value: string} => ({
+                    name: contextName,
+                    value: contextName,
+                  })),
+                default: kubeContext,
+              })) as string;
+              this.localConfig.configuration.clusterRefs.set(clusterReference, new StringFacade(selectedContext));
+            }
+
+            let deployment: Deployment = this.localConfig.configuration.deployments.find(
+              (candidate: Deployment): boolean => candidate.name === deploymentName,
+            );
+            if (!deployment) {
+              deployment = this.localConfig.configuration.deployments.addNew();
+              deployment.name = deploymentName;
+              deployment.namespace = namespaceName;
+              deployment.realm = realm;
+              deployment.shard = shard;
+            }
+
+            for (const cluster of clusters) {
+              const alreadyListed: boolean = deployment.clusters.some(
+                (clusterReference: StringFacade): boolean => clusterReference.toString() === cluster.name,
+              );
+              if (!alreadyListed) {
+                deployment.clusters.add(new StringFacade(cluster.name));
+              }
+            }
+
+            await this.localConfig.persist();
+
+            this.logger.showList(
+              `Imported deployment '${deploymentName}'`,
+              clusters.map((cluster: Readonly<ClusterSchema>): string => {
+                const mapped: string =
+                  this.localConfig.configuration.clusterRefs.get(cluster.name)?.toString() ?? '<none>';
+                return `${deploymentName} | namespace=${namespaceName} | cluster-ref=${cluster.name} | context=${mapped}`;
+              }),
+            );
+          },
+        },
+      ],
+      constants.LISTR_DEFAULT_OPTIONS.DEFAULT,
+      undefined,
+      'deployment config import',
+    );
+
+    if (tasks.isRoot()) {
+      try {
+        await tasks.run();
+      } catch (error) {
+        throw error instanceof SoloErrors.deployment.importFailed
+          ? error
+          : new SoloErrors.deployment.importFailed('could not complete the import', error);
+      }
     }
 
     return true;

--- a/src/commands/deployment.ts
+++ b/src/commands/deployment.ts
@@ -39,6 +39,7 @@ import {MessageLevel} from '../core/logging/message-level.js';
 import {PodReference} from '../integration/kube/resources/pod/pod-reference.js';
 import {PodName} from '../integration/kube/resources/pod/pod-name.js';
 import {Pod} from '../integration/kube/resources/pod/pod.js';
+import {ContainerReference} from '../integration/kube/resources/container/container-reference.js';
 import {type K8} from '../integration/kube/k8.js';
 import {type BaseStateSchema} from '../data/schema/model/remote/state/base-state-schema.js';
 import * as version from '../../version.js';
@@ -150,7 +151,7 @@ export class DeploymentCommand extends BaseCommand {
 
   public static IMPORT_FLAGS_LIST: CommandFlags = {
     required: [],
-    optional: [flags.context, flags.deployment, flags.namespace, flags.quiet, flags.realm, flags.shard],
+    optional: [flags.context, flags.deployment, flags.namespace, flags.quiet],
   };
 
   /**
@@ -563,8 +564,6 @@ export class DeploymentCommand extends BaseCommand {
       kubeContext: Context;
       namespace: Optional<NamespaceName>;
       deploymentFilter: Optional<DeploymentName>;
-      realm: Realm;
-      shard: Shard;
       configMap: Optional<ConfigMap>;
     }
 
@@ -594,8 +593,6 @@ export class DeploymentCommand extends BaseCommand {
                 this.configManager.getFlag<Context>(flags.context) || this.k8Factory.default().contexts().readCurrent(),
               namespace: namespaceValue ? NamespaceName.of(namespaceValue) : undefined,
               deploymentFilter: this.configManager.getFlag<DeploymentName>(flags.deployment) || undefined,
-              realm: this.configManager.getFlag<Realm>(flags.realm) || (flags.realm.definition.defaultValue as Realm),
-              shard: this.configManager.getFlag<Shard>(flags.shard) || (flags.shard.definition.defaultValue as Shard),
               configMap: undefined,
             };
           },
@@ -671,7 +668,7 @@ export class DeploymentCommand extends BaseCommand {
         {
           title: 'Import deployment into local configuration',
           task: async (context_: ImportTaskContext, task): Promise<void> => {
-            const {kubeContext, quiet, realm, shard} = context_.config;
+            const {kubeContext, quiet, configMap} = context_.config;
 
             const clusters: ReadonlyArray<Readonly<ClusterSchema>> = this.remoteConfig.configuration.clusters;
             if (clusters.length === 0) {
@@ -768,6 +765,7 @@ export class DeploymentCommand extends BaseCommand {
               (candidate: Deployment): boolean => candidate.name === deploymentName,
             );
             if (!deployment) {
+              const {realm, shard} = await this.readRealmAndShardFromConsensusNode(kubeContext, configMap.namespace);
               deployment = this.localConfig.configuration.deployments.addNew();
               deployment.name = deploymentName;
               deployment.namespace = namespaceName;
@@ -813,6 +811,82 @@ export class DeploymentCommand extends BaseCommand {
     }
 
     return true;
+  }
+
+  /** Read the realm and shard from the deployment's application.properties, warning and defaulting when unreachable. */
+  private async readRealmAndShardFromConsensusNode(
+    kubeContext: Context,
+    namespace: NamespaceName,
+  ): Promise<{realm: Realm; shard: Shard}> {
+    const defaultRealm: Realm = flags.realm.definition.defaultValue as Realm;
+    const defaultShard: Shard = flags.shard.definition.defaultValue as Shard;
+
+    const applicationProperties: Optional<string> = await this.readApplicationPropertiesFromCluster(
+      kubeContext,
+      namespace,
+    );
+    const realm: Optional<number> = applicationProperties
+      ? Helpers.parseNumericApplicationProperty(applicationProperties, 'hedera.realm')
+      : undefined;
+    const shard: Optional<number> = applicationProperties
+      ? Helpers.parseNumericApplicationProperty(applicationProperties, 'hedera.shard')
+      : undefined;
+
+    if (realm === undefined || shard === undefined) {
+      this.logger.showUser(
+        chalk.yellow(
+          "Could not read the realm and shard from the deployment's consensus nodes; " +
+            `defaulting to realm ${defaultRealm}, shard ${defaultShard}.`,
+        ),
+      );
+    }
+
+    return {realm: realm ?? defaultRealm, shard: shard ?? defaultShard};
+  }
+
+  /** Fetch application.properties from the first reachable consensus node pod, else from the shared data ConfigMap. */
+  private async readApplicationPropertiesFromCluster(
+    kubeContext: Context,
+    namespace: NamespaceName,
+  ): Promise<Optional<string>> {
+    const k8: K8 = this.k8Factory.getK8(kubeContext);
+    const applicationPropertiesPath: string = `${constants.HEDERA_HAPI_PATH}/data/config/${constants.APPLICATION_PROPERTIES}`;
+
+    try {
+      const pods: Pod[] = await k8.pods().list(namespace, ['solo.hedera.com/type=network-node']);
+      for (const pod of pods) {
+        if (!pod?.podReference) {
+          continue;
+        }
+        try {
+          const containerReference: ContainerReference = ContainerReference.of(
+            pod.podReference,
+            constants.ROOT_CONTAINER,
+          );
+          const applicationProperties: string = await k8
+            .containers()
+            .readByRef(containerReference)
+            .execContainer(`cat ${applicationPropertiesPath}`);
+          if (applicationProperties) {
+            return applicationProperties;
+          }
+        } catch {
+          // best-effort: this pod may not be running; try the next consensus node
+        }
+      }
+    } catch {
+      // best-effort: pod listing may fail when the network is down; fall through to the ConfigMap
+    }
+
+    try {
+      const configMap: ConfigMap = await k8
+        .configMaps()
+        .read(namespace, constants.NETWORK_NODE_SHARED_DATA_CONFIG_MAP_NAME);
+      return configMap.data?.[constants.APPLICATION_PROPERTIES];
+    } catch {
+      // best-effort: the shared data ConfigMap may be absent; the caller falls back to defaults
+      return undefined;
+    }
   }
 
   public async close(): Promise<void> {} // no-op

--- a/src/core/errors/classes/deployment/deployment-import-failed-solo-error.ts
+++ b/src/core/errors/classes/deployment/deployment-import-failed-solo-error.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {SoloError} from '../../solo-error.js';
+import {ErrorOwnership} from '../../error-ownership.js';
+import {ErrorCodeRegistry} from '../../error-code-registry.js';
+
+/**
+ * @description Thrown when `solo deployment config import` cannot reconstruct the local config
+ * from a cluster's `solo-remote-config` ConfigMap: the cluster is unreachable, no Solo deployment
+ * exists in the targeted context/namespace, the remote config is unparseable, or the selection is
+ * ambiguous in quiet mode. Retryable because transient connectivity issues often resolve on retry.
+ */
+export class DeploymentImportFailedSoloError extends SoloError {
+  protected override readonly retryable: boolean = true;
+  protected override readonly ownership: ErrorOwnership = ErrorOwnership.Infrastructure;
+
+  public constructor(details: string, cause?: Error) {
+    super(
+      {
+        message: `Failed to import deployment configuration: ${details}`,
+        code: ErrorCodeRegistry.DEPLOYMENT_IMPORT_FAILED,
+        troubleshootingSteps:
+          'Verify the kube context is reachable: kubectl --context <context> get namespaces\n' +
+          'Verify the targeted namespace contains a Solo deployment (solo-remote-config ConfigMap)\n' +
+          'Check logs for details: tail -n 100 ~/.solo/logs/solo.log',
+      },
+      cause,
+    );
+  }
+}

--- a/src/core/errors/error-code-registry.ts
+++ b/src/core/errors/error-code-registry.ts
@@ -38,6 +38,7 @@ export const ErrorCodeRegistry: Record<string, string> = {
   INIT_FAILED: 'SOLO-2028',
   BLOCK_NODE_CLUSTER_CONTEXT_NOT_FOUND: 'SOLO-2029',
   MIRROR_NODE_CLUSTER_CONTEXT_NOT_FOUND: 'SOLO-2030',
+  DEPLOYMENT_IMPORT_FAILED: 'SOLO-2031',
 
   // 3xxx - Component: Relay, Mirror Node, Explorer, CN runtime
   NODE_TRANSACTION_FAILED: 'SOLO-3001',

--- a/src/core/errors/solo-errors.ts
+++ b/src/core/errors/solo-errors.ts
@@ -7,6 +7,7 @@ import {ClusterReferenceResolutionFailedError} from './classes/deployment/cluste
 import {ContextNotFoundForClusterError} from './classes/deployment/context-not-found-for-cluster-error.js';
 import {DeploymentDeleteFailedError} from './classes/deployment/deployment-delete-failed-error.js';
 import {DeploymentHasRemoteResourcesError} from './classes/deployment/deployment-has-remote-resources-error.js';
+import {DeploymentImportFailedSoloError} from './classes/deployment/deployment-import-failed-solo-error.js';
 import {DeploymentListFailedError} from './classes/deployment/deployment-list-failed-error.js';
 import {DeploymentListPortsFailedError} from './classes/deployment/deployment-list-ports-failed-error.js';
 import {DeploymentNotFoundError} from './classes/deployment/deployment-not-found-error.js';
@@ -320,6 +321,7 @@ export class SoloErrors {
     readonly createFailed: typeof CreateDeploymentSoloError;
     readonly deleteFailed: typeof DeploymentDeleteFailedError;
     readonly hasRemoteResources: typeof DeploymentHasRemoteResourcesError;
+    readonly importFailed: typeof DeploymentImportFailedSoloError;
     readonly listFailed: typeof DeploymentListFailedError;
     readonly listPortsFailed: typeof DeploymentListPortsFailedError;
     readonly namespaceNotSet: typeof NamespaceNotSetError;
@@ -351,6 +353,7 @@ export class SoloErrors {
     createFailed: CreateDeploymentSoloError,
     deleteFailed: DeploymentDeleteFailedError,
     hasRemoteResources: DeploymentHasRemoteResourcesError,
+    importFailed: DeploymentImportFailedSoloError,
     listFailed: DeploymentListFailedError,
     listPortsFailed: DeploymentListPortsFailedError,
     namespaceNotSet: NamespaceNotSetError,

--- a/src/core/helpers.ts
+++ b/src/core/helpers.ts
@@ -168,6 +168,17 @@ export class Helpers {
     return undefined;
   }
 
+  public static parseNumericApplicationProperty(
+    applicationPropertiesText: string,
+    propertyKey: string,
+  ): number | undefined {
+    const escapedPropertyKey: string = propertyKey.replaceAll('.', String.raw`\.`);
+    const match: RegExpMatchArray | null = applicationPropertiesText.match(
+      new RegExp(String.raw`^\s*${escapedPropertyKey}\s*=\s*(\d+)\s*$`, 'm'),
+    );
+    return match ? Number(match[1]) : undefined;
+  }
+
   public static readGossipFqdnRestrictedFromFile(filePath: string): boolean | undefined {
     if (!fs.existsSync(filePath)) {
       return undefined;

--- a/src/core/helpers.ts
+++ b/src/core/helpers.ts
@@ -695,31 +695,47 @@ export class Helpers {
     };
   }
 
+  /**
+   * Best-effort extraction of the deployment names recorded in a remote-config ConfigMap.
+   * Tolerates both the current (array) and legacy (map keyed by cluster name) cluster layouts.
+   */
+  public static extractRemoteConfigDeploymentNames(remoteConfig: ConfigMap): string[] {
+    const deploymentNames: string[] = [];
+    try {
+      const remoteConfigData: unknown = yaml.parse(remoteConfig.data?.[constants.SOLO_REMOTE_CONFIGMAP_DATA_KEY]);
+      let clustersData: unknown = undefined;
+      if (typeof remoteConfigData === 'object' && remoteConfigData !== null && 'clusters' in remoteConfigData) {
+        clustersData = (remoteConfigData as Record<string, unknown>).clusters;
+      }
+      const clustersArray: unknown[] = [];
+
+      if (Array.isArray(clustersData)) {
+        clustersArray.push(...clustersData);
+      } else if (typeof clustersData === 'object' && clustersData !== null) {
+        clustersArray.push(...Object.values(clustersData));
+      }
+
+      for (const clusterData of clustersArray) {
+        if (typeof clusterData === 'object' && clusterData !== null && 'deployment' in clusterData) {
+          const deployment: unknown = (clusterData as Record<string, unknown>).deployment;
+          if (typeof deployment === 'string' && deployment.length > 0) {
+            deploymentNames.push(deployment);
+          }
+        }
+      }
+    } catch {
+      // best-effort: treat absent or unparseable remote-config data as containing no deployments
+    }
+    return deploymentNames;
+  }
+
   public static remoteConfigsToDeploymentsTable(remoteConfigs: ConfigMap[]): string[] {
     const rows: string[] = [];
     if (remoteConfigs.length > 0) {
       rows.push('Namespace : deployment');
       for (const remoteConfig of remoteConfigs) {
-        const remoteConfigData: unknown = yaml.parse(remoteConfig.data?.['remote-config-data']);
-        let clustersData: unknown = undefined;
-        if (typeof remoteConfigData === 'object' && remoteConfigData !== null && 'clusters' in remoteConfigData) {
-          clustersData = (remoteConfigData as Record<string, unknown>).clusters;
-        }
-        const clustersArray: unknown[] = [];
-
-        if (Array.isArray(clustersData)) {
-          clustersArray.push(...clustersData);
-        } else if (typeof clustersData === 'object' && clustersData !== null) {
-          clustersArray.push(...Object.values(clustersData));
-        }
-
-        for (const clusterData of clustersArray) {
-          if (typeof clusterData === 'object' && clusterData !== null && 'deployment' in clusterData) {
-            const deployment: unknown = (clusterData as Record<string, unknown>).deployment;
-            if (typeof deployment === 'string') {
-              rows.push(`${remoteConfig.namespace.name} : ${deployment}`);
-            }
-          }
+        for (const deployment of Helpers.extractRemoteConfigDeploymentNames(remoteConfig)) {
+          rows.push(`${remoteConfig.namespace.name} : ${deployment}`);
         }
       }
     }

--- a/test/unit/commands/deployment.test.ts
+++ b/test/unit/commands/deployment.test.ts
@@ -20,10 +20,15 @@ import {K8Client} from '../../../src/integration/kube/k8-client/k8-client.js';
 import {type Deployment} from '../../../src/business/runtime-state/config/local/deployment.js';
 import {type SoloLogger} from '../../../src/core/logging/solo-logger.js';
 import {type ConfigMap} from '../../../src/integration/kube/resources/config-map/config-map.js';
+import {PodReference} from '../../../src/integration/kube/resources/pod/pod-reference.js';
+import {PodName} from '../../../src/integration/kube/resources/pod/pod-name.js';
 import * as constants from '../../../src/core/constants.js';
 
 describe('DeploymentCommand unit tests', (): void => {
-  type K8StubbedMethods = Pick<K8, 'namespaces' | 'configMaps' | 'contexts' | 'clusters' | 'leases'>;
+  type K8StubbedMethods = Pick<
+    K8,
+    'namespaces' | 'configMaps' | 'contexts' | 'clusters' | 'leases' | 'pods' | 'containers'
+  >;
   type K8FactoryStubbedMethods = K8Factory & {getK8: SinonStub; default: SinonStub};
 
   const namespace: NamespaceName = NamespaceName.of('solo-e2e');
@@ -221,6 +226,87 @@ describe('DeploymentCommand unit tests', (): void => {
         (deployment: Deployment): boolean => deployment.name === importedDeploymentName,
       );
       expect(imported?.clusters.map((cluster): string => cluster.toString())).to.deep.equal([importedClusterReference]);
+    });
+
+    it("should read the realm and shard from a consensus node's application.properties", async (): Promise<void> => {
+      const applicationPropertiesContent: string = 'hedera.realm=3\nhedera.shard=2\n';
+      k8Stub.pods = sinon.stub().returns({
+        list: sinon
+          .stub()
+          .resolves([
+            {podReference: PodReference.of(NamespaceName.of(importedNamespaceName), PodName.of('network-node1-0'))},
+          ]),
+      });
+      k8Stub.containers = sinon.stub().returns({
+        readByRef: sinon.stub().returns({execContainer: sinon.stub().resolves(applicationPropertiesContent)}),
+      });
+
+      const deploymentCommand: DeploymentCommand = container.resolve(InjectTokens.DeploymentCommand);
+      const localConfig: LocalConfigRuntimeState = container.resolve(InjectTokens.LocalConfigRuntimeState);
+
+      await expect(deploymentCommand.importConfig(buildImportArgv().build())).to.eventually.be.true;
+
+      await localConfig.load();
+      const imported: Deployment | undefined = localConfig.configuration.deployments.find(
+        (deployment: Deployment): boolean => deployment.name === importedDeploymentName,
+      );
+      expect(imported?.realm).to.equal(3);
+      expect(imported?.shard).to.equal(2);
+    });
+
+    it('should read the realm and shard from the shared data ConfigMap when no consensus node is running', async (): Promise<void> => {
+      const sharedDataConfigMap: ConfigMap = {
+        name: constants.NETWORK_NODE_SHARED_DATA_CONFIG_MAP_NAME,
+        namespace: NamespaceName.of(importedNamespaceName),
+        labels: {},
+        data: {[constants.APPLICATION_PROPERTIES]: 'hedera.realm=5\nhedera.shard=1\n'},
+      };
+      const readStub: SinonStub = sinon.stub().resolves(remoteConfigMap);
+      readStub
+        .withArgs(sinon.match.any, constants.NETWORK_NODE_SHARED_DATA_CONFIG_MAP_NAME)
+        .resolves(sharedDataConfigMap);
+      k8Stub.configMaps = sinon.stub().returns({
+        exists: configMapsStub,
+        list: sinon.stub().resolves([remoteConfigMap]),
+        listForAllNamespaces: sinon.stub().resolves([remoteConfigMap]),
+        read: readStub,
+      });
+      k8Stub.pods = sinon.stub().returns({list: sinon.stub().resolves([])});
+
+      const deploymentCommand: DeploymentCommand = container.resolve(InjectTokens.DeploymentCommand);
+      const localConfig: LocalConfigRuntimeState = container.resolve(InjectTokens.LocalConfigRuntimeState);
+
+      await expect(deploymentCommand.importConfig(buildImportArgv().build())).to.eventually.be.true;
+
+      await localConfig.load();
+      const imported: Deployment | undefined = localConfig.configuration.deployments.find(
+        (deployment: Deployment): boolean => deployment.name === importedDeploymentName,
+      );
+      expect(imported?.realm).to.equal(5);
+      expect(imported?.shard).to.equal(1);
+    });
+
+    it('should warn and fall back to the default realm and shard when they cannot be determined', async (): Promise<void> => {
+      k8Stub.pods = sinon.stub().returns({list: sinon.stub().resolves([])});
+
+      const deploymentCommand: DeploymentCommand = container.resolve(InjectTokens.DeploymentCommand);
+      const localConfig: LocalConfigRuntimeState = container.resolve(InjectTokens.LocalConfigRuntimeState);
+      const logger: SoloLogger = container.resolve(InjectTokens.SoloLogger);
+      const showUserStub: SinonStub = sinon.stub(logger, 'showUser');
+
+      await expect(deploymentCommand.importConfig(buildImportArgv().build())).to.eventually.be.true;
+
+      expect(
+        showUserStub.getCalls().some((call): boolean => String(call.args[0]).includes('realm')),
+        'expected a warning about falling back to the default realm and shard',
+      ).to.be.true;
+
+      await localConfig.load();
+      const imported: Deployment | undefined = localConfig.configuration.deployments.find(
+        (deployment: Deployment): boolean => deployment.name === importedDeploymentName,
+      );
+      expect(imported?.realm).to.equal(0);
+      expect(imported?.shard).to.equal(0);
     });
 
     it('should fail when no Solo deployment exists in the targeted context', async (): Promise<void> => {

--- a/test/unit/commands/deployment.test.ts
+++ b/test/unit/commands/deployment.test.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import fs from 'node:fs';
 import sinon, {type SinonStub} from 'sinon';
 import {before, beforeEach, afterEach, describe, it} from 'mocha';
 import {expect} from 'chai';
@@ -18,6 +19,8 @@ import {type InstanceOverrides} from '../../../src/core/dependency-injection/con
 import {K8Client} from '../../../src/integration/kube/k8-client/k8-client.js';
 import {type Deployment} from '../../../src/business/runtime-state/config/local/deployment.js';
 import {type SoloLogger} from '../../../src/core/logging/solo-logger.js';
+import {type ConfigMap} from '../../../src/integration/kube/resources/config-map/config-map.js';
+import * as constants from '../../../src/core/constants.js';
 
 describe('DeploymentCommand unit tests', (): void => {
   type K8StubbedMethods = Pick<K8, 'namespaces' | 'configMaps' | 'contexts' | 'clusters' | 'leases'>;
@@ -151,6 +154,110 @@ describe('DeploymentCommand unit tests', (): void => {
 
       // Should succeed - new deployment, no conflict
       await expect(deploymentCommand.create(argv.build())).to.eventually.be.true;
+    });
+  });
+
+  describe('importConfig()', (): void => {
+    const importedDeploymentName: string = 'alpha-prod';
+    const importedNamespaceName: string = 'solo-alpha-prod';
+    const importedClusterReference: string = 'gke-alpha-prod-us-central1';
+    const importKubeContext: string = 'context-1';
+
+    let remoteConfigMap: ConfigMap;
+
+    beforeEach((): void => {
+      remoteConfigMap = {
+        name: constants.SOLO_REMOTE_CONFIGMAP_NAME,
+        namespace: NamespaceName.of(importedNamespaceName),
+        labels: constants.SOLO_REMOTE_CONFIGMAP_LABELS,
+        data: {
+          [constants.SOLO_REMOTE_CONFIGMAP_DATA_KEY]: fs.readFileSync('test/data/v0-35-1-remote-config.yaml', 'utf8'),
+        },
+      };
+
+      k8Stub.configMaps = sinon.stub().returns({
+        exists: configMapsStub,
+        list: sinon.stub().resolves([remoteConfigMap]),
+        listForAllNamespaces: sinon.stub().resolves([remoteConfigMap]),
+        read: sinon.stub().resolves(remoteConfigMap),
+      });
+    });
+
+    function buildImportArgv(): Argv {
+      const argv: Argv = Argv.getDefaultArgv(namespace);
+      argv.setArg(flags.deployment, '');
+      argv.setArg(flags.namespace, '');
+      argv.setArg(flags.context, importKubeContext);
+      return argv;
+    }
+
+    it('should reconstruct the local config from the remote config of an existing deployment', async (): Promise<void> => {
+      const deploymentCommand: DeploymentCommand = container.resolve(InjectTokens.DeploymentCommand);
+      const localConfig: LocalConfigRuntimeState = container.resolve(InjectTokens.LocalConfigRuntimeState);
+
+      await expect(deploymentCommand.importConfig(buildImportArgv().build())).to.eventually.be.true;
+
+      await localConfig.load();
+      const imported: Deployment | undefined = localConfig.configuration.deployments.find(
+        (deployment: Deployment): boolean => deployment.name === importedDeploymentName,
+      );
+      expect(imported).to.not.be.undefined;
+      expect(imported?.namespace).to.equal(importedNamespaceName);
+      expect(imported?.clusters.map((cluster): string => cluster.toString())).to.deep.equal([importedClusterReference]);
+      expect(localConfig.configuration.clusterRefs.get(importedClusterReference)?.toString()).to.equal(
+        importKubeContext,
+      );
+    });
+
+    it('should be idempotent when the deployment was already imported', async (): Promise<void> => {
+      const deploymentCommand: DeploymentCommand = container.resolve(InjectTokens.DeploymentCommand);
+      const localConfig: LocalConfigRuntimeState = container.resolve(InjectTokens.LocalConfigRuntimeState);
+
+      await expect(deploymentCommand.importConfig(buildImportArgv().build())).to.eventually.be.true;
+      await expect(deploymentCommand.importConfig(buildImportArgv().build())).to.eventually.be.true;
+
+      await localConfig.load();
+      const imported: Deployment | undefined = localConfig.configuration.deployments.find(
+        (deployment: Deployment): boolean => deployment.name === importedDeploymentName,
+      );
+      expect(imported?.clusters.map((cluster): string => cluster.toString())).to.deep.equal([importedClusterReference]);
+    });
+
+    it('should fail when no Solo deployment exists in the targeted context', async (): Promise<void> => {
+      k8Stub.configMaps = sinon.stub().returns({
+        exists: configMapsStub,
+        list: sinon.stub().resolves([]),
+        listForAllNamespaces: sinon.stub().resolves([]),
+        read: sinon.stub().rejects(new Error('not found')),
+      });
+
+      const deploymentCommand: DeploymentCommand = container.resolve(InjectTokens.DeploymentCommand);
+
+      await expect(deploymentCommand.importConfig(buildImportArgv().build())).to.be.rejectedWith(
+        'no Solo deployment found',
+      );
+    });
+
+    it('should not overwrite a conflicting local deployment in quiet mode', async (): Promise<void> => {
+      const conflictingNamespaceName: string = 'different-namespace';
+      const localConfig: LocalConfigRuntimeState = container.resolve(InjectTokens.LocalConfigRuntimeState);
+      await localConfig.load();
+      const conflicting: Deployment = localConfig.configuration.deployments.addNew();
+      conflicting.name = importedDeploymentName;
+      conflicting.namespace = conflictingNamespaceName;
+      conflicting.realm = 0;
+      conflicting.shard = 0;
+      await localConfig.persist();
+
+      const deploymentCommand: DeploymentCommand = container.resolve(InjectTokens.DeploymentCommand);
+
+      await expect(deploymentCommand.importConfig(buildImportArgv().build())).to.be.rejectedWith('already exists');
+
+      await localConfig.load();
+      const untouched: Deployment | undefined = localConfig.configuration.deployments.find(
+        (deployment: Deployment): boolean => deployment.name === importedDeploymentName,
+      );
+      expect(untouched?.namespace).to.equal(conflictingNamespaceName);
     });
   });
 

--- a/test/unit/core/helpers.test.ts
+++ b/test/unit/core/helpers.test.ts
@@ -522,6 +522,34 @@ nodes.gossipFqdnRestricted=false`;
     });
   });
 
+  describe('parseNumericApplicationProperty', (): void => {
+    it('parses the value of a numeric property', (): void => {
+      const content: string = 'hedera.realm=3\nhedera.shard=2';
+      expect(Helpers.parseNumericApplicationProperty(content, 'hedera.realm')).to.equal(3);
+      expect(Helpers.parseNumericApplicationProperty(content, 'hedera.shard')).to.equal(2);
+    });
+
+    it('handles whitespace around the equals sign and value', (): void => {
+      const content: string = 'hedera.realm  =  10 ';
+      expect(Helpers.parseNumericApplicationProperty(content, 'hedera.realm')).to.equal(10);
+    });
+
+    it('returns undefined for a missing property', (): void => {
+      const content: string = 'some.other.property=value';
+      expect(Helpers.parseNumericApplicationProperty(content, 'hedera.realm')).to.be.undefined;
+    });
+
+    it('returns undefined for a non-numeric value', (): void => {
+      const content: string = 'hedera.realm=abc';
+      expect(Helpers.parseNumericApplicationProperty(content, 'hedera.realm')).to.be.undefined;
+    });
+
+    it('does not match a property whose key is a superstring of the requested key', (): void => {
+      const content: string = 'hedera.realmNumber=7';
+      expect(Helpers.parseNumericApplicationProperty(content, 'hedera.realm')).to.be.undefined;
+    });
+  });
+
   describe('readGossipFqdnRestrictedFromFile', (): void => {
     afterEach((): void => {
       sinon.restore();


### PR DESCRIPTION
## Description

This pull request changes the following:

* Adds the `solo deployment config import` operation. On a machine with no local config, it discovers Solo deployments in a kube context by their `solo-remote-config` ConfigMaps, parses the selected one through the existing remote-config schema-migration pipeline, and non-destructively merges the deployment, namespace, and `cluster-ref → context` mapping into `local-config.yaml`.
* `--namespace` and `--context` are optional. When omitted, the current kube context is used and deployments are auto-discovered across all namespaces. A single match is selected automatically; multiple matches prompt interactively (and fail with actionable guidance under `--quiet-mode`). `--deployment` filters discovery by name.
* Non-destructive by design: an existing local deployment with conflicting settings is never overwritten without confirmation (hard failure in quiet mode), existing `cluster-ref → context` mappings are preserved, and re-importing an already-imported deployment is a no-op. For multi-cluster deployments, each unmapped cluster-ref prompts for its kube context.
* Adds the `SoloErrors.deployment.importFailed` factory (`SOLO-2031`).
* Extracts `Helpers.extractRemoteConfigDeploymentNames` from `remoteConfigsToDeploymentsTable` so both the table renderer and the new command share one parser (which now also tolerates unparseable ConfigMaps and skips empty deployment names).

### Related Issues

* Closes #5122
* Is blocking #5123
* Is blocking #5124

### Pull request (PR) checklist

* [x] This PR added tests (unit, integration, and/or end-to-end)
* [x] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [ ] Any technical debt has been documented as a separate issue and linked to this PR
* [ ] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [x] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [x] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* End-to-end against a live Kind (Docker) cluster with a real running Solo network (consensus nodes, haproxy, envoy, minio), whose `solo-remote-config` ConfigMap is at `schemaVersion 6`:
  * From an empty `SOLO_HOME` with no local config, `solo deployment config import --context <ctx> -q` reconstructed `local-config.yaml` correctly (deployment, namespace, and `cluster-ref → context` mapping), migrating the schema-v6 remote config through the pipeline.
  * `solo deployment config list` subsequently reported `status=connected`, confirming the reconstructed config connects to the cluster (the issue's acceptance criterion).
  * Re-running the import was an idempotent no-op — no duplicated deployment or cluster entries.
* Unit tests cover: happy-path reconstruction, idempotent re-import, no-deployment-found failure, and quiet-mode conflict protection (existing local deployment not overwritten).

The following was not tested:

* Multi-cluster deployments where remaining cluster-refs must be mapped to contexts interactively (logic is unit-covered via the conflict/prompt branches, but not exercised against a real multi-cluster network).
* The failure path on Windows.
