### PR TITLE
ci: retry POSIX dependency setup

### DIFF
--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -253,12 +253,15 @@ jobs:
       - name: Setup Posix Dependencies
         id: set-posix-dependencies
         if: ${{ inputs.runner != 'windows-latest' && !cancelled() && !failure() }}
-        timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
-        run: |
-          # Configure APT to use main Ubuntu archive (disable mirror rotation)
-          sudo sed -i 's|http://[a-z.]*.ubuntu.com|http://archive.ubuntu.com|g' /etc/apt/sources.list
-          # Install jq (a lightweight and flexible command-line JSON processor)
-          sudo apt-get update && sudo apt-get install -y jq
+        uses: step-security/retry@38808b4332b98bb36ca031abff0c100231608288 # v4.0.0
+        with:
+          max_attempts: 3
+          timeout_minutes: ${{ env.STEP_TIMEOUT_MINUTES }}
+          command: |
+            # Configure APT to use main Ubuntu archive (disable mirror rotation)
+            sudo sed -i 's|http://[a-z.]*.ubuntu.com|http://archive.ubuntu.com|g' /etc/apt/sources.list
+            # Install jq (a lightweight and flexible command-line JSON processor)
+            sudo apt-get update && sudo apt-get install -y jq
 
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0


### PR DESCRIPTION
## Description

This pull request changes the following:

* Wraps the `Setup Posix Dependencies` step in `.github/workflows/zxc-e2e-test.yaml` with the pinned `step-security/retry` v4 action.
* Retries transient APT failures up to three times with the existing five-minute timeout per attempt.
* Preserves the existing runner condition and POSIX dependency installation commands.

The setup previously ran only once, so intermittent Ubuntu archive or package download failures caused the entire E2E job to fail. This change makes the workflow resilient to those transient failures without changing application behavior.

### Related Issues

* Closes #5193

### Pull request (PR) checklist

* [ ] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [x] Any technical debt has been documented as a separate issue and linked to this PR
* [x] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [ ] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [ ] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* `git diff --check`
* Parsed the updated workflow successfully with Prettier.

The following was not tested:

* The retry behavior was not exercised in GitHub Actions because it requires a transient APT failure.

<details>
<summary>Commit message guidelines</summary>

We use Conventional Commits. This PR uses the `ci:` prefix because it changes CI workflow configuration.

</details>
