### PR TITLE
fix: retry solo-deployment chart install to ride out transient API server outages

### DIFF
--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -1148,6 +1148,54 @@ export class NetworkCommand extends BaseCommand {
     await Promise.all(promises);
   }
 
+  /** Installs the solo-deployment chart with bounded retries to ride out transient API server outages. */
+  private async installSoloDeploymentChart(
+    config: NetworkDeployConfigClass,
+    clusterReference: ClusterReferenceName,
+  ): Promise<void> {
+    const kubeContext: Context = config.clusterRefs.get(clusterReference);
+
+    for (let attempt: number = 1; attempt <= constants.NETWORK_CHART_INSTALL_MAX_ATTEMPTS; attempt++) {
+      try {
+        await this.chartManager.upgrade(
+          config.namespace,
+          constants.SOLO_DEPLOYMENT_CHART,
+          constants.SOLO_DEPLOYMENT_CHART,
+          config.chartDirectory || constants.SOLO_TESTING_CHART_URL,
+          config.soloChartVersion,
+          config.chartValuesMap[clusterReference],
+          kubeContext,
+          false,
+          true,
+        );
+        return;
+      } catch (error) {
+        if (attempt === constants.NETWORK_CHART_INSTALL_MAX_ATTEMPTS) {
+          throw error;
+        }
+
+        this.logger.warn(
+          `Attempt ${attempt} of ${constants.NETWORK_CHART_INSTALL_MAX_ATTEMPTS} to install chart ` +
+            `'${constants.SOLO_DEPLOYMENT_CHART}' failed, retrying in ` +
+            `${constants.NETWORK_CHART_INSTALL_RETRY_DELAY_SECS} seconds`,
+          error,
+        );
+        await sleep(Duration.ofSeconds(constants.NETWORK_CHART_INSTALL_RETRY_DELAY_SECS));
+
+        try {
+          // remove the release left behind by the failed attempt so the retry starts from a clean state
+          await this.chartManager.uninstall(config.namespace, constants.SOLO_DEPLOYMENT_CHART, kubeContext);
+        } catch (uninstallError) {
+          // best-effort cleanup: a persistent failure will surface on the next upgrade attempt
+          this.logger.warn(
+            `Failed to uninstall chart '${constants.SOLO_DEPLOYMENT_CHART}' before retry`,
+            uninstallError,
+          );
+        }
+      }
+    }
+  }
+
   private async crdExists(context: string, crdName: string): Promise<boolean> {
     return await this.k8Factory.getK8(context).crds().ifExists(crdName);
   }
