### PR TITLE
fix: retry the hasDir probe when an interrupted kubectl exec returns no output

### DIFF
--- a/src/integration/kube/k8-client/resources/container/k8-client-container.ts
+++ b/src/integration/kube/k8-client/resources/container/k8-client-container.ts
@@ -345,7 +345,7 @@ export class K8ClientContainer implements Container {
     // Retry transient exec failures that occur before the command runs: kubelet reporting "container not found" during rolling restarts, and API server to kubelet tunnel errors (connection upgrade, dial, timeout).
     const maxAttempts: number = 30;
     const retryableTransientFailure: RegExp =
-      /(container not found|unable to upgrade connection|internal error occurred: timeout occurred|error dialing backend)/i;
+      /(container not found|unable to upgrade connection|internal error occurred: timeout occurred|error dialing backend|connection reset by peer)/i;
 
     for (let attempt: number = 1; attempt <= maxAttempts; attempt++) {
       try {
@@ -368,18 +368,42 @@ export class K8ClientContainer implements Container {
   }
 
   public async hasDir(destinationPath: string): Promise<boolean> {
+    const maxAttempts: number = 3;
+
+    for (let attempt: number = 1; attempt <= maxAttempts; attempt++) {
+      const result: string = await this.probeDirectory(destinationPath);
+
+      if (result === 'true' || result === 'false') {
+        return result === 'true';
+      }
+
+      // an exec stream cut mid-flight (e.g. containerd restart) can exit 0 with no output, so only the literal probe answers are trusted
+      this.logger.warn(
+        `hasDir: unexpected probe output '${result}' on attempt ${attempt} of ${maxAttempts} [podName: ${this.containerReference.parentReference.name} -c ${this.containerReference.name}, path: ${destinationPath}]`,
+      );
+
+      if (attempt < maxAttempts) {
+        await sleep(Duration.ofMillis(attempt * 1000));
+      }
+    }
+
+    throw new KubeContainerOperationFailedError(
+      `hasDir ${destinationPath}`,
+      new Error('directory probe returned no usable output after retries'),
+    );
+  }
+
+  private async probeDirectory(destinationPath: string): Promise<string> {
     const bashScript: string = `[[ -d "${destinationPath}" ]] && echo -n "true" || echo -n "false"`;
     try {
-      const result: string = await this.execContainer(['bash', '-c', bashScript]);
-      return result === 'true';
+      return await this.execContainer(['bash', '-c', bashScript]);
     } catch (error) {
       this.logger.debug(
         `hasDir failed using bash for ${this.containerReference.parentReference.name}:${this.containerReference.name}, retrying with /bin/sh`,
         error,
       );
       const shScript: string = `[ -d "${destinationPath}" ] && echo -n "true" || echo -n "false"`;
-      const result: string = await this.execContainer(['/bin/sh', '-c', shScript]);
-      return result === 'true';
+      return await this.execContainer(['/bin/sh', '-c', shScript]);
     }
   }
 

--- a/test/unit/integration/kube/k8-client-container.test.ts
+++ b/test/unit/integration/kube/k8-client-container.test.ts
@@ -49,6 +49,7 @@ describe('K8ClientContainer execContainer', (): void => {
     'error: Internal error occurred: Timeout occurred',
     'Error from server: error dialing backend: dial tcp 10.89.0.2:10250: connect: connection refused',
     'error: unable to upgrade connection: container not found ("postgresql")',
+    'error: error reading from server: read unix @->/run/containerd/containerd.sock: read: connection reset by peer',
   ]) {
     it(`retries and succeeds after transient failure: ${stderr}`, async (): Promise<void> => {
       execKubectlStub.onFirstCall().rejects(kubectlFailure(stderr));
@@ -75,5 +76,57 @@ describe('K8ClientContainer execContainer', (): void => {
     }
 
     expect(execKubectlStub).to.have.been.calledOnce;
+  });
+
+  describe('hasDir', (): void => {
+    it('returns true when the probe prints true', async (): Promise<void> => {
+      execKubectlStub.resolves('true');
+
+      expect(await containerClient.hasDir('/tmp')).to.be.true;
+      expect(execKubectlStub).to.have.been.calledOnce;
+    });
+
+    it('returns false when the probe prints false', async (): Promise<void> => {
+      execKubectlStub.resolves('false');
+
+      expect(await containerClient.hasDir('/missing')).to.be.false;
+      expect(execKubectlStub).to.have.been.calledOnce;
+    });
+
+    it('retries when an interrupted exec returns no output, then succeeds', async (): Promise<void> => {
+      execKubectlStub.onFirstCall().resolves('');
+      execKubectlStub.onSecondCall().resolves('true');
+
+      expect(await containerClient.hasDir('/tmp')).to.be.true;
+      expect(execKubectlStub).to.have.been.calledTwice;
+    });
+
+    it('throws instead of returning false when every probe returns no usable output', async (): Promise<void> => {
+      execKubectlStub.resolves('');
+
+      try {
+        await containerClient.hasDir('/tmp');
+        expect.fail('Expected hasDir to reject');
+      } catch (error) {
+        expect(error).to.be.instanceOf(KubeContainerOperationFailedError);
+        expect((error as KubeContainerOperationFailedError).message).to.include('hasDir /tmp');
+      }
+
+      expect(execKubectlStub).to.have.been.calledThrice;
+    });
+
+    it('falls back to /bin/sh when bash is unavailable', async (): Promise<void> => {
+      execKubectlStub
+        .onFirstCall()
+        .rejects(
+          kubectlFailure(
+            'exec failed: unable to start container process: exec: "bash": executable file not found in $PATH',
+          ),
+        );
+      execKubectlStub.onSecondCall().resolves('true');
+
+      expect(await containerClient.hasDir('/tmp')).to.be.true;
+      expect(execKubectlStub.secondCall.args[0]).to.include('/bin/sh');
+    });
   });
 });


### PR DESCRIPTION
## Description

This pull request changes the following:

* Hardens `K8ClientContainer.hasDir` so it only trusts the literal `true`/`false` probe answers. Any other exec result (e.g. empty output from an exec stream cut mid-flight) is retried up to 3 times with backoff, and after exhaustion it throws a `KubeContainerOperationFailedError` instead of silently reporting the directory as missing.
* Adds `connection reset by peer` to `execContainer`'s retryable transient failure patterns.
* Adds unit tests for the `hasDir` probe semantics (true/false pass-through, retry-then-succeed on empty output, throw after exhaustion, `/bin/sh` fallback) and for the new transient retry pattern.

**Root cause of #5578:** during the `One Shot Single - using Podman` run, containerd inside the kind node crashed at `09:10:23` (kubelet event: `read unix @->/run/containerd/containerd.sock: read: connection reset by peer`) exactly while the `hasDir("/tmp")` probe on the postgres pod was in flight. The interrupted `kubectl exec` exited 0 with no output, `hasDir` treated the non-`true` result as "directory missing", and `copyTo` failed the deploy with the misleading `Invalid container path in destination: /tmp`. The same containerd blip hit a parallel exec on `network-node1-0` seconds later and was absorbed by the transient-failure retry loop, confirming the outage was survivable — `hasDir` was the only path that turned it into a hard failure.

### Related Issues

* Closes #5578

### Pull request (PR) checklist

* [x] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [ ] Any technical debt has been documented as a separate issue and linked to this PR
* [ ] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [x] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [ ] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* None — the failure scenario (containerd crashing mid-exec inside the kind node) is not reproducible on demand; the interrupted-exec behavior is covered by unit tests stubbing the kubectl layer.

The following was not tested:

* An end-to-end reproduction of the containerd crash inside a podman-backed kind node.
