### PR TITLE
fix: pin metallb chart and select migration baseline from this release line

### DIFF
--- a/.github/workflows/flow-migration-test.yaml
+++ b/.github/workflows/flow-migration-test.yaml
@@ -93,9 +93,42 @@ jobs:
           max_attempts: 3
           timeout_minutes: 5
           command: |
-            LATEST_VERSION=$(curl -s https://registry.npmjs.org/@hashgraph/solo/latest | jq -r '.version')
-            echo "Latest Version: ${LATEST_VERSION}"
-            echo "version=${LATEST_VERSION}" >> $GITHUB_OUTPUT
+            # The prior release has to come from this branch's own release line. The "latest"
+            # dist-tag points at whatever is newest across all lines, so on a maintenance branch
+            # it selects a newer release and the test migrates *down* into an older config
+            # schema, which is unsupported and fails with "schemaVersion: N not found".
+            CURRENT_VERSION=$(jq -r '.version' package.json)
+            RELEASE_LINE="${CURRENT_VERSION%.*}"
+
+            ALL_VERSIONS=$(curl -s https://registry.npmjs.org/@hashgraph/solo \
+              | jq -r '.versions | keys[]' \
+              | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$')
+
+            # Newest release on this line that is strictly older than the version being built.
+            # Appending CURRENT_VERSION and cutting the sorted list at its first occurrence
+            # leaves only genuinely older releases, whether or not it is itself published.
+            PRIOR_VERSION=$(printf '%s\n%s\n' \
+              "$(printf '%s\n' "${ALL_VERSIONS}" | grep -E "^${RELEASE_LINE}\.")" \
+              "${CURRENT_VERSION}" \
+              | grep -v '^$' | sort -V \
+              | awk -v current="${CURRENT_VERSION}" '$0 == current { exit } { print }' | tail -n 1)
+
+            # A line with no earlier publish (a freshly cut branch) falls back to the newest
+            # older release on any line, which is still never a downgrade.
+            if [[ -z "${PRIOR_VERSION}" ]]; then
+              PRIOR_VERSION=$(printf '%s\n%s\n' "${ALL_VERSIONS}" "${CURRENT_VERSION}" \
+                | grep -v '^$' | sort -V \
+                | awk -v current="${CURRENT_VERSION}" '$0 == current { exit } { print }' | tail -n 1)
+            fi
+
+            if [[ -z "${PRIOR_VERSION}" ]]; then
+              echo "No published release older than ${CURRENT_VERSION} was found" >&2
+              exit 1
+            fi
+
+            echo "Current Version: ${CURRENT_VERSION}"
+            echo "Prior Version: ${PRIOR_VERSION}"
+            echo "version=${PRIOR_VERSION}" >> $GITHUB_OUTPUT
 
       - name: Launch Network with Prior Release ${{ steps.get-version.outputs.version }}
         timeout-minutes: 60

--- a/examples/multicluster-backup-restore/Taskfile.yml
+++ b/examples/multicluster-backup-restore/Taskfile.yml
@@ -103,6 +103,7 @@ tasks:
           helm upgrade --install metallb metallb/metallb \
             --kube-context kind-solo-e2e-c1 \
             --namespace metallb-system --create-namespace --atomic --wait \
+            --version 0.15.3 \
             --set speaker.frr.enabled=true
       - cmd: kubectl apply -f metallb-cluster-1.yaml --context kind-solo-e2e-c1
 
@@ -116,6 +117,7 @@ tasks:
           helm upgrade --install metallb metallb/metallb \
             --kube-context kind-solo-e2e-c2 \
             --namespace metallb-system --create-namespace --atomic --wait \
+            --version 0.15.3 \
             --set speaker.frr.enabled=true
       - cmd: kubectl apply -f metallb-cluster-2.yaml --context kind-solo-e2e-c2
 

--- a/test/e2e/dual-cluster/setup-dual-e2e.sh
+++ b/test/e2e/dual-cluster/setup-dual-e2e.sh
@@ -13,6 +13,9 @@ readonly SCRIPT_PATH
 readonly KIND_CONFIG_RENDERER="${SCRIPT_PATH}/../../../.github/workflows/script/render_kind_config.sh"
 
 readonly CLUSTER_DIAGNOSTICS_PATH="${SCRIPT_PATH}/diagnostics/cluster"
+# Pinned rather than tracking latest: metallb 0.16.0 turned frrk8s on by default, which the
+# chart rejects as mutually exclusive with the speaker.frr.enabled=true set below.
+readonly METALLB_CHART_VERSION="0.15.3"
 readonly KIND_IMAGE="kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30"
 
 echo "SOLO_CHARTS_DIR: ${SOLO_CHARTS_DIR}"
@@ -81,6 +84,7 @@ for i in $(seq 1 "${SOLO_CLUSTER_DUALITY}"); do
   if [[ "${SOLO_CLUSTER_DUALITY}" -gt 1 ]]; then
     helm upgrade --install metallb metallb/metallb \
       --namespace metallb-system --create-namespace --atomic --wait \
+      --version "${METALLB_CHART_VERSION}" \
       --set speaker.frr.enabled=true
 
     kubectl apply -f "${SCRIPT_PATH}/metallb-cluster-${i}.yaml"

--- a/test/helpers/helm-metal-load-balancer.ts
+++ b/test/helpers/helm-metal-load-balancer.ts
@@ -5,6 +5,7 @@ import {NamespaceName} from '../../src/types/namespace/namespace-name.js';
 import {type K8ClientFactory} from '../../src/integration/kube/k8-client/k8-client-factory.js';
 import {InjectTokens} from '../../src/core/dependency-injection/inject-tokens.js';
 import {type ChartManager} from '../../src/core/chart-manager.js';
+import {METALLB_CHART_VERSION} from '../../version.js';
 
 export class HelmMetalLoadBalancer {
   public static readonly NAMESPACE: NamespaceName = NamespaceName.of('metallb-system');
@@ -13,7 +14,9 @@ export class HelmMetalLoadBalancer {
   public static readonly REPOSITORY_NAME: string = 'metallb';
   public static readonly REPOSITORY_URL: string = 'https://metallb.github.io/metallb/';
   public static readonly INSTALL_ARGS: string = '--set speaker.frr.enabled=true';
-  public static readonly VERSION: string = ''; // latest version
+  // Pinned rather than tracking latest: metallb 0.16.0 turned frrk8s on by default, which the
+  // chart rejects as mutually exclusive with the speaker.frr.enabled=true set in INSTALL_ARGS.
+  public static readonly VERSION: string = METALLB_CHART_VERSION;
 
   public static async installMetalLoadBalancer(testName: string): Promise<void> {
     try {

--- a/version.ts
+++ b/version.ts
@@ -26,6 +26,7 @@ export const HEDERA_JSON_RPC_RELAY_VERSION: string = constants.getEnvironmentVar
 export const INGRESS_CONTROLLER_VERSION: string =
   constants.getEnvironmentVariable('INGRESS_CONTROLLER_VERSION') || '0.14.5';
 export const BLOCK_NODE_VERSION: string = constants.getEnvironmentVariable('BLOCK_NODE_VERSION') || 'v0.28.1';
+export const METALLB_CHART_VERSION: string = constants.getEnvironmentVariable('METALLB_CHART_VERSION') || '0.15.3';
 export const NETWORK_LOAD_GENERATOR_CHART_VERSION: string =
   constants.getEnvironmentVariable('NETWORK_LOAD_GENERATOR_CHART_VERSION') || '0.8.0';
 


### PR DESCRIPTION
Stacked on #5653 — base is `fix/pin-indirect-dependencies-0.65`, so this diff shows only the CI fixes. Merge #5653 first, or retarget to `release/0.65` if it is dropped.

`release/0.65` needs **both** fixes. Unlike the newer release branches, it never received the metallb pin, and its migration workflow predates the restructure on `main`.

## 1. metallb chart was installed unpinned

```
execution error at (metallb/templates/speaker.yaml:3:4):
speaker.frr.enabled and frrk8s.enabled / external are mutually exclusive!
```

metallb published chart **0.16.0**, which made frrk8s the default BGP backend (`frrk8s.enabled: true`). The chart then refuses to render when `speaker.frr.enabled=true` is also set, which the tests do. 0.15.3 defaults it to `false` and is unaffected.

Nothing pinned the version, so helm resolved the newest chart — meaning this breaks on its own once 0.16.0 is published, independent of any PR's contents. Four call sites were unpinned:

| site | before | after |
|---|---|---|
| `test/helpers/helm-metal-load-balancer.ts` | `VERSION = ''` (treated as "no `--version`") | `METALLB_CHART_VERSION` |
| `test/e2e/dual-cluster/setup-dual-e2e.sh` | no `--version` | `--version "${METALLB_CHART_VERSION}"` |
| `examples/multicluster-backup-restore/Taskfile.yml` (×2) | no `--version` | `--version 0.15.3` |

Adds `METALLB_CHART_VERSION` to `version.ts` (env-overridable, default `0.15.3`), matching `main` and the newer release branches. Cherry-picked from #5643, which fixes the same gap on `release/0.64` — the only other branch missing it.

## 2. Migration test selected a newer release as its baseline

The workflow resolved the prior release from the npm `latest` dist-tag, which is the newest release across *all* lines. On `release/0.65` that is **0.85.0**, so the test launches a 0.85.0 network and migrates it *down* to 0.65.0, reading a config schema the older code cannot parse.

Now derives the baseline from `package.json`: the newest published release on the same `major.minor` line strictly older than the version being built, falling back to the newest older release on any line. Both paths compare with `sort -V`, so a downgrade can never be selected, and the step fails loudly if no older release exists.

**This branch exercises the fallback path.** 0.65.0 is the only release published on the 0.65 line, so there is nothing strictly older on it, and the baseline resolves to **0.64.1** — a genuine prior release and a real migration.

| version being built | before (`latest`) | after |
|---|---|---|
| **0.65.0 (this branch)** | 0.85.0 ✗ downgrade | **0.64.1** (via fallback) |
| 0.64.1 | 0.85.0 ✗ | 0.64.0 |
| 0.79.0 | 0.85.0 ✗ | 0.78.0 |
| 0.85.0 (main) | 0.85.0 — itself | 0.84.0 |

This branch carries the older workflow form (no `from-solo-version` input, no `helper.sh` function), so it takes #5643's inline variant rather than the `resolve_prior_release` helper used on `main` and the newer branches. Same logic, same guarantees.

## Verification

- `task build --force` — exit 0, **0 errors** (2409 warnings, pre-existing)
- unit suite — **594 passing, exit 0**
- `bash -n` on the modified shell script — clean
- baseline selection exercised against the live registry, including the fallback path this branch depends on

The metallb pin itself can only be proven by the E2E jobs, which need this branch to run.
