### PR TITLE
fix: throw ClusterUnreachableError for non-kind clusters and preserve the original cause

### DIFF
--- a/src/business/runtime-state/config/remote/remote-config-runtime-state.ts
+++ b/src/business/runtime-state/config/remote/remote-config-runtime-state.ts
@@ -56,6 +56,9 @@ import {RemoteConfig} from './remote-config.js';
 import {ComponentIdsSchema} from '../../../../data/schema/model/remote/state/component-ids-schema.js';
 import {type BaseStateSchema} from '../../../../data/schema/model/remote/state/base-state-schema.js';
 import {Helpers} from '../../../../core/helpers.js';
+import {Duration} from '../../../../core/time/duration.js';
+import {type ContainerEngineClient} from '../../../../integration/container-engine/container-engine-client.js';
+import {ClusterNodeResumeOutcome} from '../../../../integration/container-engine/cluster-node-resume-outcome.js';
 import {ResourceNotFoundError} from '../../../../integration/kube/errors/resource-operation-errors.js';
 import {MissingRequiredParametersError} from '../../errors/missing-required-parameters-error.js';
 import {SemanticVersion} from '../../../utils/semantic-version.js';
@@ -72,6 +75,13 @@ interface VersionField {
 @injectable()
 export class RemoteConfigRuntimeState implements RemoteConfigRuntimeStateApi {
   private static readonly SOLO_REMOTE_CONFIGMAP_DATA_KEY: string = 'remote-config-data';
+
+  /** Kind names the kubeconfig context it writes `kind-<cluster-name>`. */
+  private static readonly KIND_CONTEXT_PREFIX: string = 'kind-';
+
+  /** How long to wait for a resumed kind cluster's API: 30 attempts every 2 seconds, so at most a minute. */
+  private static readonly KIND_RESUME_MAX_ATTEMPTS: number = 30;
+  private static readonly KIND_RESUME_RETRY_INTERVAL: Duration = Duration.ofSeconds(2);
 
   private phase: RuntimeStatePhase = RuntimeStatePhase.NotLoaded;
 
@@ -90,6 +100,7 @@ export class RemoteConfigRuntimeState implements RemoteConfigRuntimeStateApi {
     @inject(InjectTokens.ConfigManager) private readonly configManager?: ConfigManager,
     @inject(InjectTokens.RemoteConfigValidator) private readonly remoteConfigValidator?: RemoteConfigValidatorApi,
     @inject(InjectTokens.ObjectMapper) private readonly objectMapper?: ObjectMapper,
+    @inject(InjectTokens.ContainerEngineClient) private readonly containerEngine?: ContainerEngineClient,
   ) {
     this.k8Factory = patchInject(k8Factory, InjectTokens.K8Factory, this.constructor.name);
     this.logger = patchInject(logger, InjectTokens.SoloLogger, this.constructor.name);
@@ -101,6 +112,7 @@ export class RemoteConfigRuntimeState implements RemoteConfigRuntimeStateApi {
       this.constructor.name,
     );
     this.objectMapper = patchInject(objectMapper, InjectTokens.ObjectMapper, this.constructor.name);
+    this.containerEngine = patchInject(containerEngine, InjectTokens.ContainerEngineClient, this.constructor.name);
   }
 
   public get configuration(): RemoteConfig {
@@ -321,22 +333,22 @@ export class RemoteConfigRuntimeState implements RemoteConfigRuntimeStateApi {
 
     let configMap: ConfigMap;
     try {
-      configMap = await this.k8Factory
-        .getK8(context)
-        .configMaps()
-        .read(namespace, constants.SOLO_REMOTE_CONFIGMAP_NAME);
+      configMap = await this.readRemoteConfigMap(namespace, context);
     } catch (error) {
       if (error instanceof ResourceNotFoundError) {
         throw error;
       }
 
-      // A kind cluster runs on this machine, so a failure there is a local API problem rather than a cluster
-      // solo cannot reach. Kind names its kubeconfig context `kind-<cluster-name>`, the same heuristic the
-      // one-shot deploy orchestrator uses. Either way the original failure is kept as the cause so the real
-      // reason (context down, RBAC denial, API error) reaches the error output and the logs.
-      throw context.startsWith('kind-')
-        ? new SoloErrors.system.kubernetesApiInvalidResponse(error)
-        : new SoloErrors.system.clusterUnreachable(context, error);
+      // A kind cluster runs on this machine, so a failure there is a local problem rather than a cluster solo
+      // cannot reach — and the usual local problem is a node container that is simply stopped. Kind names its
+      // kubeconfig context `kind-<cluster-name>`, the same heuristic the one-shot deploy orchestrator uses.
+      // Either way the original failure is kept as the cause so the real reason (context down, RBAC denial,
+      // API error) reaches the error output and the logs.
+      if (!context.startsWith(RemoteConfigRuntimeState.KIND_CONTEXT_PREFIX)) {
+        throw new SoloErrors.system.clusterUnreachable(context, error);
+      }
+
+      configMap = await this.resumeKindClusterAndRead(namespace, context, error);
     }
     if (!configMap) {
       throw new SoloErrors.system.resourceNotFound(
@@ -345,6 +357,61 @@ export class RemoteConfigRuntimeState implements RemoteConfigRuntimeStateApi {
     }
 
     return configMap;
+  }
+
+  private async readRemoteConfigMap(namespace: NamespaceName, context: Context): Promise<ConfigMap> {
+    return await this.k8Factory.getK8(context).configMaps().read(namespace, constants.SOLO_REMOTE_CONFIGMAP_NAME);
+  }
+
+  /**
+   * Recovers a kind cluster whose node container was left stopped — by a reboot or a manual stop — and reads
+   * the remote config ConfigMap again once its Kubernetes API answers.
+   *
+   * Only a container that solo actually started is waited on: when there was nothing to resume the original
+   * failure is reported unchanged, so this never turns an unrelated API failure into a long wait.
+   *
+   * @param namespace - the namespace holding the remote config ConfigMap.
+   * @param context - the kind kubeconfig context the read failed against.
+   * @param cause - the failure that triggered the recovery attempt.
+   */
+  private async resumeKindClusterAndRead(namespace: NamespaceName, context: Context, cause: Error): Promise<ConfigMap> {
+    const clusterName: string = context.slice(RemoteConfigRuntimeState.KIND_CONTEXT_PREFIX.length);
+    const outcome: ClusterNodeResumeOutcome = await this.containerEngine.resumeStoppedClusterNode(clusterName);
+
+    if (outcome === ClusterNodeResumeOutcome.ENGINE_UNAVAILABLE) {
+      throw new SoloErrors.system.containerEngineNotRunning(cause);
+    }
+
+    if (outcome !== ClusterNodeResumeOutcome.RESUMED) {
+      throw new SoloErrors.system.kubernetesApiInvalidResponse(cause);
+    }
+
+    this.logger.showUser(
+      `The kind cluster '${clusterName}' was stopped; solo started its node container and is waiting for the Kubernetes API...`,
+    );
+
+    let lastError: Error = cause;
+
+    for (let attempt: number = 0; attempt < RemoteConfigRuntimeState.KIND_RESUME_MAX_ATTEMPTS; attempt++) {
+      if (attempt > 0) {
+        await Helpers.sleep(RemoteConfigRuntimeState.KIND_RESUME_RETRY_INTERVAL);
+      }
+
+      try {
+        const configMap: ConfigMap = await this.readRemoteConfigMap(namespace, context);
+        this.logger.showUser(`The kind cluster '${clusterName}' is available again.`);
+        return configMap;
+      } catch (error) {
+        // The API is answering again once it can tell us the ConfigMap is missing, so that is a real answer
+        // rather than a reason to keep waiting.
+        if (error instanceof ResourceNotFoundError) {
+          throw error;
+        }
+        lastError = error;
+      }
+    }
+
+    throw new SoloErrors.system.kindClusterStopped(clusterName, lastError);
   }
 
   public async populateFromExisting(namespace: NamespaceName, context: Context): Promise<void> {

--- a/src/business/runtime-state/config/remote/remote-config-runtime-state.ts
+++ b/src/business/runtime-state/config/remote/remote-config-runtime-state.ts
@@ -326,7 +326,17 @@ export class RemoteConfigRuntimeState implements RemoteConfigRuntimeStateApi {
         .configMaps()
         .read(namespace, constants.SOLO_REMOTE_CONFIGMAP_NAME);
     } catch (error) {
-      throw error instanceof ResourceNotFoundError ? error : new SoloErrors.system.kubernetesApiInvalidResponse();
+      if (error instanceof ResourceNotFoundError) {
+        throw error;
+      }
+
+      // A kind cluster runs on this machine, so a failure there is a local API problem rather than a cluster
+      // solo cannot reach. Kind names its kubeconfig context `kind-<cluster-name>`, the same heuristic the
+      // one-shot deploy orchestrator uses. Either way the original failure is kept as the cause so the real
+      // reason (context down, RBAC denial, API error) reaches the error output and the logs.
+      throw context.startsWith('kind-')
+        ? new SoloErrors.system.kubernetesApiInvalidResponse(error)
+        : new SoloErrors.system.clusterUnreachable(context, error);
     }
     if (!configMap) {
       throw new SoloErrors.system.resourceNotFound(

--- a/src/core/errors/classes/system/cluster-unreachable-error.ts
+++ b/src/core/errors/classes/system/cluster-unreachable-error.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {SoloError} from '../../solo-error.js';
+import {ErrorOwnership} from '../../error-ownership.js';
+import {ErrorCodeRegistry} from '../../error-code-registry.js';
+
+/**
+ * @description Thrown when a Kubernetes API call against a remote cluster fails for any reason other than the
+ * resource being absent; the message names the kubeconfig context and the underlying failure, which is also
+ * wrapped in `cause`. solo reads and writes cluster state over the Kubernetes API for every deployment
+ * operation, so this means the call never produced a usable answer: the API server is down or unreachable over
+ * the network, the kubeconfig context points at a cluster that no longer exists, credentials have expired, or
+ * RBAC denied the request. Kind clusters are excluded — a local kind API failure is reported as a Kubernetes API
+ * invalid response instead. It is retryable because an API server that is restarting, or a transient network
+ * problem, often clears on a later attempt.
+ */
+export class ClusterUnreachableError extends SoloError {
+  protected override readonly retryable: boolean = true;
+  protected override readonly ownership: ErrorOwnership = ErrorOwnership.Infrastructure;
+
+  public constructor(context: string, cause: Error) {
+    super(
+      {
+        message: `Unable to reach the cluster with context: ${context}: ${cause.message}`,
+        code: ErrorCodeRegistry.CLUSTER_UNREACHABLE,
+        troubleshootingSteps:
+          'Verify the cluster is reachable: kubectl cluster-info --context <context>\n' +
+          'Verify the kubeconfig context still exists: kubectl config get-contexts\n' +
+          'Verify your credentials and RBAC permissions for the namespace\n' +
+          'Check solo logs: tail -n 100 ~/.solo/logs/solo.log',
+      },
+      cause,
+    );
+  }
+}

--- a/src/core/errors/classes/system/container-engine-not-running-error.ts
+++ b/src/core/errors/classes/system/container-engine-not-running-error.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {SoloError} from '../../solo-error.js';
+import {ErrorOwnership} from '../../error-ownership.js';
+import {ErrorCodeRegistry} from '../../error-code-registry.js';
+
+/**
+ * @description Thrown when solo needs the local container engine and neither Docker nor Podman answers; the
+ * failure that led solo to look is wrapped in `cause`. A local kind cluster only exists as containers on this
+ * machine, so with no engine running solo can neither reach the cluster nor tell whether it is still there.
+ * The usual reason is simply that Docker Desktop, the Docker daemon or the Podman machine is not started. solo
+ * does not start the engine itself, because doing so is platform-specific and needs privileges the CLI should
+ * not take on its own. It is retryable once the engine is up.
+ */
+export class ContainerEngineNotRunningError extends SoloError {
+  protected override readonly retryable: boolean = true;
+  protected override readonly ownership: ErrorOwnership = ErrorOwnership.User;
+
+  public constructor(cause: Error) {
+    super(
+      {
+        message: `No container engine is running, so the local cluster cannot be reached: ${cause.message}`,
+        code: ErrorCodeRegistry.CONTAINER_ENGINE_NOT_RUNNING,
+        troubleshootingSteps:
+          'Start Docker Desktop, or the Docker daemon: sudo systemctl start docker\n' +
+          'If you use Podman, start its machine: podman machine start\n' +
+          'Confirm the engine answers: docker info\n' +
+          'Then re-run the command',
+      },
+      cause,
+    );
+  }
+}

--- a/src/core/errors/classes/system/kind-cluster-stopped-error.ts
+++ b/src/core/errors/classes/system/kind-cluster-stopped-error.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {SoloError} from '../../solo-error.js';
+import {ErrorOwnership} from '../../error-ownership.js';
+import {ErrorCodeRegistry} from '../../error-code-registry.js';
+
+/**
+ * @description Thrown when a kind cluster's node container was found stopped, solo started it again, and the
+ * cluster's Kubernetes API still did not answer; the last API failure is wrapped in `cause`. A kind node that
+ * restarts but never serves its API usually means the cluster did not survive whatever stopped it — the host
+ * was rebooted and the node's networking or storage no longer lines up, the container is crash-looping, or the
+ * kubeconfig entry now points at a port the restarted node no longer listens on. It is retryable because a
+ * control plane can simply need longer than solo waited.
+ */
+export class KindClusterStoppedError extends SoloError {
+  protected override readonly retryable: boolean = true;
+  protected override readonly ownership: ErrorOwnership = ErrorOwnership.Infrastructure;
+
+  public constructor(clusterName: string, cause: Error) {
+    super(
+      {
+        message:
+          `The kind cluster '${clusterName}' node container was stopped; solo started it, but the ` +
+          `Kubernetes API did not become available: ${cause.message}`,
+        code: ErrorCodeRegistry.KIND_CLUSTER_STOPPED,
+        troubleshootingSteps:
+          `Check the node container is running: docker ps -a --filter name=${clusterName}-control-plane\n` +
+          `Inspect why the node is not serving its API: docker logs ${clusterName}-control-plane\n` +
+          `Verify the cluster answers: kubectl cluster-info --context kind-${clusterName}\n` +
+          `Recreate the cluster if it did not survive being stopped: kind delete cluster --name ${clusterName}`,
+      },
+      cause,
+    );
+  }
+}

--- a/src/core/errors/classes/system/kubernetes-api-invalid-response-solo-error.ts
+++ b/src/core/errors/classes/system/kubernetes-api-invalid-response-solo-error.ts
@@ -5,23 +5,27 @@ import {ErrorOwnership} from '../../error-ownership.js';
 import {ErrorCodeRegistry} from '../../error-code-registry.js';
 
 /**
- * @description Thrown when the Kubernetes API returns an incorrect or unexpected response. solo expects well-formed
- * responses from the API, so this means a call returned something it could not interpret — for example a
- * malformed or partial response, often indicating an API server problem.
+ * @description Thrown when the Kubernetes API returns an incorrect or unexpected response; when the underlying
+ * failure is known it is named in the message and wrapped in `cause`. solo expects well-formed responses from
+ * the API, so this means a call returned something it could not interpret — for example a malformed or partial
+ * response, often indicating an API server problem.
  */
 export class KubernetesApiInvalidResponseSoloError extends SoloError {
   protected override readonly retryable: boolean = false;
   protected override readonly ownership: ErrorOwnership = ErrorOwnership.Infrastructure;
 
-  public constructor() {
-    super({
-      message: 'Received an incorrect or unexpected response from the Kubernetes API',
-      code: ErrorCodeRegistry.KUBERNETES_API_INVALID_RESPONSE,
-      troubleshootingSteps:
-        'Check solo logs: tail -n 100 ~/.solo/logs/solo.log\n' +
-        'Verify Kubernetes API server is reachable: kubectl cluster-info\n' +
-        'Check kubeconfig context: kubectl config current-context\n' +
-        'Inspect Kubernetes API server health',
-    });
+  public constructor(cause?: Error) {
+    super(
+      {
+        message: `Received an incorrect or unexpected response from the Kubernetes API${cause ? `: ${cause.message}` : ''}`,
+        code: ErrorCodeRegistry.KUBERNETES_API_INVALID_RESPONSE,
+        troubleshootingSteps:
+          'Check solo logs: tail -n 100 ~/.solo/logs/solo.log\n' +
+          'Verify Kubernetes API server is reachable: kubectl cluster-info\n' +
+          'Check kubeconfig context: kubectl config current-context\n' +
+          'Inspect Kubernetes API server health',
+      },
+      cause,
+    );
   }
 }

--- a/src/core/errors/error-code-registry.ts
+++ b/src/core/errors/error-code-registry.ts
@@ -291,6 +291,7 @@ export const ErrorCodeRegistry: Record<string, string> = {
   BLOCK_NODES_JSON_EMPTY: 'SOLO-5075',
   HELM_CHART_PULL_NO_ARCHIVE: 'SOLO-5076',
   PODMAN_RUNTIME_CONFIGURATION_FAILED: 'SOLO-5077',
+  CLUSTER_UNREACHABLE: 'SOLO-5078',
 
   // 9xxx - Internal: Unexpected bugs, unimplemented paths
   TIMEOUT: 'SOLO-9001',

--- a/src/core/errors/error-code-registry.ts
+++ b/src/core/errors/error-code-registry.ts
@@ -292,6 +292,8 @@ export const ErrorCodeRegistry: Record<string, string> = {
   HELM_CHART_PULL_NO_ARCHIVE: 'SOLO-5076',
   PODMAN_RUNTIME_CONFIGURATION_FAILED: 'SOLO-5077',
   CLUSTER_UNREACHABLE: 'SOLO-5078',
+  KIND_CLUSTER_STOPPED: 'SOLO-5079',
+  CONTAINER_ENGINE_NOT_RUNNING: 'SOLO-5080',
 
   // 9xxx - Internal: Unexpected bugs, unimplemented paths
   TIMEOUT: 'SOLO-9001',

--- a/src/core/errors/kube-error-translator.ts
+++ b/src/core/errors/kube-error-translator.ts
@@ -39,7 +39,7 @@ export class KubeErrorTranslator {
       return new SoloErrors.system.multipleItemsFound(error.filters);
     }
     if (error instanceof KubeApiInvalidResponseError) {
-      return new SoloErrors.system.kubernetesApiInvalidResponse();
+      return new SoloErrors.system.kubernetesApiInvalidResponse(error);
     }
     if (error instanceof KubePvcCreationFailedError) {
       return new SoloErrors.system.pvcCreationFailed();

--- a/src/core/errors/solo-errors.ts
+++ b/src/core/errors/solo-errors.ts
@@ -21,6 +21,7 @@ import {ConsensusNodeCountRequiredError} from './classes/validation/consensus-no
 import {InvalidOutputFormatError} from './classes/validation/invalid-output-format-error.js';
 import {InvalidPortNumberError} from './classes/validation/invalid-port-number-error.js';
 import {ClusterConnectionFailedError} from './classes/system/cluster-connection-failed-error.js';
+import {ClusterUnreachableError} from './classes/system/cluster-unreachable-error.js';
 import {GitHubApiHttpResponseError} from './classes/system/github-api-http-response-error.js';
 import {GitHubApiRequestFailedError} from './classes/system/github-api-request-failed-error.js';
 import {GitHubApiResponseMissingTagNameError} from './classes/system/github-api-response-missing-tag-name-error.js';
@@ -725,6 +726,7 @@ export class SoloErrors {
     readonly blockNodesJsonEmpty: typeof BlockNodesJsonEmptySoloError;
     readonly externalBlockNodeNotInRemoteConfig: typeof ExternalBlockNodeNotInRemoteConfigSoloError;
     readonly clusterConnectionFailed: typeof ClusterConnectionFailedError;
+    readonly clusterUnreachable: typeof ClusterUnreachableError;
     readonly githubApiHttpResponseError: typeof GitHubApiHttpResponseError;
     readonly githubApiRequestFailed: typeof GitHubApiRequestFailedError;
     readonly githubApiResponseMissingTagName: typeof GitHubApiResponseMissingTagNameError;
@@ -804,6 +806,7 @@ export class SoloErrors {
     blockNodesJsonEmpty: BlockNodesJsonEmptySoloError,
     externalBlockNodeNotInRemoteConfig: ExternalBlockNodeNotInRemoteConfigSoloError,
     clusterConnectionFailed: ClusterConnectionFailedError,
+    clusterUnreachable: ClusterUnreachableError,
     githubApiHttpResponseError: GitHubApiHttpResponseError,
     githubApiRequestFailed: GitHubApiRequestFailedError,
     githubApiResponseMissingTagName: GitHubApiResponseMissingTagNameError,

--- a/src/core/errors/solo-errors.ts
+++ b/src/core/errors/solo-errors.ts
@@ -22,6 +22,8 @@ import {InvalidOutputFormatError} from './classes/validation/invalid-output-form
 import {InvalidPortNumberError} from './classes/validation/invalid-port-number-error.js';
 import {ClusterConnectionFailedError} from './classes/system/cluster-connection-failed-error.js';
 import {ClusterUnreachableError} from './classes/system/cluster-unreachable-error.js';
+import {KindClusterStoppedError} from './classes/system/kind-cluster-stopped-error.js';
+import {ContainerEngineNotRunningError} from './classes/system/container-engine-not-running-error.js';
 import {GitHubApiHttpResponseError} from './classes/system/github-api-http-response-error.js';
 import {GitHubApiRequestFailedError} from './classes/system/github-api-request-failed-error.js';
 import {GitHubApiResponseMissingTagNameError} from './classes/system/github-api-response-missing-tag-name-error.js';
@@ -727,6 +729,8 @@ export class SoloErrors {
     readonly externalBlockNodeNotInRemoteConfig: typeof ExternalBlockNodeNotInRemoteConfigSoloError;
     readonly clusterConnectionFailed: typeof ClusterConnectionFailedError;
     readonly clusterUnreachable: typeof ClusterUnreachableError;
+    readonly kindClusterStopped: typeof KindClusterStoppedError;
+    readonly containerEngineNotRunning: typeof ContainerEngineNotRunningError;
     readonly githubApiHttpResponseError: typeof GitHubApiHttpResponseError;
     readonly githubApiRequestFailed: typeof GitHubApiRequestFailedError;
     readonly githubApiResponseMissingTagName: typeof GitHubApiResponseMissingTagNameError;
@@ -807,6 +811,8 @@ export class SoloErrors {
     externalBlockNodeNotInRemoteConfig: ExternalBlockNodeNotInRemoteConfigSoloError,
     clusterConnectionFailed: ClusterConnectionFailedError,
     clusterUnreachable: ClusterUnreachableError,
+    kindClusterStopped: KindClusterStoppedError,
+    containerEngineNotRunning: ContainerEngineNotRunningError,
     githubApiHttpResponseError: GitHubApiHttpResponseError,
     githubApiRequestFailed: GitHubApiRequestFailedError,
     githubApiResponseMissingTagName: GitHubApiResponseMissingTagNameError,

--- a/src/integration/container-engine/cluster-node-resume-outcome.ts
+++ b/src/integration/container-engine/cluster-node-resume-outcome.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/** The result of attempting to resume a cluster's stopped node container. */
+export enum ClusterNodeResumeOutcome {
+  /** The node container was stopped and has been started again. */
+  RESUMED = 'resumed',
+
+  /** Nothing changed: the node container is already running, does not exist, or refused to start. */
+  UNCHANGED = 'unchanged',
+
+  /** No container engine could be reached, so the node container's state is unknown. */
+  ENGINE_UNAVAILABLE = 'engine-unavailable',
+}

--- a/src/integration/container-engine/container-engine-client.ts
+++ b/src/integration/container-engine/container-engine-client.ts
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import {type ClusterNodeResumeOutcome} from './cluster-node-resume-outcome.js';
+
 /**
  * Abstraction over local container engine operations.
  *
@@ -43,4 +45,13 @@ export interface ContainerEngineClient {
    * Lists all images loaded into the local container engine.
    */
   listLoadedImagesInCluster(clusterName: string): Promise<readonly string[]>;
+
+  /**
+   * Starts the cluster's node container when it exists but is stopped, so a local cluster that was left
+   * behind by a reboot or a manual stop can be used again without recreating it.
+   *
+   * Best-effort by contract: it reports what it found rather than throwing, so a caller that is already
+   * handling a cluster failure can decide what to surface.
+   */
+  resumeStoppedClusterNode(clusterName: string): Promise<ClusterNodeResumeOutcome>;
 }

--- a/src/integration/container-engine/docker-client.ts
+++ b/src/integration/container-engine/docker-client.ts
@@ -18,14 +18,23 @@ import {Architecture} from '../../business/utils/architecture.js';
 import {type ContainerEngineCommand} from './container-engine-command.js';
 import {PathEx} from '../../business/utils/path-ex.js';
 import {PodmanClient} from './podman-client.js';
+import {ContainerEngineResourceInspector} from './container-engine-resource-inspector.js';
+import {ClusterNodeResumeOutcome} from './cluster-node-resume-outcome.js';
+import {type ContainerEngineResources} from './container-engine-resources.js';
 import {create as createTarball} from 'tar';
 
 @injectable()
 export class DockerClient implements ContainerEngineClient {
   private static readonly IMAGE_PULL_TIMEOUT_MS: number = 10 * 60 * 1000;
   private static readonly IMAGE_PULL_IDLE_TIMEOUT_MS: number = 10 * 60 * 1000;
+  private static readonly CONTAINER_LIFECYCLE_TIMEOUT_MS: number = 30 * 1000;
+
+  /** Container states a stopped node can be started from; `paused` needs `unpause` and is left alone. */
+  private static readonly STARTABLE_CONTAINER_STATES: ReadonlySet<string> = new Set(['exited', 'created']);
+
   private readonly shellRunner: ShellRunner;
   private readonly podmanClient: PodmanClient;
+  private readonly resourceInspector: ContainerEngineResourceInspector;
 
   public constructor(
     @inject(InjectTokens.KindBuilder) private readonly kindBuilder?: DefaultKindClientBuilder,
@@ -37,6 +46,7 @@ export class DockerClient implements ContainerEngineClient {
     this.dependencyManager = patchInject(dependencyManager, InjectTokens.DependencyManager, this.constructor.name);
     this.shellRunner = new ShellRunner(this.logger);
     this.podmanClient = new PodmanClient(this.logger);
+    this.resourceInspector = new ContainerEngineResourceInspector(this.logger);
   }
 
   public async pullImage(image: string): Promise<void> {
@@ -157,5 +167,62 @@ export class DockerClient implements ContainerEngineClient {
       .map((line): string => line.trim())
       .filter((line): boolean => line.length > 0)
       .filter((line): boolean => !line.startsWith('import-'));
+  }
+
+  public async resumeStoppedClusterNode(clusterName: string): Promise<ClusterNodeResumeOutcome> {
+    const nodeName: string = `${clusterName}-control-plane`;
+    const engineCommand: ContainerEngineCommand = (await this.podmanClient.getKindContainerCommand(nodeName)) ?? {
+      executable: constants.DOCKER,
+      argumentsPrefix: [],
+    };
+
+    const state: string | undefined = await this.readContainerState(engineCommand, nodeName);
+
+    if (state === undefined) {
+      // The inspect answered nothing, which means either no engine is reachable or this cluster has no node
+      // container. Only the first is worth reporting, and an engine info probe is the cheapest way to tell
+      // the two apart without matching on engine error text.
+      const resources: ContainerEngineResources | undefined = await this.resourceInspector.getAvailableResources();
+      return resources === undefined ? ClusterNodeResumeOutcome.ENGINE_UNAVAILABLE : ClusterNodeResumeOutcome.UNCHANGED;
+    }
+
+    if (!DockerClient.STARTABLE_CONTAINER_STATES.has(state)) {
+      return ClusterNodeResumeOutcome.UNCHANGED;
+    }
+
+    try {
+      await this.shellRunner.run(engineCommand.executable, [...engineCommand.argumentsPrefix, 'start', nodeName], {
+        commandProfile: SubprocessCommandProfile.CONTAINER_ENGINE,
+        timeoutMs: DockerClient.CONTAINER_LIFECYCLE_TIMEOUT_MS,
+      });
+      return ClusterNodeResumeOutcome.RESUMED;
+    } catch (error) {
+      // best-effort: a node container that refuses to start is reported as unchanged so the caller surfaces
+      // the cluster failure it was already handling rather than this secondary one.
+      this.logger.debug(`Unable to start the stopped cluster node container ${nodeName}`, error);
+      return ClusterNodeResumeOutcome.UNCHANGED;
+    }
+  }
+
+  private async readContainerState(
+    engineCommand: ContainerEngineCommand,
+    nodeName: string,
+  ): Promise<string | undefined> {
+    try {
+      const output: string[] = await this.shellRunner.run(
+        engineCommand.executable,
+        [...engineCommand.argumentsPrefix, 'container', 'inspect', '--format', '{{.State.Status}}', nodeName],
+        {
+          commandProfile: SubprocessCommandProfile.CONTAINER_ENGINE,
+          timeoutMs: DockerClient.CONTAINER_LIFECYCLE_TIMEOUT_MS,
+        },
+      );
+      return output.join('').trim() || undefined;
+    } catch (error) {
+      // best-effort probe: the container may be absent or the engine unreachable, and the caller
+      // distinguishes those two cases itself.
+      this.logger.debug(`Unable to read the state of container ${nodeName}`, error);
+      return undefined;
+    }
   }
 }

--- a/test/unit/business/runtime-state/remote-config-runtime-state.test.ts
+++ b/test/unit/business/runtime-state/remote-config-runtime-state.test.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {expect} from 'chai';
+import {RemoteConfigRuntimeState} from '../../../../src/business/runtime-state/config/remote/remote-config-runtime-state.js';
+import {ClusterUnreachableError} from '../../../../src/core/errors/classes/system/cluster-unreachable-error.js';
+import {KubernetesApiInvalidResponseSoloError} from '../../../../src/core/errors/classes/system/kubernetes-api-invalid-response-solo-error.js';
+import {ResourceNotFoundError} from '../../../../src/integration/kube/errors/resource-operation-errors.js';
+import {ResourceOperation} from '../../../../src/integration/kube/resources/resource-operation.js';
+import {ResourceType} from '../../../../src/integration/kube/resources/resource-type.js';
+import {NamespaceName} from '../../../../src/types/namespace/namespace-name.js';
+import {type K8Factory} from '../../../../src/integration/kube/k8-factory.js';
+import {type Context} from '../../../../src/types/index.js';
+
+const namespace: NamespaceName = NamespaceName.of('solo');
+
+/** Builds a runtime state whose ConfigMap read always fails with the given error. */
+function runtimeStateFailingWith(readError: Error): RemoteConfigRuntimeState {
+  const k8Factory: K8Factory = {
+    getK8: (): unknown => ({
+      configMaps: (): unknown => ({
+        read: (): Promise<never> => Promise.reject(readError),
+      }),
+    }),
+  } as unknown as K8Factory;
+
+  // Only the K8Factory is exercised; the remaining dependencies are non-null so they are not resolved
+  // from the container.
+  return new RemoteConfigRuntimeState(
+    k8Factory,
+    {} as unknown as never,
+    {} as unknown as never,
+    {} as unknown as never,
+    {} as unknown as never,
+    {} as unknown as never,
+  );
+}
+
+/** Resolves with the error thrown while reading the remote config ConfigMap over the given context. */
+async function readFailure(readError: Error, context: Context): Promise<Error> {
+  return await runtimeStateFailingWith(readError)
+    .remoteConfigExists(namespace, context)
+    .then(
+      (): Error => undefined,
+      (error: Error): Error => error,
+    );
+}
+
+describe('RemoteConfigRuntimeState', (): void => {
+  it('should throw ClusterUnreachableError preserving the cause for a non-kind context', async (): Promise<void> => {
+    const cause: Error = new Error('connect ECONNREFUSED 10.0.0.1:6443');
+
+    const error: Error = await readFailure(cause, 'production-cluster');
+
+    expect(error).to.be.instanceOf(ClusterUnreachableError);
+    expect(error.message).to.contain('production-cluster');
+    expect(error.message).to.contain('connect ECONNREFUSED 10.0.0.1:6443');
+    expect(error.cause).to.equal(cause);
+  });
+
+  it('should throw KubernetesApiInvalidResponseSoloError preserving the cause for a kind context', async (): Promise<void> => {
+    const cause: Error = new Error('configmaps is forbidden: User cannot list resource');
+
+    const error: Error = await readFailure(cause, 'kind-solo');
+
+    expect(error).to.be.instanceOf(KubernetesApiInvalidResponseSoloError);
+    expect(error.message).to.contain('configmaps is forbidden: User cannot list resource');
+    expect(error.cause).to.equal(cause);
+  });
+
+  it('should rethrow ResourceNotFoundError untouched', async (): Promise<void> => {
+    const notFound: ResourceNotFoundError = new ResourceNotFoundError(
+      ResourceOperation.READ,
+      ResourceType.CONFIG_MAP,
+      namespace,
+      'solo-remote-config',
+    );
+
+    const error: Error = await readFailure(notFound, 'production-cluster');
+
+    expect(error).to.equal(notFound);
+  });
+});

--- a/test/unit/business/runtime-state/remote-config-runtime-state.test.ts
+++ b/test/unit/business/runtime-state/remote-config-runtime-state.test.ts
@@ -1,70 +1,83 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {expect} from 'chai';
+import sinon, {type SinonSandbox, type SinonStub} from 'sinon';
+import {afterEach, beforeEach, describe, it} from 'mocha';
 import {RemoteConfigRuntimeState} from '../../../../src/business/runtime-state/config/remote/remote-config-runtime-state.js';
 import {ClusterUnreachableError} from '../../../../src/core/errors/classes/system/cluster-unreachable-error.js';
 import {KubernetesApiInvalidResponseSoloError} from '../../../../src/core/errors/classes/system/kubernetes-api-invalid-response-solo-error.js';
+import {KindClusterStoppedError} from '../../../../src/core/errors/classes/system/kind-cluster-stopped-error.js';
+import {ContainerEngineNotRunningError} from '../../../../src/core/errors/classes/system/container-engine-not-running-error.js';
 import {ResourceNotFoundError} from '../../../../src/integration/kube/errors/resource-operation-errors.js';
 import {ResourceOperation} from '../../../../src/integration/kube/resources/resource-operation.js';
 import {ResourceType} from '../../../../src/integration/kube/resources/resource-type.js';
 import {NamespaceName} from '../../../../src/types/namespace/namespace-name.js';
 import {type K8Factory} from '../../../../src/integration/kube/k8-factory.js';
+import {type ConfigMap} from '../../../../src/integration/kube/resources/config-map/config-map.js';
+import {type ContainerEngineClient} from '../../../../src/integration/container-engine/container-engine-client.js';
+import {ClusterNodeResumeOutcome} from '../../../../src/integration/container-engine/cluster-node-resume-outcome.js';
+import {Helpers} from '../../../../src/core/helpers.js';
+import {type SoloLogger} from '../../../../src/core/logging/solo-logger.js';
 import {type Context} from '../../../../src/types/index.js';
 
 const namespace: NamespaceName = NamespaceName.of('solo');
+const remoteConfigMap: ConfigMap = {name: 'solo-remote-config'} as unknown as ConfigMap;
 
-/** Builds a runtime state whose ConfigMap read always fails with the given error. */
-function runtimeStateFailingWith(readError: Error): RemoteConfigRuntimeState {
+/**
+ * Builds a runtime state over a stubbed ConfigMap read and a stubbed container engine. Only those two
+ * dependencies are exercised; the rest are non-null so they are not resolved from the container.
+ */
+function buildRuntimeState(read: SinonStub, resumeStoppedClusterNode: SinonStub): RemoteConfigRuntimeState {
   const k8Factory: K8Factory = {
-    getK8: (): unknown => ({
-      configMaps: (): unknown => ({
-        read: (): Promise<never> => Promise.reject(readError),
-      }),
-    }),
+    getK8: (): unknown => ({configMaps: (): unknown => ({read})}),
   } as unknown as K8Factory;
 
-  // Only the K8Factory is exercised; the remaining dependencies are non-null so they are not resolved
-  // from the container.
   return new RemoteConfigRuntimeState(
     k8Factory,
+    {showUser: (): void => undefined} as unknown as SoloLogger,
     {} as unknown as never,
     {} as unknown as never,
     {} as unknown as never,
     {} as unknown as never,
-    {} as unknown as never,
+    {resumeStoppedClusterNode} as unknown as ContainerEngineClient,
   );
 }
 
 /** Resolves with the error thrown while reading the remote config ConfigMap over the given context. */
-async function readFailure(readError: Error, context: Context): Promise<Error> {
-  return await runtimeStateFailingWith(readError)
-    .remoteConfigExists(namespace, context)
-    .then(
-      (): Error => undefined,
-      (error: Error): Error => error,
-    );
+async function readFailure(runtimeState: RemoteConfigRuntimeState, context: Context): Promise<Error> {
+  return await runtimeState.remoteConfigExists(namespace, context).then(
+    (): Error => undefined,
+    (error: Error): Error => error,
+  );
 }
 
 describe('RemoteConfigRuntimeState', (): void => {
+  let sandbox: SinonSandbox;
+  let read: SinonStub;
+  let resumeStoppedClusterNode: SinonStub;
+
+  beforeEach((): void => {
+    sandbox = sinon.createSandbox();
+    read = sandbox.stub();
+    resumeStoppedClusterNode = sandbox.stub().resolves(ClusterNodeResumeOutcome.UNCHANGED);
+  });
+
+  afterEach((): void => {
+    sandbox.restore();
+  });
+
   it('should throw ClusterUnreachableError preserving the cause for a non-kind context', async (): Promise<void> => {
     const cause: Error = new Error('connect ECONNREFUSED 10.0.0.1:6443');
+    read.rejects(cause);
 
-    const error: Error = await readFailure(cause, 'production-cluster');
+    const error: Error = await readFailure(buildRuntimeState(read, resumeStoppedClusterNode), 'production-cluster');
 
     expect(error).to.be.instanceOf(ClusterUnreachableError);
     expect(error.message).to.contain('production-cluster');
     expect(error.message).to.contain('connect ECONNREFUSED 10.0.0.1:6443');
     expect(error.cause).to.equal(cause);
-  });
-
-  it('should throw KubernetesApiInvalidResponseSoloError preserving the cause for a kind context', async (): Promise<void> => {
-    const cause: Error = new Error('configmaps is forbidden: User cannot list resource');
-
-    const error: Error = await readFailure(cause, 'kind-solo');
-
-    expect(error).to.be.instanceOf(KubernetesApiInvalidResponseSoloError);
-    expect(error.message).to.contain('configmaps is forbidden: User cannot list resource');
-    expect(error.cause).to.equal(cause);
+    // A remote cluster has no local node container, so the engine must not be touched at all.
+    expect(resumeStoppedClusterNode).to.not.have.been.called;
   });
 
   it('should rethrow ResourceNotFoundError untouched', async (): Promise<void> => {
@@ -74,9 +87,65 @@ describe('RemoteConfigRuntimeState', (): void => {
       namespace,
       'solo-remote-config',
     );
+    read.rejects(notFound);
 
-    const error: Error = await readFailure(notFound, 'production-cluster');
+    const error: Error = await readFailure(buildRuntimeState(read, resumeStoppedClusterNode), 'production-cluster');
 
     expect(error).to.equal(notFound);
+  });
+
+  it('should keep KubernetesApiInvalidResponseSoloError when a kind node container was not resumed', async (): Promise<void> => {
+    const cause: Error = new Error('configmaps is forbidden: User cannot list resource');
+    read.rejects(cause);
+
+    const error: Error = await readFailure(buildRuntimeState(read, resumeStoppedClusterNode), 'kind-solo');
+
+    expect(error).to.be.instanceOf(KubernetesApiInvalidResponseSoloError);
+    expect(error.message).to.contain('configmaps is forbidden: User cannot list resource');
+    expect(error.cause).to.equal(cause);
+    expect(resumeStoppedClusterNode).to.have.been.calledOnceWithExactly('solo');
+  });
+
+  it('should throw ContainerEngineNotRunningError when no container engine answers', async (): Promise<void> => {
+    const cause: Error = new Error('connect ECONNREFUSED 127.0.0.1:52810');
+    read.rejects(cause);
+    resumeStoppedClusterNode.resolves(ClusterNodeResumeOutcome.ENGINE_UNAVAILABLE);
+
+    const error: Error = await readFailure(buildRuntimeState(read, resumeStoppedClusterNode), 'kind-solo');
+
+    expect(error).to.be.instanceOf(ContainerEngineNotRunningError);
+    expect(error.cause).to.equal(cause);
+  });
+
+  it('should read again once a stopped kind cluster has been resumed', async (): Promise<void> => {
+    read.onFirstCall().rejects(new Error('connect ECONNREFUSED 127.0.0.1:52810'));
+    read.onSecondCall().resolves(remoteConfigMap);
+    resumeStoppedClusterNode.resolves(ClusterNodeResumeOutcome.RESUMED);
+
+    const exists: boolean = await buildRuntimeState(read, resumeStoppedClusterNode).remoteConfigExists(
+      namespace,
+      'kind-solo',
+    );
+
+    expect(exists).to.be.true;
+    expect(resumeStoppedClusterNode).to.have.been.calledOnceWithExactly('solo');
+    expect(read).to.have.been.calledTwice;
+  });
+
+  it('should throw KindClusterStoppedError when a resumed kind cluster never answers', async (): Promise<void> => {
+    const cause: Error = new Error('connect ECONNREFUSED 127.0.0.1:52810');
+    read.rejects(cause);
+    resumeStoppedClusterNode.resolves(ClusterNodeResumeOutcome.RESUMED);
+    // The wait between attempts is real time the assertion does not need; only the retry count matters.
+    const sleep: SinonStub = sandbox.stub(Helpers, 'sleep').resolves();
+
+    const error: Error = await readFailure(buildRuntimeState(read, resumeStoppedClusterNode), 'kind-solo');
+
+    expect(error).to.be.instanceOf(KindClusterStoppedError);
+    expect(error.message).to.contain("kind cluster 'solo'");
+    expect(error.cause).to.equal(cause);
+    // The initial read, then one read per resume attempt, sleeping between the attempts but not before the first.
+    expect(read.callCount).to.equal(31);
+    expect(sleep.callCount).to.equal(29);
   });
 });

--- a/test/unit/integration/cache/image-cache-handler.test.ts
+++ b/test/unit/integration/cache/image-cache-handler.test.ts
@@ -13,6 +13,7 @@ import {type CacheHealthInspector} from '../../../../src/integration/cache/api/c
 import {type SoloLogger} from '../../../../src/core/logging/solo-logger.js';
 import {SoloPinoLogger} from '../../../../src/core/logging/solo-pino-logger.js';
 import {type ContainerEngineClient} from '../../../../src/integration/container-engine/container-engine-client.js';
+import {ClusterNodeResumeOutcome} from '../../../../src/integration/container-engine/cluster-node-resume-outcome.js';
 import {type SoloListrTask} from '../../../../src/types/index.js';
 import {type AnyListrContext} from '../../../../src/types/aliases.js';
 
@@ -110,6 +111,7 @@ describe('ImageCacheHandler pull', (): void => {
       loadImageArchiveIntoCluster: async (): Promise<void> => undefined,
       removeImage: async (): Promise<void> => undefined,
       listLoadedImagesInCluster: async (): Promise<readonly string[]> => [],
+      resumeStoppedClusterNode: async (): Promise<ClusterNodeResumeOutcome> => ClusterNodeResumeOutcome.UNCHANGED,
     };
 
     const provider: StaticCacheTargetProvider = new StaticCacheTargetProvider([target]);
@@ -137,6 +139,7 @@ describe('ImageCacheHandler pull', (): void => {
       loadImageArchiveIntoCluster: async (): Promise<void> => undefined,
       removeImage: async (): Promise<void> => undefined,
       listLoadedImagesInCluster: async (): Promise<readonly string[]> => [],
+      resumeStoppedClusterNode: async (): Promise<ClusterNodeResumeOutcome> => ClusterNodeResumeOutcome.UNCHANGED,
     };
 
     const provider: StaticCacheTargetProvider = new StaticCacheTargetProvider([target]);
@@ -163,6 +166,7 @@ describe('ImageCacheHandler pull', (): void => {
       loadImageArchiveIntoCluster: async (): Promise<void> => undefined,
       removeImage: async (): Promise<void> => undefined,
       listLoadedImagesInCluster: async (): Promise<readonly string[]> => [],
+      resumeStoppedClusterNode: async (): Promise<ClusterNodeResumeOutcome> => ClusterNodeResumeOutcome.UNCHANGED,
     };
 
     const provider: StaticCacheTargetProvider = new StaticCacheTargetProvider([target]);
@@ -190,6 +194,7 @@ describe('ImageCacheHandler pull', (): void => {
       loadImageArchiveIntoCluster: async (): Promise<void> => undefined,
       removeImage: async (): Promise<void> => undefined,
       listLoadedImagesInCluster: async (): Promise<readonly string[]> => [],
+      resumeStoppedClusterNode: async (): Promise<ClusterNodeResumeOutcome> => ClusterNodeResumeOutcome.UNCHANGED,
     };
 
     const provider: StaticCacheTargetProvider = new StaticCacheTargetProvider([target]);
@@ -253,6 +258,7 @@ describe('ImageCacheHandler load', (): void => {
       loadImageArchiveIntoCluster: loadArchiveStub,
       removeImage: async (): Promise<void> => undefined,
       listLoadedImagesInCluster: async (): Promise<readonly string[]> => [],
+      resumeStoppedClusterNode: async (): Promise<ClusterNodeResumeOutcome> => ClusterNodeResumeOutcome.UNCHANGED,
     };
 
     const handler: ImageCacheHandler = new ImageCacheHandler(
@@ -278,6 +284,7 @@ describe('ImageCacheHandler load', (): void => {
       loadImageArchiveIntoCluster: loadArchiveStub,
       removeImage: async (): Promise<void> => undefined,
       listLoadedImagesInCluster: async (): Promise<readonly string[]> => ['docker.io/library/busybox:1.36.1'],
+      resumeStoppedClusterNode: async (): Promise<ClusterNodeResumeOutcome> => ClusterNodeResumeOutcome.UNCHANGED,
     };
 
     const handler: ImageCacheHandler = new ImageCacheHandler(
@@ -305,6 +312,7 @@ describe('ImageCacheHandler load', (): void => {
       listLoadedImagesInCluster: async (): Promise<readonly string[]> => {
         throw new Error('cluster unreachable');
       },
+      resumeStoppedClusterNode: async (): Promise<ClusterNodeResumeOutcome> => ClusterNodeResumeOutcome.UNCHANGED,
     };
 
     const handler: ImageCacheHandler = new ImageCacheHandler(
@@ -329,6 +337,7 @@ describe('ImageCacheHandler load', (): void => {
       loadImageArchiveIntoCluster: sinon.stub().rejects(new Error('unrecognized image format')),
       removeImage: async (): Promise<void> => undefined,
       listLoadedImagesInCluster: async (): Promise<readonly string[]> => [],
+      resumeStoppedClusterNode: async (): Promise<ClusterNodeResumeOutcome> => ClusterNodeResumeOutcome.UNCHANGED,
     };
 
     const handler: ImageCacheHandler = new ImageCacheHandler(

--- a/test/unit/integration/container-engine/docker-client.test.ts
+++ b/test/unit/integration/container-engine/docker-client.test.ts
@@ -11,6 +11,7 @@ import {type SoloLogger} from '../../../../src/core/logging/solo-logger.js';
 import {type DependencyManager} from '../../../../src/core/dependency-managers/index.js';
 import {type KindClient} from '../../../../src/integration/kind/kind-client.js';
 import {PodmanDependencyManager} from '../../../../src/core/dependency-managers/podman-dependency-manager.js';
+import {ClusterNodeResumeOutcome} from '../../../../src/integration/container-engine/cluster-node-resume-outcome.js';
 
 describe('DockerClient', (): void => {
   let previousKindProvider: string | undefined;
@@ -73,14 +74,97 @@ describe('DockerClient', (): void => {
       sinon.match.has('archivePath', '/tmp/busybox.tar').and(sinon.match.has('name', 'kind')),
     );
   });
+
+  it('starts a stopped kind node container', async (): Promise<void> => {
+    delete process.env.KIND_EXPERIMENTAL_PROVIDER;
+    const nodeName: string = 'solo-cluster-control-plane';
+    DockerClientTestBuilder.stubMissingPodmanContainer(shellRunnerRunStub, nodeName);
+    shellRunnerRunStub
+      .withArgs('docker', DockerClientTestBuilder.inspectStateArguments(nodeName), sinon.match.object)
+      .resolves(['exited']);
+    shellRunnerRunStub
+      .withArgs('docker', DockerClientTestBuilder.startArguments(nodeName), sinon.match.object)
+      .resolves([]);
+
+    const client: DockerClient = DockerClientTestBuilder.build();
+    const outcome: ClusterNodeResumeOutcome = await client.resumeStoppedClusterNode('solo-cluster');
+
+    expect(outcome).to.equal(ClusterNodeResumeOutcome.RESUMED);
+    expect(shellRunnerRunStub).to.have.been.calledWith(
+      'docker',
+      DockerClientTestBuilder.startArguments(nodeName),
+      sinon.match.object,
+    );
+  });
+
+  it('leaves a running kind node container alone', async (): Promise<void> => {
+    delete process.env.KIND_EXPERIMENTAL_PROVIDER;
+    const nodeName: string = 'solo-cluster-control-plane';
+    DockerClientTestBuilder.stubMissingPodmanContainer(shellRunnerRunStub, nodeName);
+    shellRunnerRunStub
+      .withArgs('docker', DockerClientTestBuilder.inspectStateArguments(nodeName), sinon.match.object)
+      .resolves(['running']);
+
+    const client: DockerClient = DockerClientTestBuilder.build();
+    const outcome: ClusterNodeResumeOutcome = await client.resumeStoppedClusterNode('solo-cluster');
+
+    expect(outcome).to.equal(ClusterNodeResumeOutcome.UNCHANGED);
+    expect(shellRunnerRunStub).to.not.have.been.calledWith(
+      'docker',
+      DockerClientTestBuilder.startArguments(nodeName),
+      sinon.match.object,
+    );
+  });
+
+  it('reports the container engine as unavailable when nothing answers', async (): Promise<void> => {
+    delete process.env.KIND_EXPERIMENTAL_PROVIDER;
+    const nodeName: string = 'solo-cluster-control-plane';
+    DockerClientTestBuilder.stubMissingPodmanContainer(shellRunnerRunStub, nodeName);
+    shellRunnerRunStub
+      .withArgs('docker', DockerClientTestBuilder.inspectStateArguments(nodeName), sinon.match.object)
+      .rejects(new Error('Cannot connect to the Docker daemon'));
+    DockerClientTestBuilder.stubUnreachableEngineInfo(shellRunnerRunStub);
+
+    const client: DockerClient = DockerClientTestBuilder.build(
+      {} as DependencyManager,
+      {} as DefaultKindClientBuilder,
+      DockerClientTestBuilder.silentLogger(),
+    );
+    const outcome: ClusterNodeResumeOutcome = await client.resumeStoppedClusterNode('solo-cluster');
+
+    expect(outcome).to.equal(ClusterNodeResumeOutcome.ENGINE_UNAVAILABLE);
+  });
 });
 
 class DockerClientTestBuilder {
   public static build(
     dependencyManager: DependencyManager = {} as DependencyManager,
     kindBuilder: DefaultKindClientBuilder = {} as DefaultKindClientBuilder,
+    logger: SoloLogger = {} as SoloLogger,
   ): DockerClient {
-    return new DockerClient(kindBuilder, {} as SoloLogger, dependencyManager);
+    return new DockerClient(kindBuilder, logger, dependencyManager);
+  }
+
+  /** A logger for the paths that report a failed probe; the production code logs those at debug level. */
+  public static silentLogger(): SoloLogger {
+    return {debug: (): void => undefined} as unknown as SoloLogger;
+  }
+
+  public static inspectStateArguments(nodeName: string, prefix: readonly string[] = []): string[] {
+    return [...prefix, 'container', 'inspect', '--format', '{{.State.Status}}', nodeName];
+  }
+
+  public static startArguments(nodeName: string, prefix: readonly string[] = []): string[] {
+    return [...prefix, 'start', nodeName];
+  }
+
+  public static stubUnreachableEngineInfo(shellRunnerRunStub: SinonStub): void {
+    shellRunnerRunStub
+      .withArgs('docker', ['info', '--format', '{{json .}}'], sinon.match.object)
+      .rejects(new Error('Cannot connect to the Docker daemon'));
+    shellRunnerRunStub
+      .withArgs('podman', ['info', '--format', 'json'], sinon.match.object)
+      .rejects(new Error('podman is not installed'));
   }
 
   public static buildDependencyManager(kindExecutable: string): DependencyManager {


### PR DESCRIPTION
## Description

`RemoteConfigRuntimeState.getConfigMap()` is the single read path for the `solo-remote-config`
ConfigMap — every command that loads remote config goes through it, via `load()`,
`populateFromExisting()` and `remoteConfigExists()`. Its catch block re-threw a 404 unchanged and
collapsed **every other** failure into a bare `KubernetesApiInvalidResponseSoloError` constructed
with no arguments (`remote-config-runtime-state.ts:329`):

```ts
} catch (error) {
  throw error instanceof ResourceNotFoundError ? error : new SoloErrors.system.kubernetesApiInvalidResponse();
}
```

Two separate things are wrong there.

**The original error was discarded, and nothing else recovers it.** `SoloError`'s constructor takes
the originating error as its second argument, and `SoloPinoLogger.buildCauseChain()` walks
`error.cause` to build the `Caused by:` lines in development mode, the `causes[]` array in silent
mode, and the `err` object written to `~/.solo/logs/solo.log`. Constructing the error with no
argument leaves that chain empty at the point of failure, so it cannot be reconstructed later. In
the default (non-development) rendering the user only ever sees the outermost message, which means
a refused connection, an expired credential, a DNS failure and an RBAC denial were all reported
identically as:

```
[SOLO-5061] Received an incorrect or unexpected response from the Kubernetes API
```

**"Invalid response" is also the wrong diagnosis for most of those failures.** SOLO-5061 documents a
well-formed-response problem — "a malformed or partial response, often indicating an API server
problem" — and its troubleshooting steps send the user to inspect API server health. A remote
cluster that cannot be reached at all, or that rejects the caller, is a different failure with
different remedies, and the two were indistinguishable to the user and to any caller trying to
branch on the error type.

### What changed

* **`src/core/errors/classes/system/cluster-unreachable-error.ts`** (new) — `ClusterUnreachableError`
  (`SOLO-5078`, Infrastructure, retryable). Takes `(context, cause)`, names both the kubeconfig
  context and the underlying failure in its message, and attaches the cause. Its troubleshooting
  steps cover the reachability/credentials/RBAC cases rather than API server health.
* **`src/business/runtime-state/config/remote/remote-config-runtime-state.ts`** — the catch block now
  keeps the 404 pass-through, and otherwise throws `ClusterUnreachableError` for a non-kind context
  and `KubernetesApiInvalidResponseSoloError` for a kind one. Both carry the original error as
  `cause`.
* **`src/core/errors/classes/system/kubernetes-api-invalid-response-solo-error.ts`** — the constructor
  now accepts an optional `cause`, appends its message when present, and forwards it to `SoloError`.
  The no-argument form is unchanged, so existing construction sites keep their current message
  verbatim.
* **`src/core/errors/kube-error-translator.ts`** — `KubeErrorTranslator.tryTranslate()` constructed
  the same error class with no cause for `KubeApiInvalidResponseError`, while its neighbours
  (`podNotFound`, `containerOperationFailed`, `ingressClassListFailed`) all forward theirs. That is
  the same defect on a sibling path into the same class, so it is fixed here rather than left to
  resurface: the caught error is now passed through.
* **`src/core/errors/error-code-registry.ts`, `src/core/errors/solo-errors.ts`** — registration of the
  new code and class.

Design notes:

* **Why a new class rather than reusing `ClusterConnectionFailedError` (SOLO-5002).** That error is
  close in meaning, but its constructor requires a *cluster reference*, and at this point in the load
  path there is none: `clusterReferences` is populated by `populateClusterReferences()`, which runs
  *after* `populateFromExisting()` in `createFromExisting()`, so the map is empty when `getConfigMap()`
  fails. SOLO-5002 is also specifically the `deployment add-cluster` pre-flight handshake test
  (`deployment.ts:1332`) and its wording says so. Reusing it would have meant either passing
  `undefined` as the cluster reference or a reverse lookup that does not exist yet, for a message that
  still described the wrong operation.
* **Kind detection is the context-name prefix**, matching `isKindContext()` in the one-shot deploy
  orchestrator (`default-one-shot-deploy-orchestrator.ts:1198`) and the same heuristic already used in
  `base.ts`, `cache.ts` and `backup-restore.ts`. A kind cluster whose kubeconfig context has been
  renamed away from `kind-<cluster>` will be reported as unreachable; that is the existing convention
  in this codebase rather than something introduced here.
* **`SOLO-5078`, not `SOLO-5077`.** #5390 merged `PODMAN_RUNTIME_CONFIGURATION_FAILED: 'SOLO-5077'`
  onto `main` while this was being written. The collision was caught by running the error
  documentation generator, which silently overwrote one page with the other.
* **Not a breaking change.** No call site catches `KubernetesApiInvalidResponseSoloError` by type —
  the three `remoteConfigExists()` callers in `deployment.ts` all catch broadly and fall back to
  `false`/`'disconnected'` — so the narrowed type changes what is reported, not what is caught.

### Deliberately not included

The issue's closing note — *"Additionally see if using the detect feature, if kind container is
stopped, resume it or start docker engine"* — is **not** implemented here, and it is worth saying
why rather than silently leaving it out.

The nearest existing machinery is `PodmanClient.getKindContainerCommand()` /
`DockerClient`, which is entirely image-oriented (`pullImage`, `saveImage`, `loadImage`,
`loadImageArchiveIntoCluster`, `removeImage`, `listLoadedImagesInCluster`). `ContainerEngineClient`
has no container-lifecycle operation at all, so resuming a stopped kind node would mean adding
inspect/start to that interface, injecting a container engine into `RemoteConfigRuntimeState` (which
today knows nothing about local container engines), and starting the engine daemon itself —
`systemctl start docker` or `open -a Docker`, platform-specific and privileged. That is a feature
with its own design and failure modes, not part of an error-typing fix, and putting an implicit
side effect of that size on a *read* path seems worth deciding on deliberately. It is now tracked
separately as #5567, which also records the open design questions (auto-resume vs prompt vs
actionable message, and whether starting the engine daemon is in scope at all).

Because of that, this PR does **not** close #5446 — the `Do` and `Acceptance` items in it are
implemented in full, but the trailing note is not, so the closing keyword is deliberately omitted and
the issue is left for a maintainer to close once #5567 is agreed.

### Related Issues

* Related to #5446 — implements its `Do` and `Acceptance` items in full
* Related to #5567 — the deferred kind auto-resume idea from the same issue

### Pull request (PR) checklist

- [x] This PR added tests (unit, integration, and/or end-to-end)
- [ ] This PR updated documentation
- [x] This PR added no TODOs or commented out code
- [x] This PR has no breaking changes
- [x] Any technical debt has been documented as a separate issue and linked to this PR
- [x] Any `package.json` changes have been explained to and approved by a repository manager
- [x] All related issues have been linked to this PR
- [x] All changes in this PR are included in the description
- [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

No documentation file changed because the error pages are generated from source:
`scripts/docs/generate-error-documentation.ts` reads the class TSDoc, ownership, retryable flag and
troubleshooting steps, so `troubleshooting/errors/system/SOLO-5078.md` is produced by
`task build:docs:content` and is not committed.

### Testing

- [x] This PR added unit tests
- [ ] This PR added integration/end-to-end tests
- [ ] These changes required manual testing that is documented below
- [x] Anything not tested is documented

The following manual testing was done:

* `npx tsc --noEmit` — exit 0.
* `npx eslint` on all seven changed files — **0 errors, 0 warnings**.
* `npx prettier --check` on all seven changed files — clean.
* `npx mocha 'test/unit/**/*.ts' --exclude 'test/unit/core/helm/**/*.ts'` — **1408 passing, 0
  failing**.
* `npx mocha 'test/unit/business/runtime-state/remote-config-runtime-state.test.ts'` — 3 passing. The
  new tests drive `remoteConfigExists()` through a stubbed `K8Factory` whose ConfigMap read always
  rejects, and assert: a non-kind context yields `ClusterUnreachableError` whose message contains both
  the context and the original message and whose `cause` is the original error object; a `kind-` context
  yields `KubernetesApiInvalidResponseSoloError` with the same cause preserved; and a
  `ResourceNotFoundError` is still rethrown by identity. The first assertion fails against `main` by
  construction, since the class does not exist there.
* `npx tsx scripts/docs/generate-error-documentation.ts` — 289 pages, and
  `troubleshooting/errors/system/SOLO-5078.md` renders the new class with the correct code, ownership,
  retryable flag and troubleshooting steps. This is what surfaced the SOLO-5077 collision with #5390.

The following was not tested:

* **No live cluster was used.** The error paths are exercised with a stubbed `K8Factory`, not against a
  genuinely unreachable API server, an expired credential or a real RBAC denial. What a live run would
  add is confirmation that the messages those failures produce read well once embedded — the branching
  and the cause propagation are covered by the unit tests.
* The rendered output was not captured from a real terminal. `SoloPinoLogger.buildCauseChain()` and
  `buildContentLines()` are unchanged by this PR; the fix is that the chain is no longer empty when
  they run.
* The kind-context heuristic was not tested against a kind cluster with a manually renamed kubeconfig
  context, which by design will now be reported as unreachable.
* No Markdown, YAML or shell script changed, so `remark` and the workflow parse gates are not
  applicable.
