### PR TITLE
fix: replace deprecated account balance queries

### DIFF
--- a/examples/network-with-domain-names/sdk-network-connection/solo-network-connection.js
+++ b/examples/network-with-domain-names/sdk-network-connection/solo-network-connection.js
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import {AccountBalanceQuery, AccountId, Client, Logger, LogLevel, PrivateKey} from '@hiero-ledger/sdk';
+import {AccountId, AccountInfoQuery, Client, Logger, LogLevel, PrivateKey} from '@hiero-ledger/sdk';
 
 export const TREASURY_ACCOUNT_ID = '0.0.2';
 export const GENESIS_KEY =
@@ -39,10 +39,10 @@ async function main() {
   // check balance
   console.log('checking balance');
   try {
-    const balance = await new AccountBalanceQuery().setAccountId('0.0.2').execute(nodeClient);
+    const accountInfo = await new AccountInfoQuery().setAccountId('0.0.2').execute(nodeClient);
 
     console.log('checking balance...end');
-    console.log(`Account ${treasuryAccountId} balance: ${balance?.hbars}`);
+    console.log(`Account ${treasuryAccountId} balance: ${accountInfo?.balance}`);
     console.log('...end');
   } catch (error) {
     console.log('failure');

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -24,9 +24,9 @@ import {
 } from '../../core/constants.js';
 import {Templates} from '../../core/templates.js';
 import {
-  AccountBalance,
-  AccountBalanceQuery,
   AccountId,
+  type AccountInfo,
+  AccountInfoQuery,
   AccountUpdateTransaction,
   type Client,
   FileAppendTransaction,
@@ -848,26 +848,26 @@ export class NodeCommandTasks {
     client.setOperator(treasuryAccountId, treasuryPrivateKey);
 
     // check balance
-    let treasuryBalance: AccountBalance;
+    let treasuryAccountInfo: AccountInfo;
     try {
-      treasuryBalance = await new AccountBalanceQuery().setAccountId(treasuryAccountId).execute(client);
+      treasuryAccountInfo = await new AccountInfoQuery().setAccountId(treasuryAccountId).execute(client);
     } catch (error) {
       throw new SoloErrors.component.accountBalanceQueryFailed(treasuryAccountId, error);
     }
 
-    this.logger.debug(`Account ${treasuryAccountId} balance: ${treasuryBalance.hbars}`);
+    this.logger.debug(`Account ${treasuryAccountId} balance: ${treasuryAccountInfo.balance}`);
 
     // get some initial balance
     await this.accountManager.transferAmount(treasuryAccountId, accountId, stakeAmount);
 
     // check balance
-    let balance: AccountBalance;
+    let accountInfo: AccountInfo;
     try {
-      balance = await new AccountBalanceQuery().setAccountId(accountId).execute(client);
+      accountInfo = await new AccountInfoQuery().setAccountId(accountId).execute(client);
     } catch (error) {
       throw new SoloErrors.component.accountBalanceQueryFailed(accountId, error);
     }
-    this.logger.debug(`Account ${accountId} balance: ${balance.hbars}`);
+    this.logger.debug(`Account ${accountId} balance: ${accountInfo.balance}`);
 
     // Create the transaction
     const transaction: AccountUpdateTransaction = new AccountUpdateTransaction()
@@ -1000,14 +1000,14 @@ export class NodeCommandTasks {
         const treasuryAccountId: AccountId = this.accountManager.getTreasuryAccountId(deployment);
 
         // query the balance
-        let balance: AccountBalance;
+        let accountInfo: AccountInfo;
         try {
-          balance = await new AccountBalanceQuery().setAccountId(freezeAccountId).execute(nodeClient);
+          accountInfo = await new AccountInfoQuery().setAccountId(freezeAccountId).execute(nodeClient);
         } catch (error) {
           throw new SoloErrors.component.accountBalanceQueryFailed(freezeAccountId, error);
         }
 
-        this.logger.debug(`Freeze admin account balance: ${balance.hbars}`);
+        this.logger.debug(`Freeze admin account balance: ${accountInfo.balance}`);
 
         // transfer some tiny amount to the freeze admin account
         await this.accountManager.transferAmount(treasuryAccountId, freezeAccountId, 100_000);
@@ -1061,14 +1061,14 @@ export class NodeCommandTasks {
         const freezeAdminAccountId: AccountId = this.accountManager.getFreezeAccountId(deployment);
 
         // query the balance
-        let balance: AccountBalance;
+        let accountInfo: AccountInfo;
         try {
-          balance = await new AccountBalanceQuery().setAccountId(freezeAdminAccountId).execute(nodeClient);
+          accountInfo = await new AccountInfoQuery().setAccountId(freezeAdminAccountId).execute(nodeClient);
         } catch (error) {
           throw new SoloErrors.component.accountBalanceQueryFailed(freezeAdminAccountId, error);
         }
 
-        this.logger.debug(`Freeze admin account balance: ${balance.hbars}`);
+        this.logger.debug(`Freeze admin account balance: ${accountInfo.balance}`);
 
         nodeClient.setOperator(freezeAdminAccountId, freezeAdminPrivateKey);
         let freezeUpgradeReceipt: TransactionReceipt;

--- a/test/e2e/commands/separate-node-add.test.ts
+++ b/test/e2e/commands/separate-node-add.test.ts
@@ -18,9 +18,9 @@ import {type NodeAlias} from '../../../src/types/aliases.js';
 import {type DeploymentName} from '../../../src/types/index.js';
 import {type NodeServiceMapping} from '../../../src/types/mappings/node-service-mapping.js';
 import {
-  type AccountBalance,
-  AccountBalanceQuery,
   AccountCreateTransaction,
+  type AccountInfo,
+  AccountInfoQuery,
   Hbar,
   HbarUnit,
   PrivateKey,
@@ -189,11 +189,11 @@ export function testSeparateNodeAdd(
         argv.getArg<boolean>(flags.forcePortForward),
       );
 
-      const balance: AccountBalance = await new AccountBalanceQuery()
+      const accountInfoAfterRestart: AccountInfo = await new AccountInfoQuery()
         .setAccountId(accountInfo.accountId)
         .execute(accountManager._nodeClient);
 
-      expect(balance.hbars).to.be.eql(Hbar.from(accountInfo.balance, HbarUnit.Hbar));
+      expect(accountInfoAfterRestart.balance).to.be.eql(Hbar.from(accountInfo.balance, HbarUnit.Hbar));
     }).timeout(Duration.ofMinutes(10).toMillis());
   }).timeout(Duration.ofMinutes(20).toMillis());
 }

--- a/test/test-utility.ts
+++ b/test/test-utility.ts
@@ -16,10 +16,10 @@ import {type NodeCommand} from '../src/commands/node/index.js';
 import {type DependencyManager} from '../src/core/dependency-managers/index.js';
 import {sleep} from '../src/core/helpers.js';
 import {
-  type AccountBalance,
-  AccountBalanceQuery,
   AccountCreateTransaction,
   type AccountId,
+  type AccountInfo,
+  AccountInfoQuery,
   Hbar,
   HbarUnit,
   PrivateKey,
@@ -430,11 +430,11 @@ export async function queryBalance(
   );
   expect(accountManager._nodeClient).to.not.be.undefined;
 
-  const balance: AccountBalance = await new AccountBalanceQuery()
+  const accountInfo: AccountInfo = await new AccountInfoQuery()
     .setAccountId(accountManager._nodeClient.getOperator().accountId)
     .execute(accountManager._nodeClient);
 
-  expect(balance.hbars).to.not.be.null;
+  expect(accountInfo.balance).to.not.be.null;
   await sleep(Duration.ofSeconds(1));
 }
 


### PR DESCRIPTION
## Description

This pull request changes the following:

* Replaces Hedera SDK `AccountBalanceQuery` usage with `AccountInfoQuery` before `GetAccountBalance` is deprecated in consensus node v0.77.0.
* Reads HBAR balances from `AccountInfo.balance` in node staking and freeze-upgrade workflows.
* Updates shared end-to-end helpers and the SDK network connection example to use the supported query.

### Related Issues

* Closes #5241

### Pull request (PR) checklist

* [ ] This PR added tests (unit, integration, and/or end-to-end)
* [x] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [x] Any technical debt has been documented as a separate issue and linked to this PR
* [x] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [ ] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [ ] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* `task build:compile`
* `task build`
* Verified no executable `AccountBalanceQuery` imports or constructions remain in `src`, `test`, or `examples`.

The following was not tested:

* Full end-to-end suites were not run because they require a deployed Kubernetes network.

<details>
<summary>Commit message guidelines</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type. NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix | Description | Semantic Version Update | Captured in Release Notes |
|---|---|---|---|
| feat: | a new feature | MINOR | Yes |
| fix: | a bug fix | PATCH | Yes |
| perf: | performance | PATCH | Yes |
| refactor: | code change that isn't feature or fix | none | No |
| test: | adding missing tests | none | No |
| docs: | changes to documentation | none | Yes |
| build: | changes to build process | none | No |
| ci: | changes to CI configuration | none | No |
| style: | formatting, missing semi-colons, etc | none | No |
| chore: | updating grunt tasks etc; no production code change | none | No |

</details>