### PR TITLE
fix: retry kubectl exec on transient API server tunnel errors

### DIFF
--- a/src/integration/kube/k8-client/resources/container/k8-client-container.ts
+++ b/src/integration/kube/k8-client/resources/container/k8-client-container.ts
@@ -342,10 +342,10 @@ export class K8ClientContainer implements Container {
 
     const arguments_: string[] = ['exec', podName, '-n', namespace.name, '-c', containerName, '--', ...command];
 
-    // During rolling restarts, kubelet may report "container not found" for a few seconds
-    // even when the pod object is present. Retry that transient state.
+    // Retry transient exec failures that occur before the command runs: kubelet reporting "container not found" during rolling restarts, and API server to kubelet tunnel errors (connection upgrade, dial, timeout).
     const maxAttempts: number = 30;
-    const retryableContainerNotReady: RegExp = /(container not found|unable to upgrade connection)/i;
+    const retryableTransientFailure: RegExp =
+      /(container not found|unable to upgrade connection|internal error occurred: timeout occurred|error dialing backend)/i;
 
     for (let attempt: number = 1; attempt <= maxAttempts; attempt++) {
       try {
@@ -353,10 +353,13 @@ export class K8ClientContainer implements Container {
       } catch (error) {
         const message: string = error instanceof Error ? error.message : `${error}`;
 
-        if (!retryableContainerNotReady.test(message) || attempt === maxAttempts) {
+        if (!retryableTransientFailure.test(message) || attempt === maxAttempts) {
           throw error;
         }
 
+        this.logger.warn(
+          `execContainer: transient failure on attempt ${attempt} of ${maxAttempts} [podName: ${podName} -n ${namespace.name} -c ${containerName}], retrying: ${message}`,
+        );
         await sleep(Duration.ofMillis(1000));
       }
     }

--- a/test/unit/integration/kube/k8-client-container.test.ts
+++ b/test/unit/integration/kube/k8-client-container.test.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {expect} from 'chai';
+import {afterEach, beforeEach, describe, it} from 'mocha';
+import sinon, {type SinonStub} from 'sinon';
+import {K8ClientContainer} from '../../../../src/integration/kube/k8-client/resources/container/k8-client-container.js';
+import {KubeContainerOperationFailedError} from '../../../../src/integration/kube/errors/kube-container-operation-failed-error.js';
+import {ContainerReference} from '../../../../src/integration/kube/resources/container/container-reference.js';
+import {ContainerName} from '../../../../src/integration/kube/resources/container/container-name.js';
+import {PodReference} from '../../../../src/integration/kube/resources/pod/pod-reference.js';
+import {PodName} from '../../../../src/integration/kube/resources/pod/pod-name.js';
+import {type Pods} from '../../../../src/integration/kube/resources/pod/pods.js';
+import {NamespaceName} from '../../../../src/types/namespace/namespace-name.js';
+import {resetForTest} from '../../../test-container.js';
+
+function kubectlFailure(stderr: string): KubeContainerOperationFailedError {
+  return new KubeContainerOperationFailedError(
+    'container call: kubectl exec test-pod, failed with code 1',
+    new Error(stderr),
+  );
+}
+
+describe('K8ClientContainer execContainer', (): void => {
+  const containerReference: ContainerReference = ContainerReference.of(
+    PodReference.of(NamespaceName.of('test-namespace'), PodName.of('test-pod')),
+    ContainerName.of('test-container'),
+  );
+
+  let containerClient: K8ClientContainer;
+  let execKubectlStub: SinonStub;
+
+  beforeEach((): void => {
+    resetForTest();
+    const pods: Pods = {waitForPodByReference: sinon.stub().resolves({})} as unknown as Pods;
+    containerClient = new K8ClientContainer(
+      {getCurrentContext: (): string => 'test-context'} as never,
+      containerReference,
+      pods,
+      '',
+    );
+    execKubectlStub = sinon.stub(containerClient, 'execKubectl' as never);
+  });
+
+  afterEach((): void => {
+    sinon.restore();
+  });
+
+  for (const stderr of [
+    'error: Internal error occurred: Timeout occurred',
+    'Error from server: error dialing backend: dial tcp 10.89.0.2:10250: connect: connection refused',
+    'error: unable to upgrade connection: container not found ("postgresql")',
+  ]) {
+    it(`retries and succeeds after transient failure: ${stderr}`, async (): Promise<void> => {
+      execKubectlStub.onFirstCall().rejects(kubectlFailure(stderr));
+      execKubectlStub.onSecondCall().resolves('ok');
+
+      const result: string = await containerClient.execContainer('chmod +x /tmp/init-postgres.sh');
+
+      expect(result).to.equal('ok');
+      expect(execKubectlStub).to.have.been.calledTwice;
+    });
+  }
+
+  it('does not retry a non-transient failure', async (): Promise<void> => {
+    const failure: KubeContainerOperationFailedError = kubectlFailure(
+      "chmod: cannot access '/tmp/missing.sh': No such file or directory",
+    );
+    execKubectlStub.rejects(failure);
+
+    try {
+      await containerClient.execContainer('chmod +x /tmp/missing.sh');
+      expect.fail('Expected execContainer to reject');
+    } catch (error) {
+      expect(error).to.equal(failure);
+    }
+
+    expect(execKubectlStub).to.have.been.calledOnce;
+  });
+});


### PR DESCRIPTION
## Description

The one-shot Podman run failed while `solo mirror node add` was copying the Mirror Node Postgres initialization script: `kubectl exec ... chmod +x /tmp/init-postgres.sh` died with `error: Internal error occurred: Timeout occurred`. That error is the kube-apiserver timing out while establishing the exec tunnel to the kubelet — a transient condition on the resource-starved CI runner (the same run logged the low-resources warning: 4 CPUs against the recommended 6).

`execContainer` already retries transient exec failures up to 30 times, but its retryable pattern only matched `container not found` and `unable to upgrade connection`, so this timeout escaped on the first attempt and aborted the whole deploy. This PR adds the `Internal error occurred: Timeout occurred` and sibling `error dialing backend` variants to the pattern. Both occur while establishing the exec stream — before the command runs — so retrying is safe even for non-idempotent commands, exactly like the connection-upgrade failure already retried. Fixing it in `execContainer` covers every `kubectl exec` call site, not just the postgres init path.

Each retry now also logs a warning with the attempt count and failure message, so flaky runs show the retries in CI logs instead of retrying silently.

Added a unit test that stubs the kubectl invocation and asserts retry-then-success for all three transient error variants, and no retry for a genuine command failure.

### Related Issues

* Closes #5198