### PR TITLE
feat: assert the highest migration version never exceeds the declared schema version

### DIFF
--- a/src/business/runtime-state/config/remote/remote-config-runtime-state.ts
+++ b/src/business/runtime-state/config/remote/remote-config-runtime-state.ts
@@ -224,7 +224,7 @@ export class RemoteConfigRuntimeState implements RemoteConfigRuntimeStateApi {
     );
 
     const remoteConfig: RemoteConfigSchema = new RemoteConfigSchema(
-      6,
+      RemoteConfigSchema.SCHEMA_VERSION.major,
       new RemoteConfigMetadataSchema(new Date(), userIdentity),
       new ApplicationVersionsSchema(cliVersion),
       [cluster],

--- a/src/data/schema/migration/api/schema-definition-base.ts
+++ b/src/data/schema/migration/api/schema-definition-base.ts
@@ -34,8 +34,8 @@ export abstract class SchemaDefinitionBase<T> implements SchemaDefinition<T> {
     if (this.migrations.length === 0) {
       return;
     }
-    // eslint-disable-next-line unicorn/no-array-sort
-    const versionJumps: number[] = this.migrations.map((value): number => value.version.major).sort();
+    const versionJumps: number[] = this.migrations.map((value): number => value.version.major);
+    versionJumps.sort((left: number, right: number): number => left - right);
 
     for (let index: number = 1; index < versionJumps.length; index++) {
       if (versionJumps[index] === versionJumps[index - 1]) {
@@ -43,17 +43,31 @@ export abstract class SchemaDefinitionBase<T> implements SchemaDefinition<T> {
       }
     }
 
-    let currentVersion: SemanticVersion<number> = this.nextVersionJump(new SemanticVersion(0));
+    // A migration which produces data newer than the declared schema version means the declared version was never
+    // bumped alongside the migration. Newly created configurations would then be stamped with a stale version and
+    // needlessly re-migrated on the next load.
+    const newestMigrationVersion: number = versionJumps.at(-1);
+    if (newestMigrationVersion > this.version.major) {
+      throw new SchemaValidationError(
+        `Migration version '${newestMigrationVersion}' is newer than the declared schema version ` +
+          `'${this.version.major}'; the declared schema version must be bumped alongside the migration`,
+      );
+    }
+
+    // Walk the chain from the unversioned form (version zero) and assert that every jump lands exactly on the next
+    // registered migration version. The walk stops on the newest migration; looking beyond it would always report a
+    // gap because no migration exists to advance past the current schema version.
+    let currentVersion: SemanticVersion<number> = new SemanticVersion(0);
 
     for (const versionJump of versionJumps) {
-      const v: SemanticVersion<number> = new SemanticVersion(versionJump);
-      if (!v.equals(currentVersion)) {
+      const nextVersion: SemanticVersion<number> = this.nextVersionJump(currentVersion);
+      if (!nextVersion.equals(new SemanticVersion(versionJump))) {
         throw new SchemaValidationError(
-          `Invalid migration version sequence detected; expected version '${v.major}' but got '${currentVersion.major}'`,
+          `Invalid migration version sequence detected; expected version '${versionJump}' but got '${nextVersion.major}'`,
         );
       }
 
-      currentVersion = this.nextVersionJump(currentVersion);
+      currentVersion = nextVersion;
     }
 
     return;

--- a/src/data/schema/model/local/local-config-schema.ts
+++ b/src/data/schema/model/local/local-config-schema.ts
@@ -9,7 +9,11 @@ import {type ClusterReferences} from '../../../../types/index.js';
 
 @Exclude()
 export class LocalConfigSchema {
-  public static readonly SCHEMA_VERSION: SemanticVersion<number> = new SemanticVersion(1);
+  /**
+   * The current version of the local configuration schema. This must always match the version produced by the newest
+   * migration registered in LocalConfigSchemaDefinition.
+   */
+  public static readonly SCHEMA_VERSION: SemanticVersion<number> = new SemanticVersion(2);
   public static readonly EMPTY: LocalConfigSchema = new LocalConfigSchema(
     LocalConfigSchema.SCHEMA_VERSION.major,
     new ApplicationVersionsSchema(),

--- a/src/data/schema/model/remote/remote-config-schema.ts
+++ b/src/data/schema/model/remote/remote-config-schema.ts
@@ -11,7 +11,11 @@ import {RemoteConfigStructure} from './interfaces/remote-config-structure.js';
 
 @Exclude()
 export class RemoteConfigSchema implements RemoteConfigStructure {
-  public static readonly SCHEMA_VERSION: SemanticVersion<number> = new SemanticVersion(1);
+  /**
+   * The current version of the remote configuration schema. This must always match the version produced by the newest
+   * migration registered in RemoteConfigSchemaDefinition.
+   */
+  public static readonly SCHEMA_VERSION: SemanticVersion<number> = new SemanticVersion(8);
 
   @Expose()
   public schemaVersion: number;

--- a/test/unit/data/schema/migration/schema-definition-versions.test.ts
+++ b/test/unit/data/schema/migration/schema-definition-versions.test.ts
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {expect} from 'chai';
+import {describe, it} from 'mocha';
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+import {type ClassConstructor} from '../../../../../src/business/utils/class-constructor.type.js';
+import {SemanticVersion} from '../../../../../src/business/utils/semantic-version.js';
+import {VersionRange} from '../../../../../src/business/utils/version-range.js';
+import {type ObjectMapper} from '../../../../../src/data/mapper/api/object-mapper.js';
+import {SchemaDefinitionBase} from '../../../../../src/data/schema/migration/api/schema-definition-base.js';
+import {type SchemaDefinition} from '../../../../../src/data/schema/migration/api/schema-definition.js';
+import {type SchemaMigration} from '../../../../../src/data/schema/migration/api/schema-migration.js';
+import {SchemaValidationError} from '../../../../../src/data/schema/migration/api/schema-validation-error.js';
+import {LocalConfigSchemaDefinition} from '../../../../../src/data/schema/migration/impl/local/local-config-schema-definition.js';
+import {RemoteConfigSchemaDefinition} from '../../../../../src/data/schema/migration/impl/remote/remote-config-schema-definition.js';
+import {SoloConfigSchemaDefinition} from '../../../../../src/data/schema/migration/impl/solo/solo-config-schema-definition.js';
+
+/**
+ * A no-op migration which reports an arbitrary resulting schema version. Used to prove that the declared schema
+ * version guard actually fires.
+ */
+class FakeMigration implements SchemaMigration {
+  public constructor(private readonly resultingVersion: number) {}
+
+  public get range(): VersionRange<number> {
+    return VersionRange.fromIntegerVersion(this.resultingVersion - 1);
+  }
+
+  public get version(): SemanticVersion<number> {
+    return new SemanticVersion<number>(this.resultingVersion);
+  }
+
+  public async migrate(source: object): Promise<object> {
+    return source;
+  }
+}
+
+/**
+ * A schema definition whose declared version and migration list are supplied by the test.
+ */
+class FakeSchemaDefinition extends SchemaDefinitionBase<object> {
+  public constructor(
+    private readonly declaredVersion: number,
+    private readonly declaredMigrations: SchemaMigration[],
+  ) {
+    // The mapper is only consulted by transform(), which these tests never exercise.
+    super({} as ObjectMapper);
+  }
+
+  public get name(): string {
+    return 'FakeConfigSchema';
+  }
+
+  public get version(): SemanticVersion<number> {
+    return new SemanticVersion<number>(this.declaredVersion);
+  }
+
+  public get classConstructor(): ClassConstructor<object> {
+    return Object as ClassConstructor<object>;
+  }
+
+  public get migrations(): SchemaMigration[] {
+    return this.declaredMigrations;
+  }
+}
+
+describe('Schema definition versions', (): void => {
+  // The mapper is only consulted by transform(), which these tests never exercise.
+  const objectMapper: ObjectMapper = {} as ObjectMapper;
+
+  const definitions: Array<{fileName: string; definition: SchemaDefinition<unknown>}> = [
+    {fileName: 'local-config-schema-definition.ts', definition: new LocalConfigSchemaDefinition(objectMapper)},
+    {fileName: 'remote-config-schema-definition.ts', definition: new RemoteConfigSchemaDefinition(objectMapper)},
+    {fileName: 'solo-config-schema-definition.ts', definition: new SoloConfigSchemaDefinition(objectMapper)},
+  ];
+
+  const newestMigrationVersion: (definition: SchemaDefinition<unknown>) => SemanticVersion<number> = (
+    definition: SchemaDefinition<unknown>,
+  ): SemanticVersion<number> => {
+    let newest: SemanticVersion<number> = new SemanticVersion<number>(0);
+
+    for (const migration of definition.migrations) {
+      if (migration.version.greaterThan(newest)) {
+        newest = migration.version;
+      }
+    }
+
+    return newest;
+  };
+
+  it('covers every versioned configuration schema definition', (): void => {
+    const directoryName: string = path.dirname(fileURLToPath(import.meta.url));
+    const definitionsPath: string = path.resolve(directoryName, '../../../../../src/data/schema/migration/impl');
+    const discoveredFileNames: string[] = fs
+      .readdirSync(definitionsPath, {recursive: true})
+      .map((entry: string | Buffer): string => path.basename(entry.toString()))
+      .filter((fileName: string): boolean => fileName.endsWith('-schema-definition.ts'));
+    discoveredFileNames.sort((left: string, right: string): number => left.localeCompare(right));
+
+    const coveredFileNames: string[] = definitions.map(
+      (entry: {fileName: string; definition: SchemaDefinition<unknown>}): string => entry.fileName,
+    );
+    coveredFileNames.sort((left: string, right: string): number => left.localeCompare(right));
+
+    expect(
+      coveredFileNames,
+      'every versioned configuration schema definition must be listed in this test so that its declared schema ' +
+        'version is validated against its migrations',
+    ).to.deep.equal(discoveredFileNames);
+  });
+
+  for (const {definition} of definitions) {
+    describe(definition.name, (): void => {
+      it('declares a schema version which is not older than its newest migration', (): void => {
+        const newestVersion: SemanticVersion<number> = newestMigrationVersion(definition);
+
+        expect(
+          newestVersion.lessThanOrEqual(definition.version),
+          `${definition.name} registers a migration producing version '${newestVersion.major}' but declares schema ` +
+            `version '${definition.version.major}'; the declared schema version must be bumped alongside the migration`,
+        ).to.equal(true);
+      });
+
+      it('has an unbroken migration sequence', async (): Promise<void> => {
+        await definition.validateMigrations();
+      });
+    });
+  }
+
+  describe('validateMigrations', (): void => {
+    it('rejects a migration which is newer than the declared schema version', async (): Promise<void> => {
+      const definition: FakeSchemaDefinition = new FakeSchemaDefinition(1, [
+        new FakeMigration(1),
+        new FakeMigration(2),
+      ]);
+
+      await expect(definition.validateMigrations()).to.be.rejectedWith(
+        SchemaValidationError,
+        "Migration version '2' is newer than the declared schema version '1'",
+      );
+    });
+
+    it('accepts a migration sequence which reaches the declared schema version', async (): Promise<void> => {
+      const definition: FakeSchemaDefinition = new FakeSchemaDefinition(2, [
+        new FakeMigration(1),
+        new FakeMigration(2),
+      ]);
+
+      await expect(definition.validateMigrations()).to.be.fulfilled;
+    });
+
+    it('rejects a duplicated migration version', async (): Promise<void> => {
+      const definition: FakeSchemaDefinition = new FakeSchemaDefinition(2, [
+        new FakeMigration(1),
+        new FakeMigration(2),
+        new FakeMigration(2),
+      ]);
+
+      await expect(definition.validateMigrations()).to.be.rejectedWith(
+        SchemaValidationError,
+        "Duplicate migration version '2'",
+      );
+    });
+
+    it('rejects a gap in the migration sequence', async (): Promise<void> => {
+      const definition: FakeSchemaDefinition = new FakeSchemaDefinition(3, [
+        new FakeMigration(1),
+        new FakeMigration(3),
+      ]);
+
+      await expect(definition.validateMigrations()).to.be.rejectedWith(SchemaValidationError);
+    });
+  });
+});


### PR DESCRIPTION
## Description

This pull request changes the following:

- Bumped `RemoteConfigSchema.SCHEMA_VERSION` to 8 and `LocalConfigSchema.SCHEMA_VERSION` to 2.
- Replaced the hard-coded `6` in `RemoteConfigRuntimeState` with `RemoteConfigSchema.SCHEMA_VERSION.major`,
  so a newly created remote config is stamped with the current schema version.
- `SchemaDefinitionBase.validateMigrations()` now fails when a migration produces a version newer than
  the declared schema version.
- Fixed two pre-existing bugs in `validateMigrations()`: it threw a phantom "gap in the migration
  sequence" error for every non-empty migration list, and it sorted migration versions
  lexicographically instead of numerically.
- Added unit tests covering all versioned schema definitions (local, remote, solo), including a guard
  that fails if a new schema definition is added without being covered.

Adding a migration without bumping the declared schema version now fails the test suite.

### Related Issues

* Closes # https://github.com/hiero-ledger/solo/issues/5455