### PR TITLE
fix: skip loading images in cluster if already loaded

### DIFF
--- a/src/integration/cache/impl/image-cache-handler.ts
+++ b/src/integration/cache/impl/image-cache-handler.ts
@@ -106,12 +106,7 @@ export class ImageCacheHandler implements CacheOperationHandler {
 
   public async load(target: string): Promise<SoloListrTask<AnyListrContext>[]> {
     const items: readonly CachedItem[] = await this.resolveExpectedCachedItems();
-
-    // Listing the cluster's loaded images once (a single `ctr images ls`) lets each subtask skip
-    // the per-image `kind load image-archive` shell-out when the image is already present. On a warm
-    // startup this avoids ~30 subprocess invocations and shaves several seconds off the run.
     const loadedImages: ReadonlySet<string> = await this.resolveLoadedClusterImages(target);
-
     return items.map((item): SoloListrTask<AnyListrContext> => {
       const name: string = `${item.target.name}:${item.target.version}`;
 
@@ -119,7 +114,6 @@ export class ImageCacheHandler implements CacheOperationHandler {
         title: `Loading ${name} into ${target}`,
         task: async (_, task): Promise<void> => {
           if (loadedImages.has(name)) {
-            // Already present in the cluster (warm startup); skip the redundant, expensive ctr import.
             task.title += ' - ' + chalk.green('already loaded, skipped');
             return;
           }
@@ -145,9 +139,6 @@ export class ImageCacheHandler implements CacheOperationHandler {
     });
   }
 
-  // Best-effort snapshot of the images already loaded into the cluster, keyed by `name:version` for
-  // the load() skip check. A listing failure (unreachable cluster, missing container engine) must not
-  // block loading, so it degrades to an empty set: every archive is then loaded as before.
   private async resolveLoadedClusterImages(clusterName: string): Promise<ReadonlySet<string>> {
     try {
       const images: readonly string[] = await this.engine.listLoadedImagesInCluster(clusterName);

--- a/src/integration/cache/impl/image-cache-handler.ts
+++ b/src/integration/cache/impl/image-cache-handler.ts
@@ -107,12 +107,23 @@ export class ImageCacheHandler implements CacheOperationHandler {
   public async load(target: string): Promise<SoloListrTask<AnyListrContext>[]> {
     const items: readonly CachedItem[] = await this.resolveExpectedCachedItems();
 
+    // Listing the cluster's loaded images once (a single `ctr images ls`) lets each subtask skip
+    // the per-image `kind load image-archive` shell-out when the image is already present. On a warm
+    // startup this avoids ~30 subprocess invocations and shaves several seconds off the run.
+    const loadedImages: ReadonlySet<string> = await this.resolveLoadedClusterImages(target);
+
     return items.map((item): SoloListrTask<AnyListrContext> => {
       const name: string = `${item.target.name}:${item.target.version}`;
 
       return {
         title: `Loading ${name} into ${target}`,
         task: async (_, task): Promise<void> => {
+          if (loadedImages.has(name)) {
+            // Already present in the cluster (warm startup); skip the redundant, expensive ctr import.
+            task.title += ' - ' + chalk.green('already loaded, skipped');
+            return;
+          }
+
           if (!(await this.inspector.exists(item.localPath))) {
             // Not cached (surfaced by pull / `cache image status`); keep it visible but non-fatal.
             task.title += ' - ' + chalk.yellow('archive not cached, skipped');
@@ -132,6 +143,20 @@ export class ImageCacheHandler implements CacheOperationHandler {
         },
       };
     });
+  }
+
+  // Best-effort snapshot of the images already loaded into the cluster, keyed by `name:version` for
+  // the load() skip check. A listing failure (unreachable cluster, missing container engine) must not
+  // block loading, so it degrades to an empty set: every archive is then loaded as before.
+  private async resolveLoadedClusterImages(clusterName: string): Promise<ReadonlySet<string>> {
+    try {
+      const images: readonly string[] = await this.engine.listLoadedImagesInCluster(clusterName);
+      return new Set<string>(images);
+    } catch (error) {
+      const message: string = ImageCacheHandler.getErrorMessage(error);
+      this.logger.debug(`Unable to list images already loaded in cluster ${clusterName}: ${message}`);
+      return new Set<string>();
+    }
   }
 
   public async clear(): Promise<void> {

--- a/test/unit/integration/cache/image-cache-handler.test.ts
+++ b/test/unit/integration/cache/image-cache-handler.test.ts
@@ -268,6 +268,58 @@ describe('ImageCacheHandler load', (): void => {
     expect(loadArchiveStub).to.have.been.calledOnceWithExactly('/tmp/busybox.tar', 'my-cluster');
   });
 
+  it('skips loading an archive already present in the cluster', async (): Promise<void> => {
+    const loadArchiveStub: SinonStub = sinon.stub().resolves();
+    const engine: ContainerEngineClient = {
+      pullImage: async (): Promise<void> => undefined,
+      saveImage: async (): Promise<void> => undefined,
+      saveImageArchive: async (): Promise<void> => undefined,
+      loadImage: async (): Promise<void> => undefined,
+      loadImageArchiveIntoCluster: loadArchiveStub,
+      removeImage: async (): Promise<void> => undefined,
+      listLoadedImagesInCluster: async (): Promise<readonly string[]> => ['docker.io/library/busybox:1.36.1'],
+    };
+
+    const handler: ImageCacheHandler = new ImageCacheHandler(
+      engine,
+      new StaticCacheTargetProvider([target]),
+      store,
+      inspector,
+      logger,
+    );
+
+    await runReturnedLoadTasks(handler, 'my-cluster');
+
+    expect(loadArchiveStub).to.not.have.been.called;
+  });
+
+  it('loads the archive when listing the cluster images fails', async (): Promise<void> => {
+    const loadArchiveStub: SinonStub = sinon.stub().resolves();
+    const engine: ContainerEngineClient = {
+      pullImage: async (): Promise<void> => undefined,
+      saveImage: async (): Promise<void> => undefined,
+      saveImageArchive: async (): Promise<void> => undefined,
+      loadImage: async (): Promise<void> => undefined,
+      loadImageArchiveIntoCluster: loadArchiveStub,
+      removeImage: async (): Promise<void> => undefined,
+      listLoadedImagesInCluster: async (): Promise<readonly string[]> => {
+        throw new Error('cluster unreachable');
+      },
+    };
+
+    const handler: ImageCacheHandler = new ImageCacheHandler(
+      engine,
+      new StaticCacheTargetProvider([target]),
+      store,
+      inspector,
+      logger,
+    );
+
+    await runReturnedLoadTasks(handler, 'my-cluster');
+
+    expect(loadArchiveStub).to.have.been.calledOnceWithExactly('/tmp/busybox.tar', 'my-cluster');
+  });
+
   it('records a failure and never throws when a load fails', async (): Promise<void> => {
     const engine: ContainerEngineClient = {
       pullImage: async (): Promise<void> => undefined,


### PR DESCRIPTION
## Description

This PR improves the way solo checks for already loaded images in the cluster, effectively reducing the execution time of the `solo cache image load` command for warm startup from ~10 seconds to ~2 seconds. 

### Related Issues

* Closes #5051
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
