### PR TITLE
fix: select the migration test baseline from this release line

### DIFF
--- a/.github/workflows/flow-migration-test.yaml
+++ b/.github/workflows/flow-migration-test.yaml
@@ -120,7 +120,12 @@ jobs:
             TO_CN_INPUT="${{ inputs.to-consensus-node-version }}"
 
             if [[ -z "${FROM_INPUT}" ]]; then
-              FROM_INPUT=$(curl -s https://registry.npmjs.org/@hashgraph/solo/latest | jq -r '.version')
+              FROM_INPUT=$(resolve_prior_release @hashgraph/solo "$(jq -r '.version' package.json)")
+            fi
+
+            if [[ -z "${FROM_INPUT}" ]]; then
+              echo "Failed to resolve from-solo-version input or a prior published release"
+              exit 1
             fi
 
             if [[ -z "${TO_CN_INPUT}" ]]; then

--- a/.github/workflows/script/helper.sh
+++ b/.github/workflows/script/helper.sh
@@ -200,3 +200,66 @@ extract_version() {
 
   printf '%s' "${value}"
 }
+
+# Resolve the published release a migration test should start from
+#
+# Prefers the newest release on the same major.minor line as CURRENT_VERSION,
+# falling back to the newest release on any line. Both candidates are required
+# to be strictly older than CURRENT_VERSION, so the result is never the version
+# under test nor a newer one. The npm "latest" dist-tag cannot be used for this:
+# it points at the newest release across every line, which on a maintenance
+# branch selects a newer release and makes the test migrate downwards into a
+# config schema the older code cannot read.
+#
+# Usage:
+#   resolve_prior_release <PACKAGE> <CURRENT_VERSION>
+#
+# Arguments:
+#   PACKAGE          npm package name to query (e.g., @hashgraph/solo)
+#   CURRENT_VERSION  version being built (e.g., 0.85.0)
+#
+# Examples:
+#   resolve_prior_release @hashgraph/solo "$(jq -r '.version' package.json)"
+resolve_prior_release() {
+  if [[ "$#" -ne 2 ]]; then
+    echo "Usage: resolve_prior_release <PACKAGE> <CURRENT_VERSION>" >&2
+    return 1
+  fi
+
+  local PACKAGE="$1"
+  local CURRENT_VERSION="$2"
+  local RELEASE_LINE="${CURRENT_VERSION%.*}"
+
+  local all_versions
+  all_versions="$(curl -s "https://registry.npmjs.org/${PACKAGE}" \
+    | jq -r '.versions // {} | keys[]' 2>/dev/null \
+    | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$')" || true
+
+  if [[ -z "${all_versions}" ]]; then
+    echo "Unable to list published versions for ${PACKAGE}" >&2
+    return 1
+  fi
+
+  # Appending CURRENT_VERSION and cutting the version-sorted list at its first
+  # occurrence leaves only strictly older releases, whether or not the current
+  # version is itself published yet.
+  local prior
+  prior="$(printf '%s\n%s\n' \
+    "$(printf '%s\n' "${all_versions}" | grep -E "^${RELEASE_LINE}\.")" \
+    "${CURRENT_VERSION}" \
+    | grep -v '^$' | sort -V \
+    | awk -v current="${CURRENT_VERSION}" '$0 == current { exit } { print }' | tail -n 1)"
+
+  if [[ -z "${prior}" ]]; then
+    prior="$(printf '%s\n%s\n' "${all_versions}" "${CURRENT_VERSION}" \
+      | grep -v '^$' | sort -V \
+      | awk -v current="${CURRENT_VERSION}" '$0 == current { exit } { print }' | tail -n 1)"
+  fi
+
+  if [[ -z "${prior}" ]]; then
+    echo "No published release of ${PACKAGE} older than ${CURRENT_VERSION} was found" >&2
+    return 1
+  fi
+
+  printf '%s' "${prior}"
+}


### PR DESCRIPTION
Stacked on #5650 — base is `fix/pin-indirect-dependencies-0.79`, so this diff shows only the migration fix. Merge #5650 first, or retarget to `release/0.79` if it is dropped.

The migration test resolves its starting release from the npm `latest` dist-tag, which points at the newest release across *every* line rather than the newest release older than the one being built. On `release/0.79` that selects **0.85.0**, so the run launches a 0.85.0 network and migrates it *down* to **0.79.0**, failing because the older code cannot read a config schema written by the newer version.

## The fix

Adds `resolve_prior_release` to `helper.sh`, following the documented-function convention `extract_version` already uses:

- prefers the newest release on the same `major.minor` line as the version in `package.json`
- falls back to the newest release on any line when that line has no earlier publish
- requires both candidates to be **strictly older** than the version under test, so neither the current version nor a newer one can ever be selected
- fails loudly when no older release exists or the registry cannot be listed

The explicit `from-solo-version` input is untouched and still wins when set.

Cherry-picked from #5645, which fixes the same defect at source on `main`. This branch carries `main`'s restructured workflow, so the patch applied cleanly.

## Verified against the live registry

| version being built | before (`latest`) | after |
|---|---|---|
| **0.79.0 (this branch)** | 0.85.0 ✗ downgrade | **0.78.0** |
| 0.82.0 | 0.85.0 ✗ | 0.81.0 |
| 0.84.0 | 0.85.0 ✗ | 0.83.0 |
| 0.85.0 (main) | 0.85.0 — itself | 0.84.0 |

Edge cases: an unreleased patch resolves the prior patch; a freshly cut line with nothing published falls back to the newest older release; nothing older at all exits 1 with a message; an unlistable package exits 1 with a message. `bash -n` clean on the modified helper.

## metallb

Not affected on this branch — `METALLB_CHART_VERSION` in `version.ts`, the test helper, `setup-dual-e2e.sh`, and both installs in the examples Taskfile are already pinned to 0.15.3. Only `release/0.64` was missing that pin (fixed in #5643).
