### PR TITLE
fix: compute the release version on maintenance branches

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -91,28 +91,35 @@ jobs:
           GIT_COMMITTER_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
         run: |
           PROCEED="true"
-          if [[ "${{ github.event.repository.default_branch }}" == "${{ github.ref_name }}" ]]; then
-            if SEMREL_OUTPUT=$(npx semantic-release --dry-run 2>&1); then
-              if echo "${SEMREL_OUTPUT}" | grep -q "The next release version is"; then
-                echo "::notice file=flow-deploy-release-artifact.yaml::Semantic Release detected a new version"
-              else
-                echo "::notice file=flow-deploy-release-artifact.yaml::Semantic Release detected NO new version"
-                PROCEED="false"
-              fi
+          # Ask Semantic Release for the version on every branch. Which branches are
+          # releasable is already decided by the "branches" config in .releaserc, which
+          # covers main, the release/N.N maintenance lines and the prerelease lines; a
+          # branch it does not recognise simply reports no release below. Gating this on
+          # the default branch meant a maintenance branch never computed its next version
+          # and instead reported the version already sitting in package.json, which is by
+          # construction the version of the *previous* release.
+          if SEMREL_OUTPUT=$(npx semantic-release --dry-run 2>&1); then
+            if echo "${SEMREL_OUTPUT}" | grep -q "The next release version is"; then
+              echo "::notice file=flow-deploy-release-artifact.yaml::Semantic Release detected a new version"
             else
-              echo "::notice file=flow-deploy-release-artifact.yaml::Semantic Release did NOT run successfully"
+              echo "::notice file=flow-deploy-release-artifact.yaml::Semantic Release detected NO new version"
               PROCEED="false"
             fi
-            echo "::group::SemVer output"
-            echo "${SEMREL_OUTPUT}"
-            echo "::endgroup::"
           else
-            if [[ "${{ inputs.dry-run-enabled }}" == "true" ]]; then
-              jq -r '.version' './package.json' > VERSION
-              PROCEED="true"
-            else
-              PROCEED="false"
-            fi
+            echo "::notice file=flow-deploy-release-artifact.yaml::Semantic Release did NOT run successfully"
+            PROCEED="false"
+          fi
+          echo "::group::SemVer output"
+          echo "${SEMREL_OUTPUT}"
+          echo "::endgroup::"
+
+          # A dry run that finds nothing to release never invokes verifyReleaseCmd, so no
+          # VERSION file is written. Fall back to package.json so the dry run still reports
+          # a version rather than failing the job.
+          if [[ "${PROCEED}" == "false" ]] && [[ "${{ inputs.dry-run-enabled }}" == "true" ]]; then
+            echo "::notice file=flow-deploy-release-artifact.yaml::Dry run with no releasable change, reporting the current package.json version"
+            jq -r '.version' './package.json' > VERSION
+            PROCEED="true"
           fi
 
           echo "need-release=${PROCEED}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -81,7 +81,7 @@ jobs:
           npm install -g conventional-changelog-conventionalcommits@9.1.0 @commitlint/cli@18.6.0 @commitlint/config-conventional@18.6.0
           npm install -g marked-mangle@1.1.6 marked-gfm-heading-id@3.1.2 semantic-release-conventional-commits@3.0.0
 
-      - name: Calculate Next Version (default branch)
+      - name: Calculate Next Version
         id: calculate-version
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
The prepare job reports the version that has already shipped rather than the one about to ship. Run [30970172459](https://github.com/hiero-ledger/solo/actions/runs/30970172459) shows both halves of the contradiction in a single run:

```
VERSION=0.64.1                        ← prepare job output
The next release version is 0.64.2    ← release job, same run, same branch
Published release 0.64.2
```

## Root cause

`flow-deploy-release-artifact.yaml:94` asked Semantic Release for the version only when the current ref was the repository's default branch:

```bash
if [[ "${{ github.event.repository.default_branch }}" == "${{ github.ref_name }}" ]]; then
    npx semantic-release --dry-run          # computes the NEXT version
else
    jq -r '.version' './package.json' > VERSION   # ← taken on a release branch
fi
```

On `release/0.64` that renders as `"main" == "release/0.64"`, so the else branch runs. `package.json` holds whatever the previous release wrote there via the `prepareCmd` in `.releaserc` (`npm version ${nextRelease.version}`), committed as `chore(release): 0.64.1 [skip ci]`. Reading it back therefore returns the **last released** version by construction — it can never be the next one.

For the record, 0.64.2 is correct: `12fd501a fix: pin indirect dependencies (#5638)` is the only commit since `v0.64.1`, and `fix:` maps to a patch bump under the `conventionalcommits` preset.

## The gate was unnecessary

`.releaserc` already declares which branches are releasable, including the maintenance lines:

```json
{ "name": "release/([0-9]+).([0-9]+)", "channel": "…x", "range": "…x" }
```

Semantic Release is fully capable of computing 0.64.2 on this branch — the release job in that same run proves it does. Only the prepare job declined to ask.

## The fix

Runs the dry run unconditionally and lets `.releaserc` decide releasability; a branch it does not recognise simply reports no release. The `package.json` read is kept only as a fallback for a **dry run that finds nothing to release**, since `verifyReleaseCmd` never fires in that case and no `VERSION` file is written.

Behaviour in each path:

| branch / situation | before | after |
|---|---|---|
| `main`, releasable change | 0.64.2-equivalent ✓ | unchanged ✓ |
| **`release/0.64`, releasable change** | **0.64.1 ✗ (already shipped)** | **0.64.2 ✓** |
| `release/0.64`, dry run, nothing to release | current version | current version (explicit notice) |
| `release/0.64`, real run, nothing to release | halts | halts |

## Impact this removes

`prepare-release.outputs.version` feeds the artifact names (`hashgraph-solo-${VERSION}.tgz`, line 319) and downstream tags. A real release from this branch would have tagged and published **0.64.2** via Semantic Release while naming its artifacts **0.64.1**. The observed run had `dry-run-enabled: true`, so nothing was actually mispublished.

There was also a second latent problem in the same else branch: with dry run **off** it set `PROCEED="false"`, making `need-release`/`need-hg-release` false and skipping the release path entirely. So a maintenance branch had no correct path at all — wrong version on a dry run, or a halt on a real one. Both are resolved by asking Semantic Release directly.

## Verification

The rendered script passes `bash -n`, and all three branches of the new logic were simulated: releasable change → `need-release=true` with `VERSION` from Semantic Release; no change on a dry run → falls back with an explicit notice; no change on a real run → `need-release=false` and the release correctly halts.

## Applies beyond this branch

`main` carries the identical gate. It is invisible there because the comparison is true on `main`, but every other maintenance branch (`release/0.65`, `0.79`, `0.82`, `0.84`) has the same defect. Happy to open the equivalent PRs once the approach is agreed here.
