### PR TITLE
fix: detect shared-resources postgres pod so performance metrics report real TPS

### DIFF
--- a/src/business/runtime-state/services/metrics-server-impl.ts
+++ b/src/business/runtime-state/services/metrics-server-impl.ts
@@ -42,6 +42,15 @@ export class MetricsServerImpl implements MetricsServer {
     );
   }
 
+  /** True when the pod hosts the mirror node postgres DB (shared-resources, embedded, or legacy topology). */
+  public static isMirrorNodePostgresPodName(podName: string): boolean {
+    return (
+      podName.startsWith('solo-shared-resources-postgres') ||
+      (podName.startsWith('mirror-') && podName.includes('postgres')) ||
+      podName.startsWith('my-postgresql')
+    );
+  }
+
   public async getMetrics(
     snapshotName: string,
     namespaceLookup: NamespaceName = undefined,
@@ -88,8 +97,8 @@ export class MetricsServerImpl implements MetricsServer {
         if (podName.startsWith('network-node1-0')) {
           clusterNamespace = namespace;
         }
-        // Capture both internal mirror node postgres and external postgres pods
-        if ((podName.startsWith('mirror-') && podName.includes('postgres')) || podName.startsWith('my-postgresql')) {
+        // Capture the mirror node postgres pod across shared-resources, embedded, and legacy topologies.
+        if (MetricsServerImpl.isMirrorNodePostgresPodName(podName)) {
           mirrorNodePostgresPodName = podName;
           mirrorNodePostgresNamespace = namespace;
         }

--- a/test/unit/business/runtime-state/services/metrics-server-impl.test.ts
+++ b/test/unit/business/runtime-state/services/metrics-server-impl.test.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {MetricsServerImpl} from '../../../../../src/business/runtime-state/services/metrics-server-impl.js';
+
+describe('MetricsServerImpl', (): void => {
+  describe('isMirrorNodePostgresPodName', (): void => {
+    it('should match the shared-resources postgres pod', (): void => {
+      expect(MetricsServerImpl.isMirrorNodePostgresPodName('solo-shared-resources-postgres-0')).to.be.true;
+      expect(MetricsServerImpl.isMirrorNodePostgresPodName('solo-shared-resources-postgres-1')).to.be.true;
+    });
+
+    it('should match the embedded mirror node postgres pod', (): void => {
+      expect(MetricsServerImpl.isMirrorNodePostgresPodName('mirror-postgresql-0')).to.be.true;
+    });
+
+    it('should match the legacy standalone postgres pod', (): void => {
+      expect(MetricsServerImpl.isMirrorNodePostgresPodName('my-postgresql-0')).to.be.true;
+    });
+
+    it('should not match unrelated pods', (): void => {
+      expect(MetricsServerImpl.isMirrorNodePostgresPodName('network-node1-0')).to.be.false;
+      expect(MetricsServerImpl.isMirrorNodePostgresPodName('haproxy-node1-0')).to.be.false;
+      expect(MetricsServerImpl.isMirrorNodePostgresPodName('minio-pool-1-0')).to.be.false;
+      expect(MetricsServerImpl.isMirrorNodePostgresPodName('mirror-importer-0')).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION

<img width="1920" height="1070" alt="solo-4232-tps-chart" src="https://github.com/user-attachments/assets/54651e42-93cc-45c5-820c-75ffc18cdc88" />
## Description

This pull request changes the following:

* Fixes the performance-test metrics chart showing a flat **0 TPS** line. The chart derives transactions-per-second from the delta of the cumulative `transactionCount` metric, but `transactionCount` was always `0`, so the derived line was flat.
* Root cause: `MetricsServerImpl` only recognized the mirror node's *embedded* postgres pod (`mirror-*postgres*`, `my-postgresql*`). Once the mirror database moved to the **shared-resources** postgres (`solo-shared-resources-postgres-N`), the pod was never matched, `getNetworkTransactions()` short-circuited to `0`, and every metrics snapshot recorded zero transactions.
* Fix: recognize the shared-resources postgres pod during detection (via a small, unit-tested `MetricsServerImpl.isMirrorNodePostgresPodName()` helper) so the existing transaction-count query runs against it. **The query itself is unchanged** — the shared-resources postgres is the Bitnami `postgresql` chart with `usePasswordFiles` enabled, so it exposes the same `POSTGRES_PASSWORD_FILE` the query already reads (expanded container-side, so no secret reaches Solo's logs) and serves the `mirror_node` database via the `postgresql` container.
* The metrics-plotter (`scripts/metrics-plotter`) is intentionally **not** changed — its per-second delta derivation is correct; the flat line was purely a `transactionCount == 0` source-data problem.

### Related Issues

* Closes #4232

### Pull request (PR) checklist

* [x] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [ ] Any technical debt has been documented as a separate issue and linked to this PR
* [ ] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [x] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [x] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* Unit test covers pod-name detection across all three postgres topologies (shared-resources, embedded mirror-node, legacy standalone) plus negative cases; it fails against the pre-fix matcher and passes with the fix.
* Verified against source that the shared-resources postgres (`solo-shared-resources` umbrella chart → Bitnami `postgresql` subchart) exposes `POSTGRES_PASSWORD_FILE` at `/opt/bitnami/postgresql/secrets/password`, so the unchanged transaction-count query authenticates the same way it already does for the legacy embedded postgres.

The following was not tested:

* A live `select count(*) from transaction` against a running shared-resources postgres — the query is unchanged and equivalent to the proven legacy path, and true end-to-end validation is the performance-test workflow where the flat-0 chart originally appeared.

---

> Note: `.github/workflows/script/metrics.sh` line 7 (`echo "TPS"`) is a separate cosmetic defect in the spreadsheet-format log column; it does not affect the chart and is intentionally out of scope for this fix.