@@ -1498,7 +1546,7 @@ export class NetworkCommand extends BaseCommand {
         {
           title: `Install chart '${constants.SOLO_DEPLOYMENT_CHART}'`,
           task: async ({config}): Promise<void> => {
-            const {namespace, clusterRefs, chartValuesMap, chartDirectory} = config;
+            const {namespace, clusterRefs} = config;
 
             for (const [clusterReference] of clusterRefs) {
               const isInstalled: boolean = await this.chartManager.isChartInstalled(
@@ -1522,17 +1570,7 @@ export class NetworkCommand extends BaseCommand {
                 versions.MINIMUM_SOLO_CHART_VERSION,
               );
 
-              await this.chartManager.upgrade(
-                namespace,
-                constants.SOLO_DEPLOYMENT_CHART,
-                constants.SOLO_DEPLOYMENT_CHART,
-                chartDirectory || constants.SOLO_TESTING_CHART_URL,
-                config.soloChartVersion,
-                chartValuesMap[clusterReference],
-                clusterRefs.get(clusterReference),
-                false,
-                true,
-              );
+              await this.installSoloDeploymentChart(config, clusterReference);
               showVersionBanner(this.logger, constants.SOLO_DEPLOYMENT_CHART, config.soloChartVersion);
             }
           },

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -526,6 +526,11 @@ export const LOAD_BALANCER_CHECK_DELAY_SECS: number = +getEnvironmentVariable('L
 export const LOAD_BALANCER_CHECK_MAX_ATTEMPTS: number =
   +getEnvironmentVariable('LOAD_BALANCER_CHECK_MAX_ATTEMPTS') || 60;
 
+export const NETWORK_CHART_INSTALL_MAX_ATTEMPTS: number =
+  +getEnvironmentVariable('NETWORK_CHART_INSTALL_MAX_ATTEMPTS') || 3;
+export const NETWORK_CHART_INSTALL_RETRY_DELAY_SECS: number =
+  +getEnvironmentVariable('NETWORK_CHART_INSTALL_RETRY_DELAY_SECS') || 15;
+
 export const NETWORK_DESTROY_WAIT_TIMEOUT: number = +getEnvironmentVariable('NETWORK_DESTROY_WAIT_TIMEOUT') || 120;
 
 export const DEFAULT_LOCAL_CONFIG_FILE: string = 'local-config.yaml';

--- a/test/unit/commands/network.test.ts
+++ b/test/unit/commands/network.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import sinon, {type SinonStub} from 'sinon';
+import sinon, {type SinonSpyCall, type SinonStub} from 'sinon';
 import {before, beforeEach, describe, it} from 'mocha';
 import {expect} from 'chai';
 
@@ -42,6 +42,7 @@ import {type RemoteConfigRuntimeState} from '../../../src/business/runtime-state
 import {StringFacade} from '../../../src/business/runtime-state/facade/string-facade.js';
 import {SemanticVersion} from '../../../src/business/utils/semantic-version.js';
 import {HelmChartValues} from '../../../src/integration/helm/model/values.js';
+import {Duration} from '../../../src/core/time/duration.js';
 
 const testName: string = 'network-cmd-unit';
 const namespace: NamespaceName = NamespaceName.of(testName);
@@ -281,6 +282,61 @@ describe('NetworkCommand unit tests', (): void => {
         expect(options.chartManager.upgrade.args[0][1]).to.equal(constants.SOLO_DEPLOYMENT_CHART);
         expect(options.chartManager.upgrade.args[0][2]).to.equal(constants.SOLO_DEPLOYMENT_CHART);
         expect(options.chartManager.upgrade.args[0][3]).to.equal(constants.SOLO_TESTING_CHART_URL);
+      } finally {
+        sinon.restore();
+      }
+    });
+
+    it('retries the solo-deployment chart install after a transient failure', async (): Promise<void> => {
+      try {
+        // collapse the retry backoff so the test does not wait for the real delay
+        const ofSecondsStub: SinonStub = sinon.stub(Duration, 'ofSeconds');
+        ofSecondsStub.callThrough();
+        ofSecondsStub.withArgs(constants.NETWORK_CHART_INSTALL_RETRY_DELAY_SECS).returns(Duration.ofMillis(1));
+
+        const networkCommand: NetworkCommand = container.resolve(NetworkCommand);
+        options.remoteConfig.getConsensusNodes = sinon
+          .stub()
+          .returns([
+            new ConsensusNode('node1', 0, 'solo-e2e', 'solo-e2e', 'context1', 'base', 'pattern', 'fqdn', [], []),
+          ]);
+        options.remoteConfig.getContexts = sinon.stub().returns(['context1']);
+        const stubbedClusterReferences: ClusterReferences = new Map([['solo-e2e', 'context1']]);
+        options.remoteConfig.getClusterRefs = sinon.stub().returns(stubbedClusterReferences);
+        options.remoteConfig.updateComponentVersion = sinon.stub();
+        options.remoteConfig.configuration.state = {};
+        // @ts-expect-error - TS2341: to mock
+        networkCommand.getBlockNodes = sinon.stub().returns([]);
+        // @ts-expect-error - TS2341: to mock
+        networkCommand.ensurePodLogsCrd = sinon.stub().returns(true);
+        // @ts-expect-error - TS2341: to mock
+        networkCommand.ensurePrometheusOperatorCrds = sinon.stub().returns(true);
+
+        // @ts-expect-error - TS2341: to mock
+        networkCommand.componentFactory = {
+          createNewEnvoyProxyComponent: sinon.stub(),
+          createNewHaProxyComponent: sinon.stub(),
+        };
+
+        const upgradeStub: SinonStub = sinon.stub();
+        upgradeStub.resolves(true);
+        upgradeStub
+          .onFirstCall()
+          .rejects(new Error('Post "https://127.0.0.1:6443/apis/monitoring.grafana.com/v1alpha2/podlogs": EOF'));
+        options.chartManager.upgrade = upgradeStub;
+
+        await networkCommand.deploy(argv.build());
+
+        const upgradeCalls: SinonSpyCall[] = upgradeStub
+          .getCalls()
+          .filter((call: SinonSpyCall): boolean => call.args[1] === constants.SOLO_DEPLOYMENT_CHART);
+        expect(upgradeCalls).to.have.lengthOf(2);
+
+        const uninstallCalls: SinonSpyCall[] = options.chartManager.uninstall
+          .getCalls()
+          .filter((call: SinonSpyCall): boolean => call.args[1] === constants.SOLO_DEPLOYMENT_CHART);
+        // one uninstall for the pre-existing release plus one clean-up between the failed and retried attempts
+        expect(uninstallCalls).to.have.lengthOf(2);
       } finally {
         sinon.restore();
       }


### PR DESCRIPTION
## Description

The one-shot Standard Runner deploy failed when the `solo-deployment` chart's post-install hook (creating the Grafana `PodLog` custom resource) hit a transient kube-apiserver outage — the POST died with `EOF`, and in the same second solo's own lease read failed too, confirming the kind control plane was briefly unavailable. Helm treats a failed hook as a failed release, so the whole deploy aborted on one transient request.

The `Install chart 'solo-deployment'` step now retries the Helm upgrade up to `NETWORK_CHART_INSTALL_MAX_ATTEMPTS` times (default 3), waiting `NETWORK_CHART_INSTALL_RETRY_DELAY_SECS` seconds (default 15) between attempts and uninstalling the failed release before each retry so it starts from a clean state (avoiding Helm's "has no deployed releases" trap). The retry does not touch `config.isUpgrade`, which must only reflect the pre-deploy release state since it gates adding envoy/haproxy components to remote config.

Both knobs are env-overridable, following the existing `LOAD_BALANCER_CHECK_*` pattern.

Added a unit test that rejects the first upgrade with the exact `EOF` error from the issue and asserts the deploy succeeds on retry, with the inter-attempt cleanup uninstall.

### Related Issues

* Closes #5208