### PR TITLE
fix(one-shot): reconcile printed versions with values-file overrides

### DIFF
--- a/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
+++ b/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
@@ -255,6 +255,9 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
             if (!config.setupConfiguration[releaseTagKey]) {
               config.setupConfiguration[releaseTagKey] = versions.consensus;
             }
+
+            this.reconcileEffectiveVersions(config);
+
             this.logger.addLogBindings({
               clusterReference: config.clusterRef,
               context: config.context,
@@ -1174,6 +1177,32 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
         'For more information on public and private keys see: https://docs.hedera.com/hedera/core-concepts/keys-and-signatures',
       );
     }
+  }
+
+  /**
+   * The per-component sections of a values file (network, blockNode, mirrorNode, explorerNode,
+   * relayNode) can override a component's version independently of the `config.versions` resolved
+   * from argv/defaults. Reconciles config.versions with those overrides, mirroring the same
+   * override precedence the deploy argv builders use, so the "Versions Used" summary reflects what
+   * is actually deployed.
+   */
+  private reconcileEffectiveVersions(config: OneShotSingleDeployConfigClass): void {
+    const releaseTagKey: string = flags.getFormattedFlagKey(flags.consensusNodeVersion);
+    const soloChartVersionKey: string = flags.getFormattedFlagKey(flags.soloChartVersion);
+    const blockNodeVersionKey: string = flags.getFormattedFlagKey(flags.blockNodeVersion);
+    const mirrorNodeVersionKey: string = flags.getFormattedFlagKey(flags.mirrorNodeVersion);
+    const explorerVersionKey: string = flags.getFormattedFlagKey(flags.explorerVersion);
+    const relayVersionKey: string = flags.getFormattedFlagKey(flags.relayVersion);
+
+    config.versions.consensus = (config.networkConfiguration[releaseTagKey] as string) ?? config.versions.consensus;
+    config.versions.soloChart =
+      (config.networkConfiguration[soloChartVersionKey] as string) ?? config.versions.soloChart;
+    config.versions.blockNode =
+      (config.blockNodeConfiguration[blockNodeVersionKey] as string) ?? config.versions.blockNode;
+    config.versions.mirror = (config.mirrorNodeConfiguration[mirrorNodeVersionKey] as string) ?? config.versions.mirror;
+    config.versions.explorer =
+      (config.explorerNodeConfiguration[explorerVersionKey] as string) ?? config.versions.explorer;
+    config.versions.relay = (config.relayNodeConfiguration[relayVersionKey] as string) ?? config.versions.relay;
   }
 
   private async confirmNonKindContext(

--- a/test/unit/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.test.ts
+++ b/test/unit/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.test.ts
@@ -14,6 +14,7 @@ import {ComponentTypes} from '../../../../../../src/core/config/remote/enumerati
 import {DeploymentPhase} from '../../../../../../src/data/schema/model/remote/deployment-phase.js';
 import {ConfirmationRequiredSoloError} from '../../../../../../src/core/errors/classes/validation/confirmation-required-solo-error.js';
 import {UserBreak} from '../../../../../../src/core/errors/user-break.js';
+import {Flags} from '../../../../../../src/commands/flags.js';
 
 type MockType = any;
 type MockListr = MockType;
@@ -577,5 +578,90 @@ describe('DefaultOneShotDeployOrchestrator Confirm cleanup of existing deploymen
     } catch (error) {
       expect(error).to.be.instanceOf(UserBreak);
     }
+  });
+});
+
+describe('DefaultOneShotDeployOrchestrator reconcileEffectiveVersions', (): void => {
+  const releaseTagKey: string = Flags.getFormattedFlagKey(Flags.consensusNodeVersion);
+  const soloChartVersionKey: string = Flags.getFormattedFlagKey(Flags.soloChartVersion);
+  const blockNodeVersionKey: string = Flags.getFormattedFlagKey(Flags.blockNodeVersion);
+  const mirrorNodeVersionKey: string = Flags.getFormattedFlagKey(Flags.mirrorNodeVersion);
+  const explorerVersionKey: string = Flags.getFormattedFlagKey(Flags.explorerVersion);
+  const relayVersionKey: string = Flags.getFormattedFlagKey(Flags.relayVersion);
+
+  it('leaves the resolved versions untouched when no values file overrides are present', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeOrchestrator();
+    const config: OneShotSingleDeployConfigClass = makeConfig({
+      versions: {
+        soloChart: '0.64.0',
+        consensus: 'v0.74.0',
+        mirror: 'v0.158.0',
+        explorer: '26.1.0',
+        relay: '0.77.0',
+        blockNode: '0.38.0',
+      },
+    });
+
+    // @ts-expect-error - to access private method
+    orchestrator.reconcileEffectiveVersions(config);
+
+    expect(config.versions.consensus).to.equal('v0.74.0');
+    expect(config.versions.soloChart).to.equal('0.64.0');
+    expect(config.versions.blockNode).to.equal('0.38.0');
+    expect(config.versions.mirror).to.equal('v0.158.0');
+    expect(config.versions.explorer).to.equal('26.1.0');
+    expect(config.versions.relay).to.equal('0.77.0');
+  });
+
+  it('reflects a consensus node version overridden via the values file network/setup sections', (): void => {
+    // Reproduces https://github.com/hiero-ledger/solo/issues/5384: a values file that only sets
+    // --consensus-node-version under `network`/`setup` (not as a top-level CLI flag) must be
+    // reflected in the printed "Versions Used" summary, not just in the actual deployment.
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeOrchestrator();
+    const config: OneShotSingleDeployConfigClass = makeConfig({
+      networkConfiguration: {[releaseTagKey]: 'v0.77.0-rc.2'},
+      setupConfiguration: {[releaseTagKey]: 'v0.77.0-rc.2'},
+      versions: {
+        soloChart: '0.64.0',
+        consensus: 'v0.74.0',
+        mirror: 'v0.158.0',
+        explorer: '26.1.0',
+        relay: '0.77.0',
+        blockNode: '0.38.0',
+      },
+    });
+
+    // @ts-expect-error - to access private method
+    orchestrator.reconcileEffectiveVersions(config);
+
+    expect(config.versions.consensus).to.equal('v0.77.0-rc.2');
+  });
+
+  it('reflects per-component version overrides for block, mirror, explorer, and relay nodes', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeOrchestrator();
+    const config: OneShotSingleDeployConfigClass = makeConfig({
+      networkConfiguration: {[soloChartVersionKey]: '0.65.0'},
+      blockNodeConfiguration: {[blockNodeVersionKey]: '0.39.0'},
+      mirrorNodeConfiguration: {[mirrorNodeVersionKey]: 'v0.159.0'},
+      explorerNodeConfiguration: {[explorerVersionKey]: '26.2.0'},
+      relayNodeConfiguration: {[relayVersionKey]: '0.78.0'},
+      versions: {
+        soloChart: '0.64.0',
+        consensus: 'v0.74.0',
+        mirror: 'v0.158.0',
+        explorer: '26.1.0',
+        relay: '0.77.0',
+        blockNode: '0.38.0',
+      },
+    });
+
+    // @ts-expect-error - to access private method
+    orchestrator.reconcileEffectiveVersions(config);
+
+    expect(config.versions.soloChart).to.equal('0.65.0');
+    expect(config.versions.blockNode).to.equal('0.39.0');
+    expect(config.versions.mirror).to.equal('v0.159.0');
+    expect(config.versions.explorer).to.equal('26.2.0');
+    expect(config.versions.relay).to.equal('0.78.0');
   });
 });


### PR DESCRIPTION
## Summary

Fixes #5384 — `solo one-shot falcon deploy` prints the wrong component versions in the "Versions Used" summary when a `--values-file` overrides a version for an individual component.

## Root Cause

In `DefaultOneShotDeployOrchestrator.buildDeployPipeline` (Initialize phase), `config.versions` is resolved from `argv` via `DeployArgvBuilders.resolveOneShotComponentVersions(argv, edgeEnabled)` **before** the `--values-file` is parsed:

```
src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts:171-204
```

The values file is parsed afterward and its per-component sections (`network`, `setup`, `blockNode`, `mirrorNode`, `explorerNode`, `relayNode`) are copied verbatim into `config.networkConfiguration`, `config.blockNodeConfiguration`, etc. Those per-component objects are what actually get merged into each component's deploy argv in `deploy-argv-builders.ts`, e.g.:

```ts
// buildMirrorNodeArgv, deploy-argv-builders.ts:240-249
const mirrorLocalConfig: AnyObject = {
  [optionFromFlag(Flags.mirrorNodeVersion)]: config.versions.mirror,
  ...config.mirrorNodeConfiguration,   // <- values-file override wins here
  ...
};
```

Because the object spread puts `config.xConfiguration` after the default version flag, a version set in the values file's per-component section always wins for the *actual deploy*. But `config.versions` itself is never updated to reflect that override, so `showVersions()` (`default-one-shot-deploy-orchestrator.ts:994-1005`), which prints straight from `config.versions`, shows the stale pre-values-file default instead of what was actually deployed.

This reproduces the issue exactly: the reporter's values file sets `--consensus-node-version: v0.77.0-rc.2` only under `network:`/`setup:` (not as a top-level CLI flag), so `resolveOneShotComponentVersions` — which only reads `argv` — resolves the default `v0.74.0`, and that stale value is what gets printed, even though `v0.77.0-rc.2` is what's actually deployed.

## Fix

Added `DefaultOneShotDeployOrchestrator.reconcileEffectiveVersions(config)`, called once the values file has been parsed and the network/setup consensus-version defaulting has run. For each of the 6 versions, it prefers the value found in that component's resolved configuration object (the same key the argv builders would use), falling back to the originally resolved default — mirroring the exact override precedence used when building each component's deploy argv, so the printed summary always matches what's actually deployed.

## Evidence

Added `test/unit/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.test.ts` — `DefaultOneShotDeployOrchestrator reconcileEffectiveVersions`:
- unchanged when no values-file overrides are present
- reproduces the reported scenario: `--consensus-node-version` set only under `network`/`setup` is reflected in `config.versions.consensus` after reconciliation
- covers block/mirror/explorer/relay per-component version overrides

```
DefaultOneShotDeployOrchestrator reconcileEffectiveVersions
  ✔ leaves the resolved versions untouched when no values file overrides are present
  ✔ reflects a consensus node version overridden via the values file network/setup sections
  ✔ reflects per-component version overrides for block, mirror, explorer, and relay nodes

31 passing (57ms)
```

Also verified:
- `npx tsc --noEmit -p .` — clean (pre-existing unrelated errors in `test/unit/commands/wraps-key-path.test.ts` confirmed present on `main` before this change)
- `npx eslint` on both changed files — clean

## Test plan

- [x] Added unit tests covering the reported scenario and the general per-component override case
- [x] Existing orchestrator unit tests still pass (31/31)
- [x] Type-check and lint clean on changed files