### PR TITLE
fix: pin metallb chart and select migration baseline from this release line

### DIFF
--- a/.github/workflows/flow-migration-test.yaml
+++ b/.github/workflows/flow-migration-test.yaml
@@ -92,9 +92,42 @@ jobs:
           max_attempts: 3
           timeout_minutes: 5
           command: |
-            LATEST_VERSION=$(curl -s https://registry.npmjs.org/@hashgraph/solo/latest | jq -r '.version')
-            echo "Latest Version: ${LATEST_VERSION}"
-            echo "version=${LATEST_VERSION}" >> $GITHUB_OUTPUT
+            # The prior release has to come from this branch's own release line. The "latest"
+            # dist-tag points at whatever is newest across all lines, so on a maintenance branch
+            # it selects a newer release and the test migrates *down* into an older config
+            # schema, which is unsupported and fails with "schemaVersion: N not found".
+            CURRENT_VERSION=$(jq -r '.version' package.json)
+            RELEASE_LINE="${CURRENT_VERSION%.*}"
+
+            ALL_VERSIONS=$(curl -s https://registry.npmjs.org/@hashgraph/solo \
+              | jq -r '.versions | keys[]' \
+              | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$')
+
+            # Newest release on this line that is strictly older than the version being built.
+            # Appending CURRENT_VERSION and cutting the sorted list at its first occurrence
+            # leaves only genuinely older releases, whether or not it is itself published.
+            PRIOR_VERSION=$(printf '%s\n%s\n' \
+              "$(printf '%s\n' "${ALL_VERSIONS}" | grep -E "^${RELEASE_LINE}\.")" \
+              "${CURRENT_VERSION}" \
+              | grep -v '^$' | sort -V \
+              | awk -v current="${CURRENT_VERSION}" '$0 == current { exit } { print }' | tail -n 1)
+
+            # A line with no earlier publish (a freshly cut branch) falls back to the newest
+            # older release on any line, which is still never a downgrade.
+            if [[ -z "${PRIOR_VERSION}" ]]; then
+              PRIOR_VERSION=$(printf '%s\n%s\n' "${ALL_VERSIONS}" "${CURRENT_VERSION}" \
+                | grep -v '^$' | sort -V \
+                | awk -v current="${CURRENT_VERSION}" '$0 == current { exit } { print }' | tail -n 1)
+            fi
+
+            if [[ -z "${PRIOR_VERSION}" ]]; then
+              echo "No published release older than ${CURRENT_VERSION} was found" >&2
+              exit 1
+            fi
+
+            echo "Current Version: ${CURRENT_VERSION}"
+            echo "Prior Version: ${PRIOR_VERSION}"
+            echo "version=${PRIOR_VERSION}" >> $GITHUB_OUTPUT
 
       - name: Launch Network with Prior Release ${{ steps.get-version.outputs.version }}
         timeout-minutes: 60

--- a/examples/multicluster-backup-restore/Taskfile.yml
+++ b/examples/multicluster-backup-restore/Taskfile.yml
@@ -103,6 +103,7 @@ tasks:
           helm upgrade --install metallb metallb/metallb \
             --kube-context kind-solo-e2e-c1 \
             --namespace metallb-system --create-namespace --atomic --wait \
+            --version 0.15.3 \
             --set speaker.frr.enabled=true
       - cmd: kubectl apply -f metallb-cluster-1.yaml --context kind-solo-e2e-c1
 
@@ -116,6 +117,7 @@ tasks:
           helm upgrade --install metallb metallb/metallb \
             --kube-context kind-solo-e2e-c2 \
             --namespace metallb-system --create-namespace --atomic --wait \
+            --version 0.15.3 \
             --set speaker.frr.enabled=true
       - cmd: kubectl apply -f metallb-cluster-2.yaml --context kind-solo-e2e-c2
 

--- a/test/e2e/dual-cluster/setup-dual-e2e.sh
+++ b/test/e2e/dual-cluster/setup-dual-e2e.sh
@@ -12,6 +12,9 @@ SCRIPT_PATH=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 readonly SCRIPT_PATH
 
 readonly CLUSTER_DIAGNOSTICS_PATH="${SCRIPT_PATH}/diagnostics/cluster"
+# Pinned rather than tracking latest: metallb 0.16.0 turned frrk8s on by default, which the
+# chart rejects as mutually exclusive with the speaker.frr.enabled=true set below.
+readonly METALLB_CHART_VERSION="0.15.3"
 readonly KIND_IMAGE="kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30"
 
 echo "SOLO_CHARTS_DIR: ${SOLO_CHARTS_DIR}"
@@ -72,6 +75,7 @@ for i in $(seq 1 "${SOLO_CLUSTER_DUALITY}"); do
   if [[ "${SOLO_CLUSTER_DUALITY}" -gt 1 ]]; then
     helm upgrade --install metallb metallb/metallb \
       --namespace metallb-system --create-namespace --atomic --wait \
+      --version "${METALLB_CHART_VERSION}" \
       --set speaker.frr.enabled=true
 
     kubectl apply -f "${SCRIPT_PATH}/metallb-cluster-${i}.yaml"

--- a/test/helpers/helm-metal-load-balancer.ts
+++ b/test/helpers/helm-metal-load-balancer.ts
@@ -5,6 +5,7 @@ import {NamespaceName} from '../../src/types/namespace/namespace-name.js';
 import {type K8ClientFactory} from '../../src/integration/kube/k8-client/k8-client-factory.js';
 import {InjectTokens} from '../../src/core/dependency-injection/inject-tokens.js';
 import {type ChartManager} from '../../src/core/chart-manager.js';
+import {METALLB_CHART_VERSION} from '../../version.js';
 
 export class HelmMetalLoadBalancer {
   public static readonly NAMESPACE: NamespaceName = NamespaceName.of('metallb-system');
@@ -13,7 +14,9 @@ export class HelmMetalLoadBalancer {
   public static readonly REPOSITORY_NAME: string = 'metallb';
   public static readonly REPOSITORY_URL: string = 'https://metallb.github.io/metallb/';
   public static readonly INSTALL_ARGS: string = '--set speaker.frr.enabled=true';
-  public static readonly VERSION: string = ''; // latest version
+  // Pinned rather than tracking latest: metallb 0.16.0 turned frrk8s on by default, which the
+  // chart rejects as mutually exclusive with the speaker.frr.enabled=true set in INSTALL_ARGS.
+  public static readonly VERSION: string = METALLB_CHART_VERSION;
 
   public static async installMetalLoadBalancer(testName: string): Promise<void> {
     try {

--- a/version.ts
+++ b/version.ts
@@ -26,6 +26,7 @@ export const HEDERA_JSON_RPC_RELAY_VERSION: string = constants.getEnvironmentVar
 export const INGRESS_CONTROLLER_VERSION: string =
   constants.getEnvironmentVariable('INGRESS_CONTROLLER_VERSION') || '0.14.5';
 export const BLOCK_NODE_VERSION: string = constants.getEnvironmentVariable('BLOCK_NODE_VERSION') || 'v0.28.1';
+export const METALLB_CHART_VERSION: string = constants.getEnvironmentVariable('METALLB_CHART_VERSION') || '0.15.3';
 export const NETWORK_LOAD_GENERATOR_CHART_VERSION: string =
   constants.getEnvironmentVariable('NETWORK_LOAD_GENERATOR_CHART_VERSION') || '0.8.0';
 


### PR DESCRIPTION
Stacked on #5638 — base is `fix/pin-indirect-dependencies-0.64`, so this diff shows only the CI fixes. Merge #5638 first, or retarget this to `release/0.64` if #5638 is dropped.

Fixes the two failure causes diagnosed on #5638. Neither is related to dependency pinning; both are pre-existing on `release/0.64`.

## 1. metallb chart was installed unpinned

Every job that installs metallb has been failing with:

```
execution error at (metallb/templates/speaker.yaml:3:4):
speaker.frr.enabled and frrk8s.enabled / external are mutually exclusive!
```

metallb published chart **0.16.0**, which made frrk8s the default BGP backend (`frrk8s.enabled: true`). The chart then refuses to render when `speaker.frr.enabled=true` is also set, which the tests do. 0.15.3 defaults `frrk8s.enabled: false` and is unaffected.

Because nothing pinned the version, helm resolved the newest chart, so this broke on its own the moment 0.16.0 shipped — independent of any PR's contents. Four call sites were unpinned:

| site | before | after |
|---|---|---|
| `test/helpers/helm-metal-load-balancer.ts` | `VERSION = ''` (treated as "no `--version`") | `METALLB_CHART_VERSION` |
| `test/e2e/dual-cluster/setup-dual-e2e.sh` | no `--version` | `--version "${METALLB_CHART_VERSION}"` |
| `examples/multicluster-backup-restore/Taskfile.yml` (×2) | no `--version` | `--version 0.15.3` |

Adds `METALLB_CHART_VERSION` to `version.ts` (env-overridable, defaulting to `0.15.3`), matching what `main`, `release/0.82` and `release/0.84` already carry. The pin was simply never backported to this branch.

Jobs this unblocks: `performance-test`, `E2E Dual Cluster Full`, `E2E External database new` (all failed in `Setup E2E Tests`), plus `E2E One Shot Single - using Podman` and `E2E Node Upgrade` (failed in `Run E2E Tests` via the helper).

## 2. Migration test selected a newer release as its baseline

```
schemaVersion: 7 not found in remote-config-after.yaml
```

The workflow resolved the prior release from the npm `latest` dist-tag, which is the newest release across *all* lines. On `release/0.64` that is **0.85.0**, so the test launched a 0.85.0 network and migrated it *down* to 0.64.1, reading a config schema the older version does not understand. The same job passes on #5639 only because 0.85.0 → 0.84 happens not to be a downgrade.

Now derives the baseline from `package.json`: the newest published release on the same `major.minor` line strictly older than the version being built, falling back to the newest older release on any line when the line has no earlier publish. Both paths compare with `sort -V` against the current version, so a downgrade can never be selected, and the step fails loudly if no older release exists.

Verified against the live registry:

| branch version | before (`latest`) | after |
|---|---|---|
| 0.64.1 | 0.85.0 ✗ downgrade | **0.64.0** |
| 0.82.0 | 0.85.0 ✗ downgrade | **0.81.0** |
| 0.84.0 | 0.85.0 ✗ downgrade | **0.83.0** |
| 0.85.0 | 0.85.0 ✗ itself | **0.84.0** |

Edge cases: an unreleased patch (0.64.2) selects 0.64.1; a freshly cut line (0.99.0) falls back to 0.85.0; nothing older at all exits 1 with a message.

## Verification

- `task build --force` — exit 0, **0 errors** (2445 warnings, pre-existing)
- unit suite — **594 passing, exit 0**, unchanged from this branch's baseline
- `bash -n` on the modified shell script — clean
- baseline-selection logic exercised against the real npm registry for all cases in the table above

The metallb pin itself can only be proven by the E2E jobs, which need this branch to run.

## Also worth fixing on `main`

`main` pins metallb correctly, but carries the same `latest` dist-tag logic in its migration workflow (restructured, same root issue). It is green today only because `main` *is* the newest line — the bug surfaces on every maintenance branch.
