### PR TITLE
fix: select the migration test baseline from the current release line

### DIFF
--- a/.github/workflows/flow-migration-test.yaml
+++ b/.github/workflows/flow-migration-test.yaml
@@ -120,7 +120,12 @@ jobs:
             TO_CN_INPUT="${{ inputs.to-consensus-node-version }}"
 
             if [[ -z "${FROM_INPUT}" ]]; then
-              FROM_INPUT=$(curl -s https://registry.npmjs.org/@hashgraph/solo/latest | jq -r '.version')
+              FROM_INPUT=$(resolve_prior_release @hashgraph/solo "$(jq -r '.version' package.json)")
+            fi
+
+            if [[ -z "${FROM_INPUT}" ]]; then
+              echo "Failed to resolve from-solo-version input or a prior published release"
+              exit 1
             fi
 
             if [[ -z "${TO_CN_INPUT}" ]]; then

--- a/.github/workflows/script/helper.sh
+++ b/.github/workflows/script/helper.sh
@@ -200,3 +200,66 @@ extract_version() {
 
   printf '%s' "${value}"
 }
+
+# Resolve the published release a migration test should start from
+#
+# Prefers the newest release on the same major.minor line as CURRENT_VERSION,
+# falling back to the newest release on any line. Both candidates are required
+# to be strictly older than CURRENT_VERSION, so the result is never the version
+# under test nor a newer one. The npm "latest" dist-tag cannot be used for this:
+# it points at the newest release across every line, which on a maintenance
+# branch selects a newer release and makes the test migrate downwards into a
+# config schema the older code cannot read.
+#
+# Usage:
+#   resolve_prior_release <PACKAGE> <CURRENT_VERSION>
+#
+# Arguments:
+#   PACKAGE          npm package name to query (e.g., @hashgraph/solo)
+#   CURRENT_VERSION  version being built (e.g., 0.85.0)
+#
+# Examples:
+#   resolve_prior_release @hashgraph/solo "$(jq -r '.version' package.json)"
+resolve_prior_release() {
+  if [[ "$#" -ne 2 ]]; then
+    echo "Usage: resolve_prior_release <PACKAGE> <CURRENT_VERSION>" >&2
+    return 1
+  fi
+
+  local PACKAGE="$1"
+  local CURRENT_VERSION="$2"
+  local RELEASE_LINE="${CURRENT_VERSION%.*}"
+
+  local all_versions
+  all_versions="$(curl -s "https://registry.npmjs.org/${PACKAGE}" \
+    | jq -r '.versions // {} | keys[]' 2>/dev/null \
+    | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$')" || true
+
+  if [[ -z "${all_versions}" ]]; then
+    echo "Unable to list published versions for ${PACKAGE}" >&2
+    return 1
+  fi
+
+  # Appending CURRENT_VERSION and cutting the version-sorted list at its first
+  # occurrence leaves only strictly older releases, whether or not the current
+  # version is itself published yet.
+  local prior
+  prior="$(printf '%s\n%s\n' \
+    "$(printf '%s\n' "${all_versions}" | grep -E "^${RELEASE_LINE}\.")" \
+    "${CURRENT_VERSION}" \
+    | grep -v '^$' | sort -V \
+    | awk -v current="${CURRENT_VERSION}" '$0 == current { exit } { print }' | tail -n 1)"
+
+  if [[ -z "${prior}" ]]; then
+    prior="$(printf '%s\n%s\n' "${all_versions}" "${CURRENT_VERSION}" \
+      | grep -v '^$' | sort -V \
+      | awk -v current="${CURRENT_VERSION}" '$0 == current { exit } { print }' | tail -n 1)"
+  fi
+
+  if [[ -z "${prior}" ]]; then
+    echo "No published release of ${PACKAGE} older than ${CURRENT_VERSION} was found" >&2
+    return 1
+  fi
+
+  printf '%s' "${prior}"
+}


### PR DESCRIPTION
The migration test resolves its starting release from the npm `latest` dist-tag, which points at the newest release across *every* line rather than the newest release older than the one being built.

## On `main` this makes the test vacuous

`main` is at **0.85.0**, and 0.85.0 is the newest published release. So the workflow launches a 0.85.0 network and "migrates" it to 0.85.0 — exercising no migration at all, while reporting green.

The same expression is actively broken on a maintenance branch, where it selects a *newer* release and the run fails reading a config schema the older code cannot parse:

```
schemaVersion: 7 not found in remote-config-after.yaml
```

That is what surfaced on #5638 (`release/0.64`), where `latest` resolved to 0.85.0 and the test tried to migrate 0.85.0 → 0.64.1. This PR fixes the same root cause at its source on `main`; #5643 carries the equivalent fix for `release/0.64`, whose workflow predates the restructure here and cannot take this patch directly.

## The fix

Adds `resolve_prior_release` to `helper.sh`, following the documented-function convention already used by `extract_version`:

- prefers the newest release on the same `major.minor` line as the version in `package.json`
- falls back to the newest release on any line when that line has no earlier publish
- requires both candidates to be **strictly older** than the version under test, so neither the current version nor a newer one can ever be selected
- fails loudly, rather than silently picking something wrong, when no older release exists or the registry cannot be listed

Appending the current version to the version-sorted list and cutting at its first occurrence is what guarantees "strictly older" — and it works whether or not the current version is itself published yet.

The explicit `from-solo-version` workflow input is untouched and still wins when set.

## Verified against the live registry

| version being built | before (`latest`) | after |
|---|---|---|
| **0.85.0 (main today)** | 0.85.0 — migrates from itself | **0.84.0** |
| 0.84.0 | 0.85.0 ✗ newer | **0.83.0** |
| 0.82.0 | 0.85.0 ✗ newer | **0.81.0** |
| 0.64.1 | 0.85.0 ✗ newer | **0.64.0** |

Edge cases: an unreleased patch (0.64.2) resolves 0.64.1; a freshly cut line with nothing published (0.99.0) falls back to 0.85.0; nothing older at all (0.0.1) exits 1 with `No published release of @hashgraph/solo older than 0.0.1 was found`; an unlistable package exits 1 with `Unable to list published versions for ...`.

`bash -n` is clean on the modified helper.

## Related, deliberately not changed

`main` publishes as `@hiero-ledger/solo`, but this workflow queries `@hashgraph/solo`. Both currently publish the same latest (0.85.0), and `@hashgraph/solo` carries the fuller history (91 versions vs 30), so it is the better source for older baselines today. Worth a deliberate decision separately rather than a drive-by change here — if `@hashgraph/solo` ever stops being published in step, this workflow would quietly pin to a stale baseline.
