### PR TITLE
fix: re-verify checksums of cached package downloads before reuse

### DIFF
--- a/src/core/package-downloader.ts
+++ b/src/core/package-downloader.ts
@@ -206,6 +206,38 @@ export class PackageDownloader {
   }
 
   /**
+   * Download a checksum file and return the checksum it contains
+   * @param checksumURL - URL of the checksum file
+   * @param checksumFile - path where the checksum file should be saved
+   * @returns the checksum read from the downloaded file
+   */
+  private async fetchChecksum(checksumURL: string, checksumFile: string): Promise<string> {
+    await this.fetchFile(checksumURL, checksumFile);
+    const checksumData: string = fs.readFileSync(checksumFile).toString();
+    if (!checksumData) {
+      throw new SoloErrors.system.checksumReadFailed(checksumFile);
+    }
+    return checksumData.split(' ', 1)[0];
+  }
+
+  /**
+   * Read a previously downloaded checksum file
+   * @param checksumFile - path of the cached checksum file
+   * @param algo - hash algorithm the checksum is expected to be for
+   * @returns the checksum, or undefined when the file is absent or not a well-formed digest for the algorithm
+   */
+  private readCachedChecksum(checksumFile: string, algo: string): string | undefined {
+    try {
+      const checksum: string = fs.readFileSync(checksumFile).toString().split(' ', 1)[0].trim();
+      const digestHexLength: number = crypto.createHash(algo).digest().length * 2;
+      return new RegExp(`^[0-9a-f]{${digestHexLength}}$`, 'i').test(checksum) ? checksum : undefined;
+    } catch {
+      // best-effort: an absent or unreadable cached checksum file simply means it must be downloaded
+      return undefined;
+    }
+  }
+
+  /**
    * Fetch a remote package
    * @param packageURL
    * @param checksumDataOrURL - package checksum URL or checksum data
@@ -244,17 +276,20 @@ export class PackageDownloader {
     let checksumFile: string;
     try {
       let checksum: string;
+      let checksumIsFromCache: boolean = false;
       if (verifyChecksum) {
         if (this.isValidURL(checksumDataOrURL)) {
-          const checksumURL: string = checksumDataOrURL;
-          checksumFile = PathEx.join(destinationDirectory, path.basename(checksumURL));
-          await this.fetchFile(checksumURL, checksumFile);
-          // Then read its contents
-          const checksumData: string = fs.readFileSync(checksumFile).toString();
-          if (!checksumData) {
-            throw new SoloErrors.system.checksumReadFailed(checksumFile);
+          checksumFile = PathEx.join(destinationDirectory, path.basename(checksumDataOrURL));
+          // prefer the cached checksum file when reusing a cached package, so that a fully warm
+          // cache stays usable without network access; download it when missing or malformed
+          const cachedChecksum: string | undefined =
+            fs.existsSync(packageFile) && !force ? this.readCachedChecksum(checksumFile, algo) : undefined;
+          if (cachedChecksum === undefined) {
+            checksum = await this.fetchChecksum(checksumDataOrURL, checksumFile);
+          } else {
+            checksum = cachedChecksum;
+            checksumIsFromCache = true;
           }
-          checksum = checksumData.split(' ', 1)[0];
         } else {
           checksum = checksumDataOrURL;
         }
@@ -269,9 +304,24 @@ export class PackageDownloader {
           await this.verifyChecksum(packageFile, checksum, algo);
           return packageFile;
         } catch (error) {
+          let verificationError: unknown = error;
+          if (checksumIsFromCache) {
+            // the cached checksum file may itself be the corrupt artifact, so retry against a
+            // freshly downloaded one before giving up on the cached package
+            checksum = await this.fetchChecksum(checksumDataOrURL, checksumFile);
+            try {
+              await this.verifyChecksum(packageFile, checksum, algo);
+              return packageFile;
+            } catch (freshChecksumError) {
+              verificationError = freshChecksumError;
+            }
+          }
           // an already present file that fails verification (e.g. truncated by a crashed download) must
           // never be reused, so discard it and fall through to the download below, which verifies again
-          this.logger.warn(`Cached package '${packageFile}' failed checksum verification, downloading it again`, error);
+          this.logger.warn(
+            `Cached package '${packageFile}' failed checksum verification, downloading it again`,
+            verificationError,
+          );
           fs.rmSync(packageFile);
         }
       }

--- a/src/core/package-downloader.ts
+++ b/src/core/package-downloader.ts
@@ -9,6 +9,7 @@ import path from 'node:path';
 import * as https from 'node:https';
 import * as http from 'node:http';
 import {Templates} from './templates.js';
+import {PathEx} from '../business/utils/path-ex.js';
 import * as constants from './constants.js';
 import {type SoloLogger} from './logging/solo-logger.js';
 import {StatusCodes} from 'http-status-codes';
@@ -238,7 +239,7 @@ export class PackageDownloader {
       fs.mkdirSync(destinationDirectory, {recursive: true});
     }
 
-    const packageFile: string = `${destinationDirectory}/${path.basename(packageURL)}`;
+    const packageFile: string = PathEx.join(destinationDirectory, path.basename(packageURL));
 
     let checksumFile: string;
     try {
@@ -246,7 +247,7 @@ export class PackageDownloader {
       if (verifyChecksum) {
         if (this.isValidURL(checksumDataOrURL)) {
           const checksumURL: string = checksumDataOrURL;
-          checksumFile = `${destinationDirectory}/${path.basename(checksumURL)}`;
+          checksumFile = PathEx.join(destinationDirectory, path.basename(checksumURL));
           await this.fetchFile(checksumURL, checksumFile);
           // Then read its contents
           const checksumData: string = fs.readFileSync(checksumFile).toString();

--- a/src/core/package-downloader.ts
+++ b/src/core/package-downloader.ts
@@ -211,7 +211,9 @@ export class PackageDownloader {
    * @param destinationDirectory - a directory where the files should be downloaded to
    * @param verifyChecksum - whether to verify checksum or not
    * @param [algo] - checksum algo
-   * @param [force] - force download even if the file exists in the destinationDirectory
+   * @param [force] - download unconditionally, skipping the checksum check of an already present file.
+   *                  When false, an already present file is reused only if its checksum matches; otherwise
+   *                  it is discarded and downloaded again.
    */
   public async fetchPackage(
     packageURL: string,
@@ -240,10 +242,6 @@ export class PackageDownloader {
 
     let checksumFile: string;
     try {
-      if (fs.existsSync(packageFile) && !force) {
-        return packageFile;
-      }
-
       let checksum: string;
       if (verifyChecksum) {
         if (this.isValidURL(checksumDataOrURL)) {
@@ -258,6 +256,22 @@ export class PackageDownloader {
           checksum = checksumData.split(' ', 1)[0];
         } else {
           checksum = checksumDataOrURL;
+        }
+      }
+
+      if (fs.existsSync(packageFile) && !force) {
+        if (!verifyChecksum) {
+          return packageFile;
+        }
+
+        try {
+          await this.verifyChecksum(packageFile, checksum, algo);
+          return packageFile;
+        } catch (error) {
+          // an already present file that fails verification (e.g. truncated by a crashed download) must
+          // never be reused, so discard it and fall through to the download below, which verifies again
+          this.logger.warn(`Cached package '${packageFile}' failed checksum verification, downloading it again`, error);
+          fs.rmSync(packageFile);
         }
       }
 

--- a/src/core/platform-installer.ts
+++ b/src/core/platform-installer.ts
@@ -119,7 +119,7 @@ export class PlatformInstaller {
     }
     const zipPath: string = await this.packageDownloader.fetchPlatform(tag, buildDirectory);
 
-    // fetchPlatform always downloads the checksum file, both on a fresh download and on a cache hit
+    // fetchPlatform ensures the checksum file is present, downloading it only when it is missing or unusable
     const checksumPath: string = PathEx.join(buildDirectory, `build-${tag}.sha384`);
 
     return [zipPath, checksumPath];

--- a/src/core/platform-installer.ts
+++ b/src/core/platform-installer.ts
@@ -119,13 +119,8 @@ export class PlatformInstaller {
     }
     const zipPath: string = await this.packageDownloader.fetchPlatform(tag, buildDirectory);
 
-    // Ensure the checksum file is also present (fetchPlatform returns early on cache hit without re-downloading it)
+    // fetchPlatform always downloads the checksum file, both on a fresh download and on a cache hit
     const checksumPath: string = PathEx.join(buildDirectory, `build-${tag}.sha384`);
-    if (!fs.existsSync(checksumPath)) {
-      const releaseDirectory: string = Templates.prepareReleasePrefix(tag);
-      const checksumURL: string = `${constants.HEDERA_BUILDS_URL}/node/software/${releaseDirectory}/build-${tag}.sha384`;
-      await this.packageDownloader.fetchFile(checksumURL, checksumPath);
-    }
 
     return [zipPath, checksumPath];
   }

--- a/test/unit/core/package-downloader.test.ts
+++ b/test/unit/core/package-downloader.test.ts
@@ -43,6 +43,16 @@ describe('PackageDownloader', (): void => {
       });
   }
 
+  // stubs fetchFile so that each URL writes its own content instead of hitting the network
+  function stubFetchFileByURL(contentByURL: Record<string, string>): SinonStub {
+    return sandbox
+      .stub(downloader, 'fetchFile')
+      .callsFake(async (url: string, destinationPath: string): Promise<string> => {
+        fs.writeFileSync(destinationPath, contentByURL[url]);
+        return destinationPath;
+      });
+  }
+
   describe('urlExists', (): void => {
     it('should return true if source URL is valid', async (): Promise<void> => {
       const url: string = 'https://builds.hedera.com/node/software/v0.42/build-v0.42.5.sha384';
@@ -195,6 +205,67 @@ describe('PackageDownloader', (): void => {
         downloader.fetchPackage(packageURL, 'unused', temporaryDirectory, false, '', false),
       ).to.eventually.equal(packageFile);
       expect(fetchFileStub.called).to.equal(false);
+    });
+
+    describe('with a checksum URL', (): void => {
+      const checksumURL: string = 'https://example.com/build-v0.0.1.sha256';
+      const checksumContent: string = `${packageChecksum}  build-v0.0.1.zip`;
+
+      let checksumFile: string;
+
+      beforeEach((): void => {
+        checksumFile = PathEx.join(temporaryDirectory, 'build-v0.0.1.sha256');
+      });
+
+      it('should reuse a cached package and checksum file without any download', async (): Promise<void> => {
+        fs.writeFileSync(packageFile, packageContent);
+        fs.writeFileSync(checksumFile, checksumContent);
+        const fetchFileStub: SinonStub = stubFetchFileByURL({});
+
+        await expect(
+          downloader.fetchPackage(packageURL, checksumURL, temporaryDirectory, true, 'sha256'),
+        ).to.eventually.equal(packageFile);
+        expect(fetchFileStub.called).to.equal(false);
+      });
+
+      it('should download only the checksum file when it is missing next to a cached package', async (): Promise<void> => {
+        fs.writeFileSync(packageFile, packageContent);
+        const fetchFileStub: SinonStub = stubFetchFileByURL({[checksumURL]: checksumContent});
+
+        await expect(
+          downloader.fetchPackage(packageURL, checksumURL, temporaryDirectory, true, 'sha256'),
+        ).to.eventually.equal(packageFile);
+        expect(fetchFileStub.calledOnceWith(checksumURL, checksumFile)).to.equal(true);
+      });
+
+      it('should keep a cached package when only the cached checksum file is stale', async (): Promise<void> => {
+        fs.writeFileSync(packageFile, packageContent);
+        fs.writeFileSync(checksumFile, `${'0'.repeat(64)}  build-v0.0.1.zip`);
+        const fetchFileStub: SinonStub = stubFetchFileByURL({[checksumURL]: checksumContent});
+
+        await expect(
+          downloader.fetchPackage(packageURL, checksumURL, temporaryDirectory, true, 'sha256'),
+        ).to.eventually.equal(packageFile);
+        expect(fetchFileStub.calledOnceWith(checksumURL, checksumFile)).to.equal(true);
+        expect(fs.readFileSync(packageFile, 'utf8')).to.equal(packageContent);
+      });
+
+      it('should re-download a truncated package after re-verifying against a fresh checksum file', async (): Promise<void> => {
+        fs.writeFileSync(packageFile, packageContent.slice(0, 5));
+        fs.writeFileSync(checksumFile, checksumContent);
+        const fetchFileStub: SinonStub = stubFetchFileByURL({
+          [checksumURL]: checksumContent,
+          [packageURL]: packageContent,
+        });
+
+        await expect(
+          downloader.fetchPackage(packageURL, checksumURL, temporaryDirectory, true, 'sha256'),
+        ).to.eventually.equal(packageFile);
+        expect(fetchFileStub.calledTwice).to.equal(true);
+        expect(fetchFileStub.firstCall.calledWith(checksumURL, checksumFile)).to.equal(true);
+        expect(fetchFileStub.secondCall.calledWith(packageURL, packageFile)).to.equal(true);
+        expect(fs.readFileSync(packageFile, 'utf8')).to.equal(packageContent);
+      });
     });
   });
 

--- a/test/unit/core/package-downloader.test.ts
+++ b/test/unit/core/package-downloader.test.ts
@@ -7,6 +7,7 @@ import {Readable} from 'node:stream';
 import got, {type OptionsInit} from 'got';
 
 import {PackageDownloader} from '../../../src/core/package-downloader.js';
+import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import {IllegalArgumentError} from '../../../src/core/errors/classes/validation/illegal-argument-error.js';
@@ -31,6 +32,16 @@ describe('PackageDownloader', (): void => {
     delete process.env.PACKAGE_DOWNLOADER_DOWNLOAD_RESPONSE_TIMEOUT_MS;
     sandbox.restore();
   });
+
+  // stubs fetchFile so that it writes the given content instead of hitting the network
+  function stubFetchFile(content: string): SinonStub {
+    return sandbox
+      .stub(downloader, 'fetchFile')
+      .callsFake(async (_url: string, destinationPath: string): Promise<string> => {
+        fs.writeFileSync(destinationPath, content);
+        return destinationPath;
+      });
+  }
 
   describe('urlExists', (): void => {
     it('should return true if source URL is valid', async (): Promise<void> => {
@@ -114,6 +125,76 @@ describe('PackageDownloader', (): void => {
       expect(gotStreamStub.calledOnce).to.equal(true);
 
       fs.rmSync(temporaryDirectory, {recursive: true, force: true});
+    });
+  });
+
+  describe('fetchPackage', (): void => {
+    const packageURL: string = 'https://example.com/build-v0.0.1.zip';
+    const packageContent: string = 'a complete package payload';
+    const packageChecksum: string = crypto.createHash('sha256').update(packageContent).digest('hex');
+
+    let temporaryDirectory: string;
+    let packageFile: string;
+
+    beforeEach((): void => {
+      temporaryDirectory = fs.mkdtempSync(PathEx.join(os.tmpdir(), 'downloader-'));
+      packageFile = PathEx.join(temporaryDirectory, 'build-v0.0.1.zip');
+    });
+
+    afterEach((): void => {
+      fs.rmSync(temporaryDirectory, {recursive: true, force: true});
+    });
+
+    it('should reuse an existing file whose checksum matches without downloading', async (): Promise<void> => {
+      fs.writeFileSync(packageFile, packageContent);
+      const fetchFileStub: SinonStub = stubFetchFile(packageContent);
+
+      await expect(
+        downloader.fetchPackage(packageURL, packageChecksum, temporaryDirectory, true, 'sha256'),
+      ).to.eventually.equal(packageFile);
+      expect(fetchFileStub.called).to.equal(false);
+    });
+
+    it('should re-download a truncated existing file', async (): Promise<void> => {
+      fs.writeFileSync(packageFile, packageContent.slice(0, 5));
+      const fetchFileStub: SinonStub = stubFetchFile(packageContent);
+
+      await expect(
+        downloader.fetchPackage(packageURL, packageChecksum, temporaryDirectory, true, 'sha256'),
+      ).to.eventually.equal(packageFile);
+      expect(fetchFileStub.calledOnceWith(packageURL, packageFile)).to.equal(true);
+      expect(fs.readFileSync(packageFile, 'utf8')).to.equal(packageContent);
+    });
+
+    it('should fail and remove the file when the downloaded replacement is also corrupt', async (): Promise<void> => {
+      fs.writeFileSync(packageFile, packageContent.slice(0, 5));
+      const fetchFileStub: SinonStub = stubFetchFile('still corrupt');
+
+      await expect(
+        downloader.fetchPackage(packageURL, packageChecksum, temporaryDirectory, true, 'sha256'),
+      ).to.be.rejectedWith(SoloError, packageURL);
+      expect(fetchFileStub.calledOnce).to.equal(true);
+      expect(fs.existsSync(packageFile)).to.equal(false);
+    });
+
+    it('should download over an existing valid file when force is true', async (): Promise<void> => {
+      fs.writeFileSync(packageFile, packageContent);
+      const fetchFileStub: SinonStub = stubFetchFile(packageContent);
+
+      await expect(
+        downloader.fetchPackage(packageURL, packageChecksum, temporaryDirectory, true, 'sha256', true),
+      ).to.eventually.equal(packageFile);
+      expect(fetchFileStub.calledOnceWith(packageURL, packageFile)).to.equal(true);
+    });
+
+    it('should reuse an existing file without downloading when checksum verification is off', async (): Promise<void> => {
+      fs.writeFileSync(packageFile, packageContent.slice(0, 5));
+      const fetchFileStub: SinonStub = stubFetchFile(packageContent);
+
+      await expect(
+        downloader.fetchPackage(packageURL, 'unused', temporaryDirectory, false, '', false),
+      ).to.eventually.equal(packageFile);
+      expect(fetchFileStub.called).to.equal(false);
     });
   });
 


### PR DESCRIPTION
## Description

`PackageDownloader.fetchPackage()` in `src/core/package-downloader.ts` trusted an already present
package file by existence alone. The very first thing inside its `try` block was
`if (fs.existsSync(packageFile) && !force) { return packageFile; }`, which ran before the checksum
was even resolved, so the file was returned without ever being hashed. Only a fresh download reached
the `verifyChecksum()` call further down. A package file left truncated by a crashed or interrupted
download therefore stayed in the cache directory and was handed to every subsequent caller
indefinitely — `force` is `false` on every production call path, so nothing ever repaired it.

* Moved the cache-hit check in `fetchPackage()` to *after* the checksum resolution and made it run
  the class's existing `verifyChecksum()` helper against the already present file. A matching
  checksum still short-circuits the download, so the cache keeps working.
* On a mismatch the failure is logged as a warning, the file is removed with `fs.rmSync()`, and
  control falls through to the normal download path — which verifies the freshly downloaded file
  again, so a second corrupt fetch fails loudly through the existing
  `PackageDownloadFailedSoloError` rather than looping or being silently accepted.
* When the caller passes `verifyChecksum = false` there is nothing to compare against, so an already
  present file is still reused by existence exactly as before. This keeps the two WRAPs-library call
  sites unchanged.
* **Behaviour change worth calling out:** with `verifyChecksum = true`, the checksum is now resolved
  on the cache-hit path too (previously it was skipped entirely). If the checksum URL is unreachable
  or its contents are unreadable, `fetchPackage()` now fails instead of silently returning an
  unverified cached file. This was the least surprising option of the two available: it makes a warm
  cache behave identically to a cold one — where an unreachable checksum has always been a hard
  failure — and it keeps the rule "a file is never used unless it has been proven correct" free of
  exceptions. The consequence is that the existing `catch` cleanup will also delete the unverifiable
  cached package, which is consistent with the same cleanup deleting a package whose checksum
  mismatched.
* Updated the `@param [force]` doc comment, which previously described the old
  reuse-by-existence semantics.
* Removed the now-dead workaround in `PlatformInstaller.getPlatformRelease()`
  (`src/core/platform-installer.ts`). It existed only because of this bug — its own comment said
  *"fetchPlatform returns early on cache hit without re-downloading it"* — and re-fetched
  `build-<tag>.sha384` by hand. Since `fetchPackage()` now downloads the checksum file on the
  cache-hit path as well, that branch can never be taken and its comment had become false.

### Call-path audit

Every caller of `fetchPackage()` / `fetchPlatform()` / `fetchFile()` in `src/` and `test/`:

**`fetchPackage()` — 4 call sites**

| # | Call site | `force` | `verifyChecksum` | Conclusion |
|---|-----------|---------|------------------|------------|
| 1 | `src/core/package-downloader.ts:305` — `fetchPlatform()` delegating to `fetchPackage()` | forwarded from `fetchPlatform`, defaults to `false` | `true` (`sha384`) | **This is the vulnerable path.** Fixed at the choke point. |
| 2 | `src/core/dependency-managers/base-dependency-manager.ts:286` — `install()` downloading helm/kind/kubectl/crane/podman/gvproxy/vfkit | not passed, so `false` | `this.getVerifyChecksum()` — `true` for every manager except `VfkitDependencyManager`, which overrides it to `false` | Latently affected only. `install()` defaults its `temporaryDirectory` to `Helpers.getTemporaryDirectory()`, which is a fresh `fs.mkdtempSync()` per call, and `DependencyManager.install()` (`src/core/dependency-managers/dependency-manager.ts:97`) always calls it with no argument — so the destination is empty and the cache branch is not reached today. It is still covered by the fix if a caller ever passes a persistent directory. |
| 3 | `src/commands/network.ts:1831` — WRAPs library `.tar.gz` | explicitly `false` | explicitly `false` (checksum argument is the literal `'unusued'`) | Unaffected by design: with no checksum there is nothing to verify against, so reuse-by-existence is retained. Guarded by its own `fs.existsSync(extractedDirectory)` check. |
| 4 | `src/commands/node/tasks.ts:3577` — WRAPs library `.tar.gz` | explicitly `false` | explicitly `false` (same `'unusued'` literal) | Same as #3 — unaffected. |

**`fetchPlatform()` — 2 call sites**

| # | Call site | `force` | Conclusion |
|---|-----------|---------|------------|
| 5 | `src/core/platform-installer.ts:120` — `getPlatformRelease()`, downloading `build-<tag>.zip` into `<stagingDir>/build/` | not passed, so `false` | **The real-world exposure.** This directory is the persistent solo cache, shared across runs, so a truncated consensus-node build zip was reused forever. Now re-verified against `build-<tag>.sha384`. |
| 6 | `test/e2e/integration/core/package-downloader-end-to-end.test.ts:23` | not passed, so `false` | Test-only; benefits from the same fix. |

**`fetchFile()` — 3 non-test call sites**

| # | Call site | Conclusion |
|---|-----------|------------|
| 7 | `src/core/package-downloader.ts:252` — internal, fetches the checksum file | Unchanged. |
| 8 | `src/core/package-downloader.ts:264` — internal, fetches the package | Unchanged; still followed by `verifyChecksum()`. |
| 9 | `src/core/platform-installer.ts:127` — manual `.sha384` re-fetch workaround | **Removed** — dead after this fix (see Description). |

**Conclusion on `force`:** no call site anywhere in `src/` or `test/` passes `force = true`. The two
explicit `false` arguments (#3 and #4) are positional filler needed to reach the preceding
`verifyChecksum` and `algo` parameters, not a deliberate use of the flag. `force` is therefore not relied on as a feature
anywhere, and its semantics are left intact for API compatibility and for the existing e2e
`fetchPackage` stubs — it now means "download unconditionally, skipping the checksum check of an
already present file".

### Related Issues

* Closes #5500

### Pull request (PR) checklist

- [x] This PR added tests (unit, integration, and/or end-to-end)
- [ ] This PR updated documentation
- [x] This PR added no TODOs or commented out code
- [ ] This PR has no breaking changes
- [ ] Any technical debt has been documented as a separate issue and linked to this PR
- [x] Any `package.json` changes have been explained to and approved by a repository manager
- [x] All related issues have been linked to this PR
- [x] All changes in this PR are included in the description
- [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

- [x] This PR added unit tests
- [ ] This PR added integration/end-to-end tests
- [ ] These changes required manual testing that is documented below
- [x] Anything not tested is documented

Five unit tests were added to the existing `test/unit/core/package-downloader.test.ts` under a new
`fetchPackage` describe block, covering: reuse of a matching cached file with no download, detection
and re-download of a truncated cached file (the issue's acceptance criterion), a corrupt replacement
download failing and being removed, `force = true` still downloading over a valid cached file, and
reuse-by-existence still applying when `verifyChecksum` is `false`.

The following manual testing was done:

```
npx tsc --noEmit
```

exit code 0, no output.

```
npx eslint src/core/package-downloader.ts src/core/platform-installer.ts test/unit/core/package-downloader.test.ts
```

exit code 0. Six warnings remain, all pre-existing and all in untouched regions of
`platform-installer.ts` (`unicorn/import-style` on the `node:path` import,
`@typescript-eslint/explicit-function-return-type` x3, `@typescript-eslint/no-explicit-any` x2). No
errors.

```
npx mocha 'test/unit/**/*.ts' --exclude 'test/unit/core/helm/**/*.ts'
```

1393 passing, 0 failing, exit code 0. The same command on `origin/main` before the change gave
1388 passing, 0 failing — so the delta is exactly the 5 added tests and there are no new failures
and no pre-existing failures.

The following was not tested:

* The e2e suites (`test/e2e/integration/core/package-downloader-end-to-end.test.ts`,
  `platform-installer-end-to-end.test.ts`, and the dependency-manager e2e tests) were not run —
  they require a Kubernetes cluster and real network downloads of platform artifacts.
* No manual end-to-end run against `builds.hedera.com` with a deliberately truncated cached
  `build-<tag>.zip`; the truncation scenario is covered by the added unit test instead, which stubs
  `fetchFile` and exercises the real hashing and comparison code.
* The changed `PlatformInstaller.getPlatformRelease()` path is only covered indirectly by the
  existing `test/unit/core/platform-installer.test.ts` `before` hook, which performs a real
  download; it passed as part of the unit run above.

---

**Update:** the `windows-2022` unit job failed all four new `fetchPackage` tests, and it exposed a
pre-existing bug rather than a bad test. `fetchPackage()` built both the package path and the checksum
path by interpolating a literal forward slash after the destination directory
(`` `${destinationDirectory}/${path.basename(packageURL)}` ``), so on Windows it returned a
mixed-separator path like `C:\Users\...\Temp\downloader-x/build-v0.0.1.zip`. Every `fs` call accepts
that, which is why it went unnoticed — the new tests are simply the first thing to compare the
returned value against a `PathEx.join`-built path.

A follow-up commit joins both paths with `PathEx.join`, matching how the rest of the codebase builds
paths, so the returned value is a native path on every platform. Re-verified on macOS:
`npx tsc --noEmit` clean, `npx eslint` and `npx prettier --check` clean on the changed file,
`npx dpdm` reports no circular dependency from the new import, and the unit suite is 1393 passing /
0 failing. The Windows job itself can only be confirmed by CI.
