### PR TITLE
feat: resume a stopped kind node container instead of failing the cluster call

### DIFF
--- a/src/business/runtime-state/config/remote/remote-config-runtime-state.ts
+++ b/src/business/runtime-state/config/remote/remote-config-runtime-state.ts
@@ -56,6 +56,9 @@ import {RemoteConfig} from './remote-config.js';
 import {ComponentIdsSchema} from '../../../../data/schema/model/remote/state/component-ids-schema.js';
 import {type BaseStateSchema} from '../../../../data/schema/model/remote/state/base-state-schema.js';
 import {Helpers} from '../../../../core/helpers.js';
+import {Duration} from '../../../../core/time/duration.js';
+import {type ContainerEngineClient} from '../../../../integration/container-engine/container-engine-client.js';
+import {ClusterNodeResumeOutcome} from '../../../../integration/container-engine/cluster-node-resume-outcome.js';
 import {ResourceNotFoundError} from '../../../../integration/kube/errors/resource-operation-errors.js';
 import {MissingRequiredParametersError} from '../../errors/missing-required-parameters-error.js';
 import {SemanticVersion} from '../../../utils/semantic-version.js';
@@ -72,6 +75,13 @@ interface VersionField {
 @injectable()
 export class RemoteConfigRuntimeState implements RemoteConfigRuntimeStateApi {
   private static readonly SOLO_REMOTE_CONFIGMAP_DATA_KEY: string = 'remote-config-data';
+
+  /** Kind names the kubeconfig context it writes `kind-<cluster-name>`. */
+  private static readonly KIND_CONTEXT_PREFIX: string = 'kind-';
+
+  /** How long to wait for a resumed kind cluster's API: 30 attempts every 2 seconds, so at most a minute. */
+  private static readonly KIND_RESUME_MAX_ATTEMPTS: number = 30;
+  private static readonly KIND_RESUME_RETRY_INTERVAL: Duration = Duration.ofSeconds(2);
 
   private phase: RuntimeStatePhase = RuntimeStatePhase.NotLoaded;
 
@@ -90,6 +100,7 @@ export class RemoteConfigRuntimeState implements RemoteConfigRuntimeStateApi {
     @inject(InjectTokens.ConfigManager) private readonly configManager?: ConfigManager,
     @inject(InjectTokens.RemoteConfigValidator) private readonly remoteConfigValidator?: RemoteConfigValidatorApi,
     @inject(InjectTokens.ObjectMapper) private readonly objectMapper?: ObjectMapper,
+    @inject(InjectTokens.ContainerEngineClient) private readonly containerEngine?: ContainerEngineClient,
   ) {
     this.k8Factory = patchInject(k8Factory, InjectTokens.K8Factory, this.constructor.name);
     this.logger = patchInject(logger, InjectTokens.SoloLogger, this.constructor.name);
@@ -101,6 +112,7 @@ export class RemoteConfigRuntimeState implements RemoteConfigRuntimeStateApi {
       this.constructor.name,
     );
     this.objectMapper = patchInject(objectMapper, InjectTokens.ObjectMapper, this.constructor.name);
+    this.containerEngine = patchInject(containerEngine, InjectTokens.ContainerEngineClient, this.constructor.name);
   }
 
   public get configuration(): RemoteConfig {
@@ -321,22 +333,22 @@ export class RemoteConfigRuntimeState implements RemoteConfigRuntimeStateApi {
 
     let configMap: ConfigMap;
     try {
-      configMap = await this.k8Factory
-        .getK8(context)
-        .configMaps()
-        .read(namespace, constants.SOLO_REMOTE_CONFIGMAP_NAME);
+      configMap = await this.readRemoteConfigMap(namespace, context);
     } catch (error) {
       if (error instanceof ResourceNotFoundError) {
         throw error;
       }
 
-      // A kind cluster runs on this machine, so a failure there is a local API problem rather than a cluster
-      // solo cannot reach. Kind names its kubeconfig context `kind-<cluster-name>`, the same heuristic the
-      // one-shot deploy orchestrator uses. Either way the original failure is kept as the cause so the real
-      // reason (context down, RBAC denial, API error) reaches the error output and the logs.
-      throw context.startsWith('kind-')
-        ? new SoloErrors.system.kubernetesApiInvalidResponse(error)
-        : new SoloErrors.system.clusterUnreachable(context, error);
+      // A kind cluster runs on this machine, so a failure there is a local problem rather than a cluster solo
+      // cannot reach — and the usual local problem is a node container that is simply stopped. Kind names its
+      // kubeconfig context `kind-<cluster-name>`, the same heuristic the one-shot deploy orchestrator uses.
+      // Either way the original failure is kept as the cause so the real reason (context down, RBAC denial,
+      // API error) reaches the error output and the logs.
+      if (!context.startsWith(RemoteConfigRuntimeState.KIND_CONTEXT_PREFIX)) {
+        throw new SoloErrors.system.clusterUnreachable(context, error);
+      }
+
+      configMap = await this.resumeKindClusterAndRead(namespace, context, error);
     }
     if (!configMap) {
       throw new SoloErrors.system.resourceNotFound(
@@ -345,6 +357,61 @@ export class RemoteConfigRuntimeState implements RemoteConfigRuntimeStateApi {
     }
 
     return configMap;
+  }
+
+  private async readRemoteConfigMap(namespace: NamespaceName, context: Context): Promise<ConfigMap> {
+    return await this.k8Factory.getK8(context).configMaps().read(namespace, constants.SOLO_REMOTE_CONFIGMAP_NAME);
+  }
+
+  /**
+   * Recovers a kind cluster whose node container was left stopped — by a reboot or a manual stop — and reads
+   * the remote config ConfigMap again once its Kubernetes API answers.
+   *
+   * Only a container that solo actually started is waited on: when there was nothing to resume the original
+   * failure is reported unchanged, so this never turns an unrelated API failure into a long wait.
+   *
+   * @param namespace - the namespace holding the remote config ConfigMap.
+   * @param context - the kind kubeconfig context the read failed against.
+   * @param cause - the failure that triggered the recovery attempt.
+   */
+  private async resumeKindClusterAndRead(namespace: NamespaceName, context: Context, cause: Error): Promise<ConfigMap> {
+    const clusterName: string = context.slice(RemoteConfigRuntimeState.KIND_CONTEXT_PREFIX.length);
+    const outcome: ClusterNodeResumeOutcome = await this.containerEngine.resumeStoppedClusterNode(clusterName);
+
+    if (outcome === ClusterNodeResumeOutcome.ENGINE_UNAVAILABLE) {
+      throw new SoloErrors.system.containerEngineNotRunning(cause);
+    }
+
+    if (outcome !== ClusterNodeResumeOutcome.RESUMED) {
+      throw new SoloErrors.system.kubernetesApiInvalidResponse(cause);
+    }
+
+    this.logger.showUser(
+      `The kind cluster '${clusterName}' was stopped; solo started its node container and is waiting for the Kubernetes API...`,
+    );
+
+    let lastError: Error = cause;
+
+    for (let attempt: number = 0; attempt < RemoteConfigRuntimeState.KIND_RESUME_MAX_ATTEMPTS; attempt++) {
+      if (attempt > 0) {
+        await Helpers.sleep(RemoteConfigRuntimeState.KIND_RESUME_RETRY_INTERVAL);
+      }
+
+      try {
+        const configMap: ConfigMap = await this.readRemoteConfigMap(namespace, context);
+        this.logger.showUser(`The kind cluster '${clusterName}' is available again.`);
+        return configMap;
+      } catch (error) {
+        // The API is answering again once it can tell us the ConfigMap is missing, so that is a real answer
+        // rather than a reason to keep waiting.
+        if (error instanceof ResourceNotFoundError) {
+          throw error;
+        }
+        lastError = error;
+      }
+    }
+
+    throw new SoloErrors.system.kindClusterStopped(clusterName, lastError);
   }
 
   public async populateFromExisting(namespace: NamespaceName, context: Context): Promise<void> {

--- a/src/core/errors/classes/system/container-engine-not-running-error.ts
+++ b/src/core/errors/classes/system/container-engine-not-running-error.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {SoloError} from '../../solo-error.js';
+import {ErrorOwnership} from '../../error-ownership.js';
+import {ErrorCodeRegistry} from '../../error-code-registry.js';
+
+/**
+ * @description Thrown when solo needs the local container engine and neither Docker nor Podman answers; the
+ * failure that led solo to look is wrapped in `cause`. A local kind cluster only exists as containers on this
+ * machine, so with no engine running solo can neither reach the cluster nor tell whether it is still there.
+ * The usual reason is simply that Docker Desktop, the Docker daemon or the Podman machine is not started. solo
+ * does not start the engine itself, because doing so is platform-specific and needs privileges the CLI should
+ * not take on its own. It is retryable once the engine is up.
+ */
+export class ContainerEngineNotRunningError extends SoloError {
+  protected override readonly retryable: boolean = true;
+  protected override readonly ownership: ErrorOwnership = ErrorOwnership.User;
+
+  public constructor(cause: Error) {
+    super(
+      {
+        message: `No container engine is running, so the local cluster cannot be reached: ${cause.message}`,
+        code: ErrorCodeRegistry.CONTAINER_ENGINE_NOT_RUNNING,
+        troubleshootingSteps:
+          'Start Docker Desktop, or the Docker daemon: sudo systemctl start docker\n' +
+          'If you use Podman, start its machine: podman machine start\n' +
+          'Confirm the engine answers: docker info\n' +
+          'Then re-run the command',
+      },
+      cause,
+    );
+  }
+}

--- a/src/core/errors/classes/system/kind-cluster-stopped-error.ts
+++ b/src/core/errors/classes/system/kind-cluster-stopped-error.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {SoloError} from '../../solo-error.js';
+import {ErrorOwnership} from '../../error-ownership.js';
+import {ErrorCodeRegistry} from '../../error-code-registry.js';
+
+/**
+ * @description Thrown when a kind cluster's node container was found stopped, solo started it again, and the
+ * cluster's Kubernetes API still did not answer; the last API failure is wrapped in `cause`. A kind node that
+ * restarts but never serves its API usually means the cluster did not survive whatever stopped it — the host
+ * was rebooted and the node's networking or storage no longer lines up, the container is crash-looping, or the
+ * kubeconfig entry now points at a port the restarted node no longer listens on. It is retryable because a
+ * control plane can simply need longer than solo waited.
+ */
+export class KindClusterStoppedError extends SoloError {
+  protected override readonly retryable: boolean = true;
+  protected override readonly ownership: ErrorOwnership = ErrorOwnership.Infrastructure;
+
+  public constructor(clusterName: string, cause: Error) {
+    super(
+      {
+        message:
+          `The kind cluster '${clusterName}' node container was stopped; solo started it, but the ` +
+          `Kubernetes API did not become available: ${cause.message}`,
+        code: ErrorCodeRegistry.KIND_CLUSTER_STOPPED,
+        troubleshootingSteps:
+          `Check the node container is running: docker ps -a --filter name=${clusterName}-control-plane\n` +
+          `Inspect why the node is not serving its API: docker logs ${clusterName}-control-plane\n` +
+          `Verify the cluster answers: kubectl cluster-info --context kind-${clusterName}\n` +
+          `Recreate the cluster if it did not survive being stopped: kind delete cluster --name ${clusterName}`,
+      },
+      cause,
+    );
+  }
+}

--- a/src/core/errors/error-code-registry.ts
+++ b/src/core/errors/error-code-registry.ts
@@ -292,6 +292,8 @@ export const ErrorCodeRegistry: Record<string, string> = {
   HELM_CHART_PULL_NO_ARCHIVE: 'SOLO-5076',
   PODMAN_RUNTIME_CONFIGURATION_FAILED: 'SOLO-5077',
   CLUSTER_UNREACHABLE: 'SOLO-5078',
+  KIND_CLUSTER_STOPPED: 'SOLO-5079',
+  CONTAINER_ENGINE_NOT_RUNNING: 'SOLO-5080',
 
   // 9xxx - Internal: Unexpected bugs, unimplemented paths
   TIMEOUT: 'SOLO-9001',

--- a/src/core/errors/solo-errors.ts
+++ b/src/core/errors/solo-errors.ts
@@ -22,6 +22,8 @@ import {InvalidOutputFormatError} from './classes/validation/invalid-output-form
 import {InvalidPortNumberError} from './classes/validation/invalid-port-number-error.js';
 import {ClusterConnectionFailedError} from './classes/system/cluster-connection-failed-error.js';
 import {ClusterUnreachableError} from './classes/system/cluster-unreachable-error.js';
+import {KindClusterStoppedError} from './classes/system/kind-cluster-stopped-error.js';
+import {ContainerEngineNotRunningError} from './classes/system/container-engine-not-running-error.js';
 import {GitHubApiHttpResponseError} from './classes/system/github-api-http-response-error.js';
 import {GitHubApiRequestFailedError} from './classes/system/github-api-request-failed-error.js';
 import {GitHubApiResponseMissingTagNameError} from './classes/system/github-api-response-missing-tag-name-error.js';
@@ -727,6 +729,8 @@ export class SoloErrors {
     readonly externalBlockNodeNotInRemoteConfig: typeof ExternalBlockNodeNotInRemoteConfigSoloError;
     readonly clusterConnectionFailed: typeof ClusterConnectionFailedError;
     readonly clusterUnreachable: typeof ClusterUnreachableError;
+    readonly kindClusterStopped: typeof KindClusterStoppedError;
+    readonly containerEngineNotRunning: typeof ContainerEngineNotRunningError;
     readonly githubApiHttpResponseError: typeof GitHubApiHttpResponseError;
     readonly githubApiRequestFailed: typeof GitHubApiRequestFailedError;
     readonly githubApiResponseMissingTagName: typeof GitHubApiResponseMissingTagNameError;
@@ -807,6 +811,8 @@ export class SoloErrors {
     externalBlockNodeNotInRemoteConfig: ExternalBlockNodeNotInRemoteConfigSoloError,
     clusterConnectionFailed: ClusterConnectionFailedError,
     clusterUnreachable: ClusterUnreachableError,
+    kindClusterStopped: KindClusterStoppedError,
+    containerEngineNotRunning: ContainerEngineNotRunningError,
     githubApiHttpResponseError: GitHubApiHttpResponseError,
     githubApiRequestFailed: GitHubApiRequestFailedError,
     githubApiResponseMissingTagName: GitHubApiResponseMissingTagNameError,

--- a/src/integration/container-engine/cluster-node-resume-outcome.ts
+++ b/src/integration/container-engine/cluster-node-resume-outcome.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/** The result of attempting to resume a cluster's stopped node container. */
+export enum ClusterNodeResumeOutcome {
+  /** The node container was stopped and has been started again. */
+  RESUMED = 'resumed',
+
+  /** Nothing changed: the node container is already running, does not exist, or refused to start. */
+  UNCHANGED = 'unchanged',
+
+  /** No container engine could be reached, so the node container's state is unknown. */
+  ENGINE_UNAVAILABLE = 'engine-unavailable',
+}

--- a/src/integration/container-engine/container-engine-client.ts
+++ b/src/integration/container-engine/container-engine-client.ts
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import {type ClusterNodeResumeOutcome} from './cluster-node-resume-outcome.js';
+
 /**
  * Abstraction over local container engine operations.
  *
@@ -43,4 +45,13 @@ export interface ContainerEngineClient {
    * Lists all images loaded into the local container engine.
    */
   listLoadedImagesInCluster(clusterName: string): Promise<readonly string[]>;
+
+  /**
+   * Starts the cluster's node container when it exists but is stopped, so a local cluster that was left
+   * behind by a reboot or a manual stop can be used again without recreating it.
+   *
+   * Best-effort by contract: it reports what it found rather than throwing, so a caller that is already
+   * handling a cluster failure can decide what to surface.
+   */
+  resumeStoppedClusterNode(clusterName: string): Promise<ClusterNodeResumeOutcome>;
 }

--- a/src/integration/container-engine/docker-client.ts
+++ b/src/integration/container-engine/docker-client.ts
@@ -18,14 +18,23 @@ import {Architecture} from '../../business/utils/architecture.js';
 import {type ContainerEngineCommand} from './container-engine-command.js';
 import {PathEx} from '../../business/utils/path-ex.js';
 import {PodmanClient} from './podman-client.js';
+import {ContainerEngineResourceInspector} from './container-engine-resource-inspector.js';
+import {ClusterNodeResumeOutcome} from './cluster-node-resume-outcome.js';
+import {type ContainerEngineResources} from './container-engine-resources.js';
 import {create as createTarball} from 'tar';
 
 @injectable()
 export class DockerClient implements ContainerEngineClient {
   private static readonly IMAGE_PULL_TIMEOUT_MS: number = 10 * 60 * 1000;
   private static readonly IMAGE_PULL_IDLE_TIMEOUT_MS: number = 10 * 60 * 1000;
+  private static readonly CONTAINER_LIFECYCLE_TIMEOUT_MS: number = 30 * 1000;
+
+  /** Container states a stopped node can be started from; `paused` needs `unpause` and is left alone. */
+  private static readonly STARTABLE_CONTAINER_STATES: ReadonlySet<string> = new Set(['exited', 'created']);
+
   private readonly shellRunner: ShellRunner;
   private readonly podmanClient: PodmanClient;
+  private readonly resourceInspector: ContainerEngineResourceInspector;
 
   public constructor(
     @inject(InjectTokens.KindBuilder) private readonly kindBuilder?: DefaultKindClientBuilder,
@@ -37,6 +46,7 @@ export class DockerClient implements ContainerEngineClient {
     this.dependencyManager = patchInject(dependencyManager, InjectTokens.DependencyManager, this.constructor.name);
     this.shellRunner = new ShellRunner(this.logger);
     this.podmanClient = new PodmanClient(this.logger);
+    this.resourceInspector = new ContainerEngineResourceInspector(this.logger);
   }
 
   public async pullImage(image: string): Promise<void> {
@@ -157,5 +167,62 @@ export class DockerClient implements ContainerEngineClient {
       .map((line): string => line.trim())
       .filter((line): boolean => line.length > 0)
       .filter((line): boolean => !line.startsWith('import-'));
+  }
+
+  public async resumeStoppedClusterNode(clusterName: string): Promise<ClusterNodeResumeOutcome> {
+    const nodeName: string = `${clusterName}-control-plane`;
+    const engineCommand: ContainerEngineCommand = (await this.podmanClient.getKindContainerCommand(nodeName)) ?? {
+      executable: constants.DOCKER,
+      argumentsPrefix: [],
+    };
+
+    const state: string | undefined = await this.readContainerState(engineCommand, nodeName);
+
+    if (state === undefined) {
+      // The inspect answered nothing, which means either no engine is reachable or this cluster has no node
+      // container. Only the first is worth reporting, and an engine info probe is the cheapest way to tell
+      // the two apart without matching on engine error text.
+      const resources: ContainerEngineResources | undefined = await this.resourceInspector.getAvailableResources();
+      return resources === undefined ? ClusterNodeResumeOutcome.ENGINE_UNAVAILABLE : ClusterNodeResumeOutcome.UNCHANGED;
+    }
+
+    if (!DockerClient.STARTABLE_CONTAINER_STATES.has(state)) {
+      return ClusterNodeResumeOutcome.UNCHANGED;
+    }
+
+    try {
+      await this.shellRunner.run(engineCommand.executable, [...engineCommand.argumentsPrefix, 'start', nodeName], {
+        commandProfile: SubprocessCommandProfile.CONTAINER_ENGINE,
+        timeoutMs: DockerClient.CONTAINER_LIFECYCLE_TIMEOUT_MS,
+      });
+      return ClusterNodeResumeOutcome.RESUMED;
+    } catch (error) {
+      // best-effort: a node container that refuses to start is reported as unchanged so the caller surfaces
+      // the cluster failure it was already handling rather than this secondary one.
+      this.logger.debug(`Unable to start the stopped cluster node container ${nodeName}`, error);
+      return ClusterNodeResumeOutcome.UNCHANGED;
+    }
+  }
+
+  private async readContainerState(
+    engineCommand: ContainerEngineCommand,
+    nodeName: string,
+  ): Promise<string | undefined> {
+    try {
+      const output: string[] = await this.shellRunner.run(
+        engineCommand.executable,
+        [...engineCommand.argumentsPrefix, 'container', 'inspect', '--format', '{{.State.Status}}', nodeName],
+        {
+          commandProfile: SubprocessCommandProfile.CONTAINER_ENGINE,
+          timeoutMs: DockerClient.CONTAINER_LIFECYCLE_TIMEOUT_MS,
+        },
+      );
+      return output.join('').trim() || undefined;
+    } catch (error) {
+      // best-effort probe: the container may be absent or the engine unreachable, and the caller
+      // distinguishes those two cases itself.
+      this.logger.debug(`Unable to read the state of container ${nodeName}`, error);
+      return undefined;
+    }
   }
 }

--- a/test/unit/business/runtime-state/remote-config-runtime-state.test.ts
+++ b/test/unit/business/runtime-state/remote-config-runtime-state.test.ts
@@ -1,70 +1,83 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {expect} from 'chai';
+import sinon, {type SinonSandbox, type SinonStub} from 'sinon';
+import {afterEach, beforeEach, describe, it} from 'mocha';
 import {RemoteConfigRuntimeState} from '../../../../src/business/runtime-state/config/remote/remote-config-runtime-state.js';
 import {ClusterUnreachableError} from '../../../../src/core/errors/classes/system/cluster-unreachable-error.js';
 import {KubernetesApiInvalidResponseSoloError} from '../../../../src/core/errors/classes/system/kubernetes-api-invalid-response-solo-error.js';
+import {KindClusterStoppedError} from '../../../../src/core/errors/classes/system/kind-cluster-stopped-error.js';
+import {ContainerEngineNotRunningError} from '../../../../src/core/errors/classes/system/container-engine-not-running-error.js';
 import {ResourceNotFoundError} from '../../../../src/integration/kube/errors/resource-operation-errors.js';
 import {ResourceOperation} from '../../../../src/integration/kube/resources/resource-operation.js';
 import {ResourceType} from '../../../../src/integration/kube/resources/resource-type.js';
 import {NamespaceName} from '../../../../src/types/namespace/namespace-name.js';
 import {type K8Factory} from '../../../../src/integration/kube/k8-factory.js';
+import {type ConfigMap} from '../../../../src/integration/kube/resources/config-map/config-map.js';
+import {type ContainerEngineClient} from '../../../../src/integration/container-engine/container-engine-client.js';
+import {ClusterNodeResumeOutcome} from '../../../../src/integration/container-engine/cluster-node-resume-outcome.js';
+import {Helpers} from '../../../../src/core/helpers.js';
+import {type SoloLogger} from '../../../../src/core/logging/solo-logger.js';
 import {type Context} from '../../../../src/types/index.js';
 
 const namespace: NamespaceName = NamespaceName.of('solo');
+const remoteConfigMap: ConfigMap = {name: 'solo-remote-config'} as unknown as ConfigMap;
 
-/** Builds a runtime state whose ConfigMap read always fails with the given error. */
-function runtimeStateFailingWith(readError: Error): RemoteConfigRuntimeState {
+/**
+ * Builds a runtime state over a stubbed ConfigMap read and a stubbed container engine. Only those two
+ * dependencies are exercised; the rest are non-null so they are not resolved from the container.
+ */
+function buildRuntimeState(read: SinonStub, resumeStoppedClusterNode: SinonStub): RemoteConfigRuntimeState {
   const k8Factory: K8Factory = {
-    getK8: (): unknown => ({
-      configMaps: (): unknown => ({
-        read: (): Promise<never> => Promise.reject(readError),
-      }),
-    }),
+    getK8: (): unknown => ({configMaps: (): unknown => ({read})}),
   } as unknown as K8Factory;
 
-  // Only the K8Factory is exercised; the remaining dependencies are non-null so they are not resolved
-  // from the container.
   return new RemoteConfigRuntimeState(
     k8Factory,
+    {showUser: (): void => undefined} as unknown as SoloLogger,
     {} as unknown as never,
     {} as unknown as never,
     {} as unknown as never,
     {} as unknown as never,
-    {} as unknown as never,
+    {resumeStoppedClusterNode} as unknown as ContainerEngineClient,
   );
 }
 
 /** Resolves with the error thrown while reading the remote config ConfigMap over the given context. */
-async function readFailure(readError: Error, context: Context): Promise<Error> {
-  return await runtimeStateFailingWith(readError)
-    .remoteConfigExists(namespace, context)
-    .then(
-      (): Error => undefined,
-      (error: Error): Error => error,
-    );
+async function readFailure(runtimeState: RemoteConfigRuntimeState, context: Context): Promise<Error> {
+  return await runtimeState.remoteConfigExists(namespace, context).then(
+    (): Error => undefined,
+    (error: Error): Error => error,
+  );
 }
 
 describe('RemoteConfigRuntimeState', (): void => {
+  let sandbox: SinonSandbox;
+  let read: SinonStub;
+  let resumeStoppedClusterNode: SinonStub;
+
+  beforeEach((): void => {
+    sandbox = sinon.createSandbox();
+    read = sandbox.stub();
+    resumeStoppedClusterNode = sandbox.stub().resolves(ClusterNodeResumeOutcome.UNCHANGED);
+  });
+
+  afterEach((): void => {
+    sandbox.restore();
+  });
+
   it('should throw ClusterUnreachableError preserving the cause for a non-kind context', async (): Promise<void> => {
     const cause: Error = new Error('connect ECONNREFUSED 10.0.0.1:6443');
+    read.rejects(cause);
 
-    const error: Error = await readFailure(cause, 'production-cluster');
+    const error: Error = await readFailure(buildRuntimeState(read, resumeStoppedClusterNode), 'production-cluster');
 
     expect(error).to.be.instanceOf(ClusterUnreachableError);
     expect(error.message).to.contain('production-cluster');
     expect(error.message).to.contain('connect ECONNREFUSED 10.0.0.1:6443');
     expect(error.cause).to.equal(cause);
-  });
-
-  it('should throw KubernetesApiInvalidResponseSoloError preserving the cause for a kind context', async (): Promise<void> => {
-    const cause: Error = new Error('configmaps is forbidden: User cannot list resource');
-
-    const error: Error = await readFailure(cause, 'kind-solo');
-
-    expect(error).to.be.instanceOf(KubernetesApiInvalidResponseSoloError);
-    expect(error.message).to.contain('configmaps is forbidden: User cannot list resource');
-    expect(error.cause).to.equal(cause);
+    // A remote cluster has no local node container, so the engine must not be touched at all.
+    expect(resumeStoppedClusterNode).to.not.have.been.called;
   });
 
   it('should rethrow ResourceNotFoundError untouched', async (): Promise<void> => {
@@ -74,9 +87,65 @@ describe('RemoteConfigRuntimeState', (): void => {
       namespace,
       'solo-remote-config',
     );
+    read.rejects(notFound);
 
-    const error: Error = await readFailure(notFound, 'production-cluster');
+    const error: Error = await readFailure(buildRuntimeState(read, resumeStoppedClusterNode), 'production-cluster');
 
     expect(error).to.equal(notFound);
+  });
+
+  it('should keep KubernetesApiInvalidResponseSoloError when a kind node container was not resumed', async (): Promise<void> => {
+    const cause: Error = new Error('configmaps is forbidden: User cannot list resource');
+    read.rejects(cause);
+
+    const error: Error = await readFailure(buildRuntimeState(read, resumeStoppedClusterNode), 'kind-solo');
+
+    expect(error).to.be.instanceOf(KubernetesApiInvalidResponseSoloError);
+    expect(error.message).to.contain('configmaps is forbidden: User cannot list resource');
+    expect(error.cause).to.equal(cause);
+    expect(resumeStoppedClusterNode).to.have.been.calledOnceWithExactly('solo');
+  });
+
+  it('should throw ContainerEngineNotRunningError when no container engine answers', async (): Promise<void> => {
+    const cause: Error = new Error('connect ECONNREFUSED 127.0.0.1:52810');
+    read.rejects(cause);
+    resumeStoppedClusterNode.resolves(ClusterNodeResumeOutcome.ENGINE_UNAVAILABLE);
+
+    const error: Error = await readFailure(buildRuntimeState(read, resumeStoppedClusterNode), 'kind-solo');
+
+    expect(error).to.be.instanceOf(ContainerEngineNotRunningError);
+    expect(error.cause).to.equal(cause);
+  });
+
+  it('should read again once a stopped kind cluster has been resumed', async (): Promise<void> => {
+    read.onFirstCall().rejects(new Error('connect ECONNREFUSED 127.0.0.1:52810'));
+    read.onSecondCall().resolves(remoteConfigMap);
+    resumeStoppedClusterNode.resolves(ClusterNodeResumeOutcome.RESUMED);
+
+    const exists: boolean = await buildRuntimeState(read, resumeStoppedClusterNode).remoteConfigExists(
+      namespace,
+      'kind-solo',
+    );
+
+    expect(exists).to.be.true;
+    expect(resumeStoppedClusterNode).to.have.been.calledOnceWithExactly('solo');
+    expect(read).to.have.been.calledTwice;
+  });
+
+  it('should throw KindClusterStoppedError when a resumed kind cluster never answers', async (): Promise<void> => {
+    const cause: Error = new Error('connect ECONNREFUSED 127.0.0.1:52810');
+    read.rejects(cause);
+    resumeStoppedClusterNode.resolves(ClusterNodeResumeOutcome.RESUMED);
+    // The wait between attempts is real time the assertion does not need; only the retry count matters.
+    const sleep: SinonStub = sandbox.stub(Helpers, 'sleep').resolves();
+
+    const error: Error = await readFailure(buildRuntimeState(read, resumeStoppedClusterNode), 'kind-solo');
+
+    expect(error).to.be.instanceOf(KindClusterStoppedError);
+    expect(error.message).to.contain("kind cluster 'solo'");
+    expect(error.cause).to.equal(cause);
+    // The initial read, then one read per resume attempt, sleeping between the attempts but not before the first.
+    expect(read.callCount).to.equal(31);
+    expect(sleep.callCount).to.equal(29);
   });
 });

--- a/test/unit/integration/cache/image-cache-handler.test.ts
+++ b/test/unit/integration/cache/image-cache-handler.test.ts
@@ -13,6 +13,7 @@ import {type CacheHealthInspector} from '../../../../src/integration/cache/api/c
 import {type SoloLogger} from '../../../../src/core/logging/solo-logger.js';
 import {SoloPinoLogger} from '../../../../src/core/logging/solo-pino-logger.js';
 import {type ContainerEngineClient} from '../../../../src/integration/container-engine/container-engine-client.js';
+import {ClusterNodeResumeOutcome} from '../../../../src/integration/container-engine/cluster-node-resume-outcome.js';
 import {type SoloListrTask} from '../../../../src/types/index.js';
 import {type AnyListrContext} from '../../../../src/types/aliases.js';
 
@@ -110,6 +111,7 @@ describe('ImageCacheHandler pull', (): void => {
       loadImageArchiveIntoCluster: async (): Promise<void> => undefined,
       removeImage: async (): Promise<void> => undefined,
       listLoadedImagesInCluster: async (): Promise<readonly string[]> => [],
+      resumeStoppedClusterNode: async (): Promise<ClusterNodeResumeOutcome> => ClusterNodeResumeOutcome.UNCHANGED,
     };
 
     const provider: StaticCacheTargetProvider = new StaticCacheTargetProvider([target]);
@@ -137,6 +139,7 @@ describe('ImageCacheHandler pull', (): void => {
       loadImageArchiveIntoCluster: async (): Promise<void> => undefined,
       removeImage: async (): Promise<void> => undefined,
       listLoadedImagesInCluster: async (): Promise<readonly string[]> => [],
+      resumeStoppedClusterNode: async (): Promise<ClusterNodeResumeOutcome> => ClusterNodeResumeOutcome.UNCHANGED,
     };
 
     const provider: StaticCacheTargetProvider = new StaticCacheTargetProvider([target]);
@@ -163,6 +166,7 @@ describe('ImageCacheHandler pull', (): void => {
       loadImageArchiveIntoCluster: async (): Promise<void> => undefined,
       removeImage: async (): Promise<void> => undefined,
       listLoadedImagesInCluster: async (): Promise<readonly string[]> => [],
+      resumeStoppedClusterNode: async (): Promise<ClusterNodeResumeOutcome> => ClusterNodeResumeOutcome.UNCHANGED,
     };
 
     const provider: StaticCacheTargetProvider = new StaticCacheTargetProvider([target]);
@@ -190,6 +194,7 @@ describe('ImageCacheHandler pull', (): void => {
       loadImageArchiveIntoCluster: async (): Promise<void> => undefined,
       removeImage: async (): Promise<void> => undefined,
       listLoadedImagesInCluster: async (): Promise<readonly string[]> => [],
+      resumeStoppedClusterNode: async (): Promise<ClusterNodeResumeOutcome> => ClusterNodeResumeOutcome.UNCHANGED,
     };
 
     const provider: StaticCacheTargetProvider = new StaticCacheTargetProvider([target]);
@@ -253,6 +258,7 @@ describe('ImageCacheHandler load', (): void => {
       loadImageArchiveIntoCluster: loadArchiveStub,
       removeImage: async (): Promise<void> => undefined,
       listLoadedImagesInCluster: async (): Promise<readonly string[]> => [],
+      resumeStoppedClusterNode: async (): Promise<ClusterNodeResumeOutcome> => ClusterNodeResumeOutcome.UNCHANGED,
     };
 
     const handler: ImageCacheHandler = new ImageCacheHandler(
@@ -278,6 +284,7 @@ describe('ImageCacheHandler load', (): void => {
       loadImageArchiveIntoCluster: loadArchiveStub,
       removeImage: async (): Promise<void> => undefined,
       listLoadedImagesInCluster: async (): Promise<readonly string[]> => ['docker.io/library/busybox:1.36.1'],
+      resumeStoppedClusterNode: async (): Promise<ClusterNodeResumeOutcome> => ClusterNodeResumeOutcome.UNCHANGED,
     };
 
     const handler: ImageCacheHandler = new ImageCacheHandler(
@@ -305,6 +312,7 @@ describe('ImageCacheHandler load', (): void => {
       listLoadedImagesInCluster: async (): Promise<readonly string[]> => {
         throw new Error('cluster unreachable');
       },
+      resumeStoppedClusterNode: async (): Promise<ClusterNodeResumeOutcome> => ClusterNodeResumeOutcome.UNCHANGED,
     };
 
     const handler: ImageCacheHandler = new ImageCacheHandler(
@@ -329,6 +337,7 @@ describe('ImageCacheHandler load', (): void => {
       loadImageArchiveIntoCluster: sinon.stub().rejects(new Error('unrecognized image format')),
       removeImage: async (): Promise<void> => undefined,
       listLoadedImagesInCluster: async (): Promise<readonly string[]> => [],
+      resumeStoppedClusterNode: async (): Promise<ClusterNodeResumeOutcome> => ClusterNodeResumeOutcome.UNCHANGED,
     };
 
     const handler: ImageCacheHandler = new ImageCacheHandler(

--- a/test/unit/integration/container-engine/docker-client.test.ts
+++ b/test/unit/integration/container-engine/docker-client.test.ts
@@ -11,6 +11,7 @@ import {type SoloLogger} from '../../../../src/core/logging/solo-logger.js';
 import {type DependencyManager} from '../../../../src/core/dependency-managers/index.js';
 import {type KindClient} from '../../../../src/integration/kind/kind-client.js';
 import {PodmanDependencyManager} from '../../../../src/core/dependency-managers/podman-dependency-manager.js';
+import {ClusterNodeResumeOutcome} from '../../../../src/integration/container-engine/cluster-node-resume-outcome.js';
 
 describe('DockerClient', (): void => {
   let previousKindProvider: string | undefined;
@@ -73,14 +74,97 @@ describe('DockerClient', (): void => {
       sinon.match.has('archivePath', '/tmp/busybox.tar').and(sinon.match.has('name', 'kind')),
     );
   });
+
+  it('starts a stopped kind node container', async (): Promise<void> => {
+    delete process.env.KIND_EXPERIMENTAL_PROVIDER;
+    const nodeName: string = 'solo-cluster-control-plane';
+    DockerClientTestBuilder.stubMissingPodmanContainer(shellRunnerRunStub, nodeName);
+    shellRunnerRunStub
+      .withArgs('docker', DockerClientTestBuilder.inspectStateArguments(nodeName), sinon.match.object)
+      .resolves(['exited']);
+    shellRunnerRunStub
+      .withArgs('docker', DockerClientTestBuilder.startArguments(nodeName), sinon.match.object)
+      .resolves([]);
+
+    const client: DockerClient = DockerClientTestBuilder.build();
+    const outcome: ClusterNodeResumeOutcome = await client.resumeStoppedClusterNode('solo-cluster');
+
+    expect(outcome).to.equal(ClusterNodeResumeOutcome.RESUMED);
+    expect(shellRunnerRunStub).to.have.been.calledWith(
+      'docker',
+      DockerClientTestBuilder.startArguments(nodeName),
+      sinon.match.object,
+    );
+  });
+
+  it('leaves a running kind node container alone', async (): Promise<void> => {
+    delete process.env.KIND_EXPERIMENTAL_PROVIDER;
+    const nodeName: string = 'solo-cluster-control-plane';
+    DockerClientTestBuilder.stubMissingPodmanContainer(shellRunnerRunStub, nodeName);
+    shellRunnerRunStub
+      .withArgs('docker', DockerClientTestBuilder.inspectStateArguments(nodeName), sinon.match.object)
+      .resolves(['running']);
+
+    const client: DockerClient = DockerClientTestBuilder.build();
+    const outcome: ClusterNodeResumeOutcome = await client.resumeStoppedClusterNode('solo-cluster');
+
+    expect(outcome).to.equal(ClusterNodeResumeOutcome.UNCHANGED);
+    expect(shellRunnerRunStub).to.not.have.been.calledWith(
+      'docker',
+      DockerClientTestBuilder.startArguments(nodeName),
+      sinon.match.object,
+    );
+  });
+
+  it('reports the container engine as unavailable when nothing answers', async (): Promise<void> => {
+    delete process.env.KIND_EXPERIMENTAL_PROVIDER;
+    const nodeName: string = 'solo-cluster-control-plane';
+    DockerClientTestBuilder.stubMissingPodmanContainer(shellRunnerRunStub, nodeName);
+    shellRunnerRunStub
+      .withArgs('docker', DockerClientTestBuilder.inspectStateArguments(nodeName), sinon.match.object)
+      .rejects(new Error('Cannot connect to the Docker daemon'));
+    DockerClientTestBuilder.stubUnreachableEngineInfo(shellRunnerRunStub);
+
+    const client: DockerClient = DockerClientTestBuilder.build(
+      {} as DependencyManager,
+      {} as DefaultKindClientBuilder,
+      DockerClientTestBuilder.silentLogger(),
+    );
+    const outcome: ClusterNodeResumeOutcome = await client.resumeStoppedClusterNode('solo-cluster');
+
+    expect(outcome).to.equal(ClusterNodeResumeOutcome.ENGINE_UNAVAILABLE);
+  });
 });
 
 class DockerClientTestBuilder {
   public static build(
     dependencyManager: DependencyManager = {} as DependencyManager,
     kindBuilder: DefaultKindClientBuilder = {} as DefaultKindClientBuilder,
+    logger: SoloLogger = {} as SoloLogger,
   ): DockerClient {
-    return new DockerClient(kindBuilder, {} as SoloLogger, dependencyManager);
+    return new DockerClient(kindBuilder, logger, dependencyManager);
+  }
+
+  /** A logger for the paths that report a failed probe; the production code logs those at debug level. */
+  public static silentLogger(): SoloLogger {
+    return {debug: (): void => undefined} as unknown as SoloLogger;
+  }
+
+  public static inspectStateArguments(nodeName: string, prefix: readonly string[] = []): string[] {
+    return [...prefix, 'container', 'inspect', '--format', '{{.State.Status}}', nodeName];
+  }
+
+  public static startArguments(nodeName: string, prefix: readonly string[] = []): string[] {
+    return [...prefix, 'start', nodeName];
+  }
+
+  public static stubUnreachableEngineInfo(shellRunnerRunStub: SinonStub): void {
+    shellRunnerRunStub
+      .withArgs('docker', ['info', '--format', '{{json .}}'], sinon.match.object)
+      .rejects(new Error('Cannot connect to the Docker daemon'));
+    shellRunnerRunStub
+      .withArgs('podman', ['info', '--format', 'json'], sinon.match.object)
+      .rejects(new Error('podman is not installed'));
   }
 
   public static buildDependencyManager(kindExecutable: string): DependencyManager {


### PR DESCRIPTION
## Description

> **Stacked on #5565.** The base of this PR is `fix/5446-cluster-unreachable-error`, so the diff shown
> here is only the #5567 work. GitHub will retarget it to `main` when #5565 merges. Both PRs edit the
> same catch block in `getConfigMap()`, which is why they are stacked rather than parallel.

A kind cluster is not a remote thing solo connects to — it is a set of containers on this machine. A
host reboot, a `docker stop`, or Docker Desktop being quit leaves the cluster fully present on disk
but not serving anything. Every solo command that reads remote config then fails at the first
Kubernetes API call, and until #5565 it failed with a message that said nothing about why.

Knowing why is an improvement, but it is still a dead end for the case that causes it most often:
the node container is sitting right there, stopped, and starting it is a single command. This PR
detects that case and does it.

### What changed

* **`src/integration/container-engine/cluster-node-resume-outcome.ts`** (new) —
  `ClusterNodeResumeOutcome`: `RESUMED`, `UNCHANGED`, `ENGINE_UNAVAILABLE`.
* **`src/integration/container-engine/container-engine-client.ts`** — adds
  `resumeStoppedClusterNode(clusterName)`. `ContainerEngineClient` had no container-lifecycle
  operation at all; everything on it was image movement (`pullImage`, `saveImage`, `loadImage`,
  `loadImageArchiveIntoCluster`, `removeImage`, `listLoadedImagesInCluster`). It is documented as
  best-effort by contract — it reports what it found rather than throwing, because its caller is
  already handling a cluster failure and needs to decide what to surface.
* **`src/integration/container-engine/docker-client.ts`** — the implementation. It resolves the engine
  the same way the existing methods do (`PodmanClient.getKindContainerCommand()` first, docker
  otherwise, so a rootful-podman kind node is handled by the same path), reads
  `container inspect --format '{{.State.Status}}'`, and runs `start` only from `exited` or `created`.
  A `paused` container needs `unpause` rather than `start` and is deliberately left alone.
* **`src/business/runtime-state/config/remote/remote-config-runtime-state.ts`** — on a kind-context
  read failure it now asks the engine to resume the node, and **only when a container was actually
  started** waits for the Kubernetes API, retrying the read for up to a minute (30 attempts, 2s apart,
  the first immediate) before giving up. The raw read moved into `readRemoteConfigMap()` so the retry
  and the first attempt cannot drift apart.
* **`src/core/errors/classes/system/kind-cluster-stopped-error.ts`** (new) — `KindClusterStoppedError`
  (`SOLO-5079`, Infrastructure, retryable): the node was stopped, solo started it, and the API still
  never answered. Its troubleshooting steps name the cluster: `docker logs <cluster>-control-plane`,
  `kubectl cluster-info --context kind-<cluster>`, and recreating the cluster as the last resort.
* **`src/core/errors/classes/system/container-engine-not-running-error.ts`** (new) —
  `ContainerEngineNotRunningError` (`SOLO-5080`, User, retryable): no engine answered, so the cluster's
  state cannot even be determined. Steps cover Docker Desktop, `systemctl start docker` and
  `podman machine start`.

### The decisions #5567 left open

The issue deliberately did not pre-decide these. What was chosen, and why:

* **Resume automatically, rather than prompt or gate behind a flag.** These are read paths (`load()`,
  `populateFromExisting()`, `remoteConfigExists()`) that also run non-interactively — one-shot, CI —
  where a prompt is a hang, and a flag means the person who most needs the recovery is the one who
  does not know to pass it. The action is narrow and local: starting a container that solo itself
  created, on the user's own machine, that solo was already about to fail on. The user is told it
  happened, on both ends: *"The kind cluster 'X' was stopped; solo started its node container and is
  waiting for the Kubernetes API..."* then *"The kind cluster 'X' is available again."*
* **Do not start the container engine daemon.** `systemctl start docker` needs root and `open -a
  Docker` is macOS-only and takes tens of seconds; a CLI that silently starts a system service during
  a config read is doing something the user did not ask for. `ContainerEngineNotRunningError` reports
  it with the exact command for each platform instead, which is the remaining half of the issue's
  "container-engine-not-running case".
* **Never wait on a cluster that was not resumed.** The wait is reached only after `RESUMED`. An
  RBAC denial, a bad kubeconfig or a genuinely deleted cluster all return `UNCHANGED` and surface
  immediately, exactly as they do today — so this cannot turn a fast failure into a 60-second one.
* **Distinguishing "no engine" from "no such container" without matching on error text.** Both make
  `container inspect` fail. Rather than pattern-matching engine stderr, a failed inspect falls back to
  `ContainerEngineResourceInspector.getAvailableResources()`, which already probes `docker info` and
  then `podman info`; `undefined` from both means no engine is reachable. Reusing the existing probe
  keeps this free of string matching that would break on an engine version bump.

### Related Issues

* Closes #5567
* Related to #5446 — this is the "additionally see if..." half of that issue
* Related to #5565 — the base of this PR, which made the kind-vs-remote distinction this builds on

### Pull request (PR) checklist

- [x] This PR added tests (unit, integration, and/or end-to-end)
- [ ] This PR updated documentation
- [x] This PR added no TODOs or commented out code
- [x] This PR has no breaking changes
- [x] Any technical debt has been documented as a separate issue and linked to this PR
- [x] Any `package.json` changes have been explained to and approved by a repository manager
- [x] All related issues have been linked to this PR
- [x] All changes in this PR are included in the description
- [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

No documentation file changed: the pages for `SOLO-5079` and `SOLO-5080` are generated from the class
TSDoc by `scripts/docs/generate-error-documentation.ts` at `task build:docs:content` time and are not
committed. `ContainerEngineClient` gained a method, but it is an internal interface with a single
implementation, so no public surface changed.

### Testing

- [x] This PR added unit tests
- [ ] This PR added integration/end-to-end tests
- [x] These changes required manual testing that is documented below
- [x] Anything not tested is documented

The following manual testing was done:

* `npx tsc --noEmit` — exit 0.
* `npx eslint` on all eleven changed files — **0 errors, 0 warnings**.
* `npx prettier --check` on all eleven changed files — clean.
* `npx mocha 'test/unit/**/*.ts' --exclude 'test/unit/core/helm/**/*.ts'` — **1414 passing, 0
  failing** (1408 before this PR, +6).
* `npx mocha 'test/unit/business/runtime-state/remote-config-runtime-state.test.ts'` — 6 passing. They
  drive `remoteConfigExists()` over a stubbed ConfigMap read and a stubbed engine, and cover: a
  non-kind context still failing as `ClusterUnreachableError` **without the engine being consulted at
  all**; `ResourceNotFoundError` still rethrown by identity; `UNCHANGED` keeping today's
  `KubernetesApiInvalidResponseSoloError` with its cause; `ENGINE_UNAVAILABLE` producing
  `ContainerEngineNotRunningError`; `RESUMED` followed by a successful read returning normally with
  exactly two reads and `resumeStoppedClusterNode('solo')` called once for context `kind-solo`; and a
  resumed cluster that never answers producing `KindClusterStoppedError` after 1 + 30 reads and 29
  waits (`Helpers.sleep` is stubbed, so the retry count is asserted without spending the minute).
* `npx mocha 'test/unit/integration/container-engine/docker-client.test.ts'` — 5 passing, 3 of them
  new: an `exited` node is started and `docker start <node>` is issued; a `running` node returns
  `UNCHANGED` with no start call; and a failed inspect plus unanswered `docker info`/`podman info`
  returns `ENGINE_UNAVAILABLE`.
* **DI resolution smoke test.** `RemoteConfigRuntimeState` gained an injected dependency, and a
  dependency cycle would only appear at runtime, so the container was initialised in a throwaway
  script and both tokens resolved: `RemoteConfigRuntimeState + DockerClient`. No cycle, and the
  runtime state receives the real engine client.
* `npx tsx scripts/docs/generate-error-documentation.ts` — 291 pages;
  `system/SOLO-5079.md` and `system/SOLO-5080.md` render as `KindClusterStoppedError` and
  `ContainerEngineNotRunningError` with the right ownership and retryable flags.

The following was not tested:

* **The end-to-end behaviour was not exercised against a real stopped kind cluster.** Every layer is
  unit-tested with the shell and the API stubbed, but no run actually stopped a kind node, restarted
  it through solo, and watched a command carry on. That is the one check worth doing before merge and
  it needs a machine with kind and a live cluster.
* **The one-minute ceiling is a guess, not a measurement.** 30 attempts × 2s was chosen to match the
  existing control-plane wait in `backup-restore.ts` (60 × 2s for a freshly created cluster, where
  more is expected). A restarted node that routinely needs longer would surface as
  `KindClusterStoppedError`, which is retryable and says so, but the number deserves a real
  measurement.
* **Multi-node kind clusters.** Only `<cluster>-control-plane` is resumed. A multi-node cluster whose
  workers are also stopped will come back with just its control plane; the API answers, so solo
  proceeds, and the missing workers surface later as unschedulable pods rather than as this error.
  Single-node is what solo creates by default.
* **Podman was not exercised on a live host.** The podman path reuses
  `PodmanClient.getKindContainerCommand()` unchanged, including its rootful `sudo` variant, and is
  covered only by the stubbed unit tests.
* Whether a kind cluster reliably survives a stop/start at all is a property of kind and the host, not
  of this change. When it does not, the outcome is `KindClusterStoppedError` naming exactly that, with
  `kind delete cluster` as the documented last step.
