### PR TITLE
fix: validate the legacy local-config.yaml before migrating it

### DIFF
--- a/src/business/runtime-state/config/local/local-config-runtime-state.ts
+++ b/src/business/runtime-state/config/local/local-config-runtime-state.ts
@@ -17,6 +17,7 @@ import {LocalConfig} from './local-config.js';
 import path from 'node:path';
 import {Templates} from '../../../../core/templates.js';
 import {type ConfigManager} from '../../../../core/config-manager.js';
+import {type SoloLogger} from '../../../../core/logging/solo-logger.js';
 import {Flags as flags} from '../../../../commands/flags.js';
 
 @injectable()
@@ -32,10 +33,12 @@ export class LocalConfigRuntimeState {
     @inject(InjectTokens.HomeDirectory) private readonly basePath: string,
     @inject(InjectTokens.LocalConfigFileName) private readonly fileName: string,
     @inject(InjectTokens.ConfigManager) private readonly configManager?: ConfigManager,
+    @inject(InjectTokens.SoloLogger) private readonly logger?: SoloLogger,
   ) {
     this.fileName = patchInject(fileName, InjectTokens.LocalConfigFileName, this.constructor.name);
     this.basePath = patchInject(basePath, InjectTokens.HomeDirectory, this.constructor.name);
     this.configManager = patchInject(configManager, InjectTokens.ConfigManager, this.constructor.name);
+    this.logger = patchInject(logger, InjectTokens.SoloLogger, this.constructor.name);
     this.backend = new YamlFileStorageBackend(this.basePath);
     this.objectMapper = new ClassToObjectMapper(ConfigKeyFormatter.instance());
     this.source = new LocalConfigSource(
@@ -58,20 +61,10 @@ export class LocalConfigRuntimeState {
   // Loads the source data and writes it back in case of migrations.
   public async load(): Promise<void> {
     // TODO this needs to be a migration, not a load
-    // check if config from an old version exists under the cache directory
-    const oldConfigPath: string = PathEx.join(this.basePath, 'cache');
-    const oldConfigFile: string = PathEx.join(oldConfigPath, this.fileName);
-    const oldConfigFileExists: boolean = existsSync(oldConfigFile);
-
-    if (this.configFileExists() && oldConfigFileExists) {
-      // if both files exist, remove the old one
-      fs.rmSync(oldConfigFile);
-    } else if (existsSync(oldConfigFile)) {
-      // if only the old file exists, copy it to the new location
-      mkdirSync(this.basePath, {recursive: true});
-      fs.copyFileSync(oldConfigFile, PathEx.join(this.basePath, this.fileName));
-      fs.rmSync(oldConfigFile);
-    }
+    // Stage a legacy config (from the old cache path) at the current path without deleting the legacy
+    // file yet, so validation can run before the legacy copy is retired.
+    const legacyConfigFile: string = PathEx.join(this.basePath, 'cache', this.fileName);
+    const legacyMigrationPending: boolean = this.stageLegacyLocalConfig(legacyConfigFile);
 
     this.refresh();
     if (!this.configFileExists()) {
@@ -82,12 +75,63 @@ export class LocalConfigRuntimeState {
       await this.source.refresh();
       this.refresh();
     } catch (error) {
+      if (legacyMigrationPending) {
+        // The legacy config failed validation: discard the corrupt copy and keep the legacy file in
+        // place so nothing is lost, then surface an actionable error naming the legacy file.
+        this.removeFileSafely(PathEx.join(this.basePath, this.fileName));
+        throw new SoloErrors.config.migrateLegacyLocalConfig(error, legacyConfigFile);
+      }
       throw new SoloErrors.config.refreshLocalConfigSource(PathEx.join(this.basePath, this.fileName), error);
     }
     await this.persist();
 
+    if (legacyMigrationPending) {
+      // Validated and persisted (unknown fields pruned by the mapper): retire the legacy file.
+      this.removeFileSafely(legacyConfigFile);
+      this.logger?.warn(
+        `Migrated legacy local configuration from ${legacyConfigFile} to ${PathEx.join(this.basePath, this.fileName)}`,
+      );
+    }
+
     await this.migrateCacheDirectories();
     this.isLoaded = true;
+  }
+
+  /**
+   * Stages a legacy local config (from the old cache path) at the current path without deleting the
+   * legacy file, so it can be validated before the legacy copy is retired. Returns true when a legacy
+   * file was copied and is awaiting validation; false when there is nothing to migrate or a current
+   * config already exists (in which case the redundant legacy file is removed).
+   */
+  private stageLegacyLocalConfig(legacyConfigFile: string): boolean {
+    if (!existsSync(legacyConfigFile)) {
+      return false;
+    }
+
+    // A current config already exists: the legacy copy is redundant — remove it, keep the current one.
+    if (this.configFileExists()) {
+      this.removeFileSafely(legacyConfigFile);
+      return false;
+    }
+
+    try {
+      mkdirSync(this.basePath, {recursive: true});
+      fs.copyFileSync(legacyConfigFile, PathEx.join(this.basePath, this.fileName));
+    } catch (error) {
+      throw new SoloErrors.config.migrateLegacyLocalConfig(error, legacyConfigFile);
+    }
+    return true;
+  }
+
+  /** Removes a file if it exists, wrapping any filesystem failure in a typed error. */
+  private removeFileSafely(filePath: string): void {
+    try {
+      if (existsSync(filePath)) {
+        fs.rmSync(filePath);
+      }
+    } catch (error) {
+      throw new SoloErrors.config.migrateLegacyLocalConfig(error, filePath);
+    }
   }
 
   /**

--- a/src/business/runtime-state/config/local/local-config-runtime-state.ts
+++ b/src/business/runtime-state/config/local/local-config-runtime-state.ts
@@ -18,6 +18,7 @@ import {LocalConfig} from './local-config.js';
 import path from 'node:path';
 import {Templates} from '../../../../core/templates.js';
 import {type ConfigManager} from '../../../../core/config-manager.js';
+import {type SoloLogger} from '../../../../core/logging/solo-logger.js';
 import {Flags as flags} from '../../../../commands/flags.js';
 
 @injectable()
@@ -33,10 +34,12 @@ export class LocalConfigRuntimeState {
     @inject(InjectTokens.HomeDirectory) private readonly basePath: string,
     @inject(InjectTokens.LocalConfigFileName) private readonly fileName: string,
     @inject(InjectTokens.ConfigManager) private readonly configManager?: ConfigManager,
+    @inject(InjectTokens.SoloLogger) private readonly logger?: SoloLogger,
   ) {
     this.fileName = patchInject(fileName, InjectTokens.LocalConfigFileName, this.constructor.name);
     this.basePath = patchInject(basePath, InjectTokens.HomeDirectory, this.constructor.name);
     this.configManager = patchInject(configManager, InjectTokens.ConfigManager, this.constructor.name);
+    this.logger = patchInject(logger, InjectTokens.SoloLogger, this.constructor.name);
     this.backend = new YamlFileStorageBackend(this.basePath);
     this.objectMapper = new ClassToObjectMapper(ConfigKeyFormatter.instance());
     this.source = new LocalConfigSource(
@@ -59,20 +62,10 @@ export class LocalConfigRuntimeState {
   // Loads the source data and writes it back in case of migrations.
   public async load(): Promise<void> {
     // TODO this needs to be a migration, not a load
-    // check if config from an old version exists under the cache directory
-    const oldConfigPath: string = PathEx.join(this.basePath, 'cache');
-    const oldConfigFile: string = PathEx.join(oldConfigPath, this.fileName);
-    const oldConfigFileExists: boolean = existsSync(oldConfigFile);
-
-    if (this.configFileExists() && oldConfigFileExists) {
-      // if both files exist, remove the old one
-      fs.rmSync(oldConfigFile);
-    } else if (existsSync(oldConfigFile)) {
-      // if only the old file exists, copy it to the new location
-      mkdirSync(this.basePath, {recursive: true});
-      fs.copyFileSync(oldConfigFile, PathEx.join(this.basePath, this.fileName));
-      fs.rmSync(oldConfigFile);
-    }
+    // Stage a legacy config (from the old cache path) at the current path without deleting the legacy
+    // file yet, so validation can run before the legacy copy is retired.
+    const legacyConfigFile: string = PathEx.join(this.basePath, 'cache', this.fileName);
+    const legacyMigrationPending: boolean = this.stageLegacyLocalConfig(legacyConfigFile);
 
     this.refresh();
     if (!this.configFileExists()) {
@@ -85,12 +78,26 @@ export class LocalConfigRuntimeState {
       await this.source.refresh();
       this.refresh();
     } catch (error) {
+      if (legacyMigrationPending) {
+        // A legacy config failed validation (unparseable or incomplete): discard the corrupt copy and
+        // keep the legacy file in place so nothing is lost, then surface an actionable error naming it.
+        this.removeFileSafely(configFilePath);
+        throw new SoloErrors.config.migrateLegacyLocalConfig(error, legacyConfigFile);
+      }
       if (error instanceof IncompleteLocalConfigError) {
         throw error;
       }
       throw new SoloErrors.config.refreshLocalConfigSource(configFilePath, error);
     }
     await this.persist();
+
+    if (legacyMigrationPending) {
+      // Validated and persisted (unknown fields pruned by the mapper): retire the legacy file.
+      this.removeFileSafely(legacyConfigFile);
+      this.logger?.warn(
+        `Migrated legacy local configuration from ${legacyConfigFile} to ${PathEx.join(this.basePath, this.fileName)}`,
+      );
+    }
 
     await this.migrateCacheDirectories();
     this.isLoaded = true;
@@ -123,6 +130,43 @@ export class LocalConfigRuntimeState {
       : LocalConfigRuntimeState.REQUIRED_TOP_LEVEL_KEYS;
     if (missingKeys.length > 0) {
       throw new SoloErrors.config.incompleteLocalConfig(configFilePath, missingKeys);
+    }
+  }
+
+  /**
+   * Stages a legacy local config (from the old cache path) at the current path without deleting the
+   * legacy file, so it can be validated before the legacy copy is retired. Returns true when a legacy
+   * file was copied and is awaiting validation; false when there is nothing to migrate or a current
+   * config already exists (in which case the redundant legacy file is removed).
+   */
+  private stageLegacyLocalConfig(legacyConfigFile: string): boolean {
+    if (!existsSync(legacyConfigFile)) {
+      return false;
+    }
+
+    // A current config already exists: the legacy copy is redundant — remove it, keep the current one.
+    if (this.configFileExists()) {
+      this.removeFileSafely(legacyConfigFile);
+      return false;
+    }
+
+    try {
+      mkdirSync(this.basePath, {recursive: true});
+      fs.copyFileSync(legacyConfigFile, PathEx.join(this.basePath, this.fileName));
+    } catch (error) {
+      throw new SoloErrors.config.migrateLegacyLocalConfig(error, legacyConfigFile);
+    }
+    return true;
+  }
+
+  /** Removes a file if it exists, wrapping any filesystem failure in a typed error. */
+  private removeFileSafely(filePath: string): void {
+    try {
+      if (existsSync(filePath)) {
+        fs.rmSync(filePath);
+      }
+    } catch (error) {
+      throw new SoloErrors.config.migrateLegacyLocalConfig(error, filePath);
     }
   }
 

--- a/src/core/errors/classes/config/migrate-legacy-local-config-error.ts
+++ b/src/core/errors/classes/config/migrate-legacy-local-config-error.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {SoloError} from '../../solo-error.js';
+import {ErrorOwnership} from '../../error-ownership.js';
+import {ErrorCodeRegistry} from '../../error-code-registry.js';
+
+/**
+ * @description Thrown when solo cannot migrate the legacy local configuration from the old cache
+ * path (`~/.solo/cache/local-config.yaml`) to the current path (`~/.solo/local-config.yaml`). The
+ * migration copies the legacy file to the current path and validates it *before* the legacy file is
+ * removed, so this error is raised either because a filesystem operation failed (copy/remove/mkdir,
+ * wrapped in `cause`) or because the legacy configuration is corrupt and cannot be parsed. In both
+ * cases the legacy file is left in place — it is never deleted while unvalidated — and the corrupt
+ * copy (if any) is discarded, so no configuration is silently propagated or lost.
+ */
+export class MigrateLegacyLocalConfigError extends SoloError {
+  protected override readonly retryable: boolean = false;
+  protected override readonly ownership: ErrorOwnership = ErrorOwnership.Infrastructure;
+
+  public constructor(cause?: Error, legacyConfigFile?: string) {
+    super(
+      {
+        message: legacyConfigFile
+          ? `Failed to migrate legacy local configuration file: ${legacyConfigFile}`
+          : 'Failed to migrate legacy local configuration file',
+        code: ErrorCodeRegistry.MIGRATE_LEGACY_LOCAL_CONFIG,
+        troubleshootingSteps:
+          'Inspect the legacy file at ~/.solo/cache/local-config.yaml. If it is corrupt, fix the YAML ' +
+          'or remove it, then re-run the command. Also verify file system permissions for ~/.solo.',
+      },
+      cause,
+    );
+  }
+}

--- a/src/core/errors/classes/config/migrate-legacy-local-config-error.ts
+++ b/src/core/errors/classes/config/migrate-legacy-local-config-error.ts
@@ -6,8 +6,8 @@ import {ErrorCodeRegistry} from '../../error-code-registry.js';
 
 /**
  * @description Thrown when solo cannot migrate the legacy local configuration from the old cache
- * path (`~/.solo/cache/local-config.yaml`) to the current path (`~/.solo/local-config.yaml`). The
- * migration copies the legacy file to the current path and validates it *before* the legacy file is
+ * path (`$SOLO_HOME/cache/local-config.yaml`) to the current path (`$SOLO_HOME/local-config.yaml`).
+ * The migration copies the legacy file to the current path and validates it *before* the legacy file is
  * removed, so this error is raised either because a filesystem operation failed (copy/remove/mkdir,
  * wrapped in `cause`) or because the legacy configuration is corrupt and cannot be parsed. In both
  * cases the legacy file is left in place — it is never deleted while unvalidated — and the corrupt
@@ -24,9 +24,11 @@ export class MigrateLegacyLocalConfigError extends SoloError {
           ? `Failed to migrate legacy local configuration file: ${legacyConfigFile}`
           : 'Failed to migrate legacy local configuration file',
         code: ErrorCodeRegistry.MIGRATE_LEGACY_LOCAL_CONFIG,
-        troubleshootingSteps:
-          'Inspect the legacy file at ~/.solo/cache/local-config.yaml. If it is corrupt, fix the YAML ' +
-          'or remove it, then re-run the command. Also verify file system permissions for ~/.solo.',
+        troubleshootingSteps: legacyConfigFile
+          ? `Inspect the legacy file at ${legacyConfigFile}. If it is corrupt, fix the YAML or remove it, ` +
+            'then re-run the command. Also verify file system permissions for your Solo home directory.'
+          : 'Inspect the legacy local configuration file. If it is corrupt, fix the YAML or remove it, then ' +
+            're-run the command. Also verify file system permissions for your Solo home directory.',
       },
       cause,
     );

--- a/src/core/errors/error-code-registry.ts
+++ b/src/core/errors/error-code-registry.ts
@@ -8,6 +8,7 @@ export const ErrorCodeRegistry: Record<string, string> = {
   REMOTE_CONFIGS_MISMATCH: 'SOLO-1004',
   INCOMPLETE_LOCAL_CONFIG: 'SOLO-1005',
   REMOTE_CONFIG_DATA_INVALID: 'SOLO-1006',
+  MIGRATE_LEGACY_LOCAL_CONFIG: 'SOLO-1007',
 
   // 2xxx - Deployment / Infrastructure: Cluster, namespace, pod lifecycle
   CREATE_DEPLOYMENT: 'SOLO-2001',

--- a/src/core/errors/error-code-registry.ts
+++ b/src/core/errors/error-code-registry.ts
@@ -6,6 +6,7 @@ export const ErrorCodeRegistry: Record<string, string> = {
   WRITE_LOCAL_CONFIG: 'SOLO-1002',
   REFRESH_LOCAL_CONFIG_SOURCE: 'SOLO-1003',
   REMOTE_CONFIGS_MISMATCH: 'SOLO-1004',
+  MIGRATE_LEGACY_LOCAL_CONFIG: 'SOLO-1005',
 
   // 2xxx - Deployment / Infrastructure: Cluster, namespace, pod lifecycle
   CREATE_DEPLOYMENT: 'SOLO-2001',

--- a/src/core/errors/solo-errors.ts
+++ b/src/core/errors/solo-errors.ts
@@ -36,6 +36,7 @@ import {LocalConfigNotFoundSoloError} from './classes/config/local-config-not-fo
 import {ReadRemoteConfigBeforeLoadError} from './classes/internal/read-remote-config-before-load-error.js';
 import {RefreshLocalConfigSourceError} from './classes/config/refresh-local-config-source-error.js';
 import {RemoteConfigDataInvalidSoloError} from './classes/config/remote-config-data-invalid-solo-error.js';
+import {MigrateLegacyLocalConfigError} from './classes/config/migrate-legacy-local-config-error.js';
 import {RemoteConfigsMismatchSoloError} from './classes/config/remote-configs-mismatch-solo-error.js';
 import {WriteLocalConfigFileError} from './classes/config/write-local-config-file-error.js';
 import {WriteRemoteConfigBeforeLoadError} from './classes/internal/write-remote-config-before-load-error.js';
@@ -314,6 +315,7 @@ export class SoloErrors {
     readonly remoteDataInvalid: typeof RemoteConfigDataInvalidSoloError;
     readonly remoteMismatch: typeof RemoteConfigsMismatchSoloError;
     readonly writeLocalConfig: typeof WriteLocalConfigFileError;
+    readonly migrateLegacyLocalConfig: typeof MigrateLegacyLocalConfigError;
   } = Object.freeze({
     incompleteLocalConfig: IncompleteLocalConfigError,
     localNotFound: LocalConfigNotFoundSoloError,
@@ -321,6 +323,7 @@ export class SoloErrors {
     remoteDataInvalid: RemoteConfigDataInvalidSoloError,
     remoteMismatch: RemoteConfigsMismatchSoloError,
     writeLocalConfig: WriteLocalConfigFileError,
+    migrateLegacyLocalConfig: MigrateLegacyLocalConfigError,
   });
 
   // 2xxx - Deployment / Infrastructure: Cluster, namespace, pod lifecycle

--- a/src/core/errors/solo-errors.ts
+++ b/src/core/errors/solo-errors.ts
@@ -31,6 +31,7 @@ import {ResourceNotFoundError} from './classes/system/resource-not-found-error.j
 import {LocalConfigNotFoundSoloError} from './classes/config/local-config-not-found-solo-error.js';
 import {ReadRemoteConfigBeforeLoadError} from './classes/internal/read-remote-config-before-load-error.js';
 import {RefreshLocalConfigSourceError} from './classes/config/refresh-local-config-source-error.js';
+import {MigrateLegacyLocalConfigError} from './classes/config/migrate-legacy-local-config-error.js';
 import {RemoteConfigsMismatchSoloError} from './classes/config/remote-configs-mismatch-solo-error.js';
 import {WriteLocalConfigFileError} from './classes/config/write-local-config-file-error.js';
 import {WriteRemoteConfigBeforeLoadError} from './classes/internal/write-remote-config-before-load-error.js';
@@ -305,11 +306,13 @@ export class SoloErrors {
     readonly refreshLocalConfigSource: typeof RefreshLocalConfigSourceError;
     readonly remoteMismatch: typeof RemoteConfigsMismatchSoloError;
     readonly writeLocalConfig: typeof WriteLocalConfigFileError;
+    readonly migrateLegacyLocalConfig: typeof MigrateLegacyLocalConfigError;
   } = Object.freeze({
     localNotFound: LocalConfigNotFoundSoloError,
     refreshLocalConfigSource: RefreshLocalConfigSourceError,
     remoteMismatch: RemoteConfigsMismatchSoloError,
     writeLocalConfig: WriteLocalConfigFileError,
+    migrateLegacyLocalConfig: MigrateLegacyLocalConfigError,
   });
 
   // 2xxx - Deployment / Infrastructure: Cluster, namespace, pod lifecycle

--- a/test/unit/business/runtime-state/local-config-runtime-state.test.ts
+++ b/test/unit/business/runtime-state/local-config-runtime-state.test.ts
@@ -5,6 +5,7 @@ import {LocalConfigRuntimeState} from '../../../../src/business/runtime-state/co
 import {DeploymentNotFoundError} from '../../../../src/core/errors/classes/deployment/deployment-not-found-error.js';
 import {RefreshLocalConfigSourceError} from '../../../../src/core/errors/classes/config/refresh-local-config-source-error.js';
 import {IncompleteLocalConfigError} from '../../../../src/core/errors/classes/config/incomplete-local-config-error.js';
+import {MigrateLegacyLocalConfigError} from '../../../../src/core/errors/classes/config/migrate-legacy-local-config-error.js';
 import {getTemporaryDirectory} from '../../../test-utility.js';
 import fs from 'node:fs';
 import {PathEx} from '../../../../src/business/utils/path-ex.js';
@@ -29,6 +30,22 @@ describe('LocalConfigRuntimeState', (): void => {
     deployment.shard = 2;
     await runtimeState.persist();
     await runtimeState.load();
+  }
+
+  const validLegacyConfig: string =
+    "userEmailAddress: joe@doe.com\nsoloVersion: '0.35.1'\ndeployments: {}\nclusterRefs: {}\n";
+
+  function legacyConfigFilePath(): string {
+    return PathEx.join(basePath, 'cache', testFileName);
+  }
+
+  function currentConfigFilePath(): string {
+    return PathEx.join(basePath, testFileName);
+  }
+
+  function writeLegacyConfig(contents: string): void {
+    fs.mkdirSync(PathEx.join(basePath, 'cache'), {recursive: true});
+    fs.writeFileSync(legacyConfigFilePath(), contents);
   }
 
   beforeEach((): void => {
@@ -154,5 +171,46 @@ describe('LocalConfigRuntimeState', (): void => {
       expect(soloError.message).to.include(filePath);
       expect(soloError.getTroubleshootingSteps().join('\n')).to.include('solo deployment config import');
     }
+  });
+
+  describe('legacy config migration', (): void => {
+    it('migrates a valid legacy config, then removes the legacy file', async (): Promise<void> => {
+      writeLegacyConfig(validLegacyConfig);
+
+      await runtimeState.load();
+
+      expect(fs.existsSync(currentConfigFilePath()), 'current config should exist').to.be.true;
+      expect(fs.existsSync(legacyConfigFilePath()), 'legacy config should be removed').to.be.false;
+      // the migrated config validated and loaded, and the persisted file carries the current schema
+      expect(runtimeState.isLoaded, 'config should be loaded').to.be.true;
+      expect(fs.readFileSync(currentConfigFilePath(), 'utf8')).to.contain('schemaVersion');
+    });
+
+    it('preserves the legacy file and throws when the legacy config is corrupt', async (): Promise<void> => {
+      writeLegacyConfig('this: is: not: valid: yaml: [unterminated');
+
+      let caughtError: Error | undefined;
+      try {
+        await runtimeState.load();
+      } catch (error) {
+        caughtError = error as Error;
+      }
+
+      expect(caughtError, 'a migration error should be thrown').to.be.instanceOf(MigrateLegacyLocalConfigError);
+      // the legacy file must never be lost, and the corrupt copy must not be propagated
+      expect(fs.existsSync(legacyConfigFilePath()), 'legacy config should be preserved').to.be.true;
+      expect(fs.existsSync(currentConfigFilePath()), 'corrupt copy should not be propagated').to.be.false;
+    });
+
+    it('removes the redundant legacy file when a current config already exists', async (): Promise<void> => {
+      await runtimeState.persist();
+      expect(fs.existsSync(currentConfigFilePath())).to.be.true;
+      writeLegacyConfig(validLegacyConfig);
+
+      await runtimeState.load();
+
+      expect(fs.existsSync(currentConfigFilePath()), 'current config should remain').to.be.true;
+      expect(fs.existsSync(legacyConfigFilePath()), 'redundant legacy config should be removed').to.be.false;
+    });
   });
 });

--- a/test/unit/business/runtime-state/local-config-runtime-state.test.ts
+++ b/test/unit/business/runtime-state/local-config-runtime-state.test.ts
@@ -4,6 +4,7 @@ import {expect} from 'chai';
 import {LocalConfigRuntimeState} from '../../../../src/business/runtime-state/config/local/local-config-runtime-state.js';
 import {DeploymentNotFoundError} from '../../../../src/core/errors/classes/deployment/deployment-not-found-error.js';
 import {RefreshLocalConfigSourceError} from '../../../../src/core/errors/classes/config/refresh-local-config-source-error.js';
+import {MigrateLegacyLocalConfigError} from '../../../../src/core/errors/classes/config/migrate-legacy-local-config-error.js';
 import {getTemporaryDirectory} from '../../../test-utility.js';
 import fs from 'node:fs';
 import {PathEx} from '../../../../src/business/utils/path-ex.js';
@@ -28,6 +29,22 @@ describe('LocalConfigRuntimeState', (): void => {
     deployment.shard = 2;
     await runtimeState.persist();
     await runtimeState.load();
+  }
+
+  const validLegacyConfig: string =
+    "userEmailAddress: joe@doe.com\nsoloVersion: '0.35.1'\ndeployments: {}\nclusterRefs: {}\n";
+
+  function legacyConfigFilePath(): string {
+    return PathEx.join(basePath, 'cache', testFileName);
+  }
+
+  function currentConfigFilePath(): string {
+    return PathEx.join(basePath, testFileName);
+  }
+
+  function writeLegacyConfig(contents: string): void {
+    fs.mkdirSync(PathEx.join(basePath, 'cache'), {recursive: true});
+    fs.writeFileSync(legacyConfigFilePath(), contents);
   }
 
   beforeEach((): void => {
@@ -87,5 +104,46 @@ describe('LocalConfigRuntimeState', (): void => {
       expect(soloError.message).to.include(filePath);
       expect(soloError.getTroubleshootingSteps().join('\n')).to.include('solo deployment config import');
     }
+  });
+
+  describe('legacy config migration', (): void => {
+    it('migrates a valid legacy config, then removes the legacy file', async (): Promise<void> => {
+      writeLegacyConfig(validLegacyConfig);
+
+      await runtimeState.load();
+
+      expect(fs.existsSync(currentConfigFilePath()), 'current config should exist').to.be.true;
+      expect(fs.existsSync(legacyConfigFilePath()), 'legacy config should be removed').to.be.false;
+      // the migrated config validated and loaded, and the persisted file carries the current schema
+      expect(runtimeState.isLoaded, 'config should be loaded').to.be.true;
+      expect(fs.readFileSync(currentConfigFilePath(), 'utf8')).to.contain('schemaVersion');
+    });
+
+    it('preserves the legacy file and throws when the legacy config is corrupt', async (): Promise<void> => {
+      writeLegacyConfig('this: is: not: valid: yaml: [unterminated');
+
+      let caughtError: Error | undefined;
+      try {
+        await runtimeState.load();
+      } catch (error) {
+        caughtError = error as Error;
+      }
+
+      expect(caughtError, 'a migration error should be thrown').to.be.instanceOf(MigrateLegacyLocalConfigError);
+      // the legacy file must never be lost, and the corrupt copy must not be propagated
+      expect(fs.existsSync(legacyConfigFilePath()), 'legacy config should be preserved').to.be.true;
+      expect(fs.existsSync(currentConfigFilePath()), 'corrupt copy should not be propagated').to.be.false;
+    });
+
+    it('removes the redundant legacy file when a current config already exists', async (): Promise<void> => {
+      await runtimeState.persist();
+      expect(fs.existsSync(currentConfigFilePath())).to.be.true;
+      writeLegacyConfig(validLegacyConfig);
+
+      await runtimeState.load();
+
+      expect(fs.existsSync(currentConfigFilePath()), 'current config should remain').to.be.true;
+      expect(fs.existsSync(legacyConfigFilePath()), 'redundant legacy config should be removed').to.be.false;
+    });
   });
 });


### PR DESCRIPTION
## Description

On upgrade, the legacy ~/.solo/cache/local-config.yaml was copied to the new path and the old file deleted unconditionally, before validation ran. A corrupt legacy file was propagated to the new path, the old file was lost, and the subsequent parse failure escaped as an unwrapped fs/parse error.

load() now stages the legacy file at the new path, validates/migrates it, and only deletes the legacy file after a successful persist. On a corrupt legacy config the copied file is discarded and the legacy file is kept in place, and a typed MigrateLegacyLocalConfigError (SOLO-1005) is thrown with actionable guidance. A successful migration prunes unknown fields via the mapper and logs a WARN. The copy/remove/mkdir fs operations are wrapped in the typed error.

### Related Issues

* Closes #5443
* Related to #

### Pull request (PR) checklist

* \[x] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[x] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[x] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[x] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

### Manual Testing

1. Valid legacy migration — placed a v0 config at $SOLO_HOME/cache/local-config.yaml
   (no file at the new path). Result: migrated to $SOLO_HOME/local-config.yaml
   (schemaVersion: 2), legacy file removed, and a WARN logged:
   "Migrated legacy local configuration from .../cache/local-config.yaml to .../local-config.yaml".

2. Corrupt legacy — replaced it with invalid YAML. Result: command failed with an
   actionable error ("Failed to migrate legacy local configuration file: .../cache/local-config.yaml
   → Inspect the legacy file... fix the YAML or remove it"); the legacy file was PRESERVED
   and no corrupt file was written to the new path.

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
