### PR TITLE
fix: compute the release version on maintenance branches

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -81,7 +81,7 @@ jobs:
           npm install -g conventional-changelog-conventionalcommits@9.1.0 @commitlint/cli@18.6.0 @commitlint/config-conventional@18.6.0
           npm install -g marked-mangle@1.1.6 marked-gfm-heading-id@3.1.2 semantic-release-conventional-commits@3.0.0
 
-      - name: Calculate Next Version (default branch)
+      - name: Calculate Next Version
         id: calculate-version
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
@@ -91,28 +91,35 @@ jobs:
           GIT_COMMITTER_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
         run: |
           PROCEED="true"
-          if [[ "${{ github.event.repository.default_branch }}" == "${{ github.ref_name }}" ]]; then
-            if SEMREL_OUTPUT=$(npx semantic-release --dry-run 2>&1); then
-              if echo "${SEMREL_OUTPUT}" | grep -q "The next release version is"; then
-                echo "::notice file=flow-deploy-release-artifact.yaml::Semantic Release detected a new version"
-              else
-                echo "::notice file=flow-deploy-release-artifact.yaml::Semantic Release detected NO new version"
-                PROCEED="false"
-              fi
+          # Ask Semantic Release for the version on every branch. Which branches are
+          # releasable is already decided by the "branches" config in .releaserc, which
+          # covers main, the release/N.N maintenance lines and the prerelease lines; a
+          # branch it does not recognise simply reports no release below. Gating this on
+          # the default branch meant a maintenance branch never computed its next version
+          # and instead reported the version already sitting in package.json, which is by
+          # construction the version of the *previous* release.
+          if SEMREL_OUTPUT=$(npx semantic-release --dry-run 2>&1); then
+            if echo "${SEMREL_OUTPUT}" | grep -q "The next release version is"; then
+              echo "::notice file=flow-deploy-release-artifact.yaml::Semantic Release detected a new version"
             else
-              echo "::notice file=flow-deploy-release-artifact.yaml::Semantic Release did NOT run successfully"
+              echo "::notice file=flow-deploy-release-artifact.yaml::Semantic Release detected NO new version"
               PROCEED="false"
             fi
-            echo "::group::SemVer output"
-            echo "${SEMREL_OUTPUT}"
-            echo "::endgroup::"
           else
-            if [[ "${{ inputs.dry-run-enabled }}" == "true" ]]; then
-              jq -r '.version' './package.json' > VERSION
-              PROCEED="true"
-            else
-              PROCEED="false"
-            fi
+            echo "::notice file=flow-deploy-release-artifact.yaml::Semantic Release did NOT run successfully"
+            PROCEED="false"
+          fi
+          echo "::group::SemVer output"
+          echo "${SEMREL_OUTPUT}"
+          echo "::endgroup::"
+
+          # A dry run that finds nothing to release never invokes verifyReleaseCmd, so no
+          # VERSION file is written. Fall back to package.json so the dry run still reports
+          # a version rather than failing the job.
+          if [[ "${PROCEED}" == "false" ]] && [[ "${{ inputs.dry-run-enabled }}" == "true" ]]; then
+            echo "::notice file=flow-deploy-release-artifact.yaml::Dry run with no releasable change, reporting the current package.json version"
+            jq -r '.version' './package.json' > VERSION
+            PROCEED="true"
           fi
 
           echo "need-release=${PROCEED}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
Applies the fix from #5658 to `release/0.79`. Same defect, same patch — the gate is byte-identical on every branch.

## The defect

The prepare job asked Semantic Release for the next version only when the current ref was the repository's default branch:

```bash
if [[ "${{ github.event.repository.default_branch }}" == "${{ github.ref_name }}" ]]; then
    npx semantic-release --dry-run          # computes the NEXT version
else
    jq -r '.version' './package.json' > VERSION   # emits the version already shipped
fi
```

Any branch that is not the default falls through to reading `package.json`, which holds whatever the previous release wrote there via the `prepareCmd` in `.releaserc` (`npm version ${nextRelease.version}`). That is the **last released** version by construction, so it can never be the next one.

On `release/0.79` the comparison is `"main" == "release/0.79"` → false, so this branch is affected.

## Evidence

Run [30970172459](https://github.com/hiero-ledger/solo/actions/runs/30970172459) on `release/0.64` shows both halves of the contradiction in a single run:

```
VERSION=0.64.1                        ← prepare job
The next release version is 0.64.2    ← release job, same run, same branch
Published release 0.64.2
```

`prepare-release.outputs.version` feeds the artifact names (`hashgraph-solo-${VERSION}.tgz`) and downstream tags, so a real release would tag one version while naming its artifacts another.

## The gate was unnecessary

`.releaserc` already declares which branches are releasable, including the maintenance lines:

```json
{ "name": "release/([0-9]+).([0-9]+)", "channel": "…x", "range": "…x" }
```

So Semantic Release can be asked on any branch; one it does not recognise simply reports no release.

## The fix

Runs the dry run unconditionally and keeps the `package.json` read only as a fallback for a **dry run that finds nothing to release** — `verifyReleaseCmd` never fires in that case, so no `VERSION` file is written. A real run with no releasable change still stops, as before. The step name drops its now-inaccurate `(default branch)` qualifier.

| situation | before | after |
|---|---|---|
| default branch, releasable change | correct | unchanged |
| maintenance branch, releasable change | **version already shipped** | **next version** |
| dry run, nothing to release | current version | current version, with an explicit notice |
| real run, nothing to release | halts | halts |

## Second latent bug this removes

In the same else branch, when dry run was **off** it set `PROCEED="false"`, making `need-release` false and skipping the release path entirely. A non-default branch therefore had no correct path at all — wrong version on a dry run, or a halt on a real one.

## Verification

Rendered script passes `bash -n`, and all three branches of the new logic were simulated: releasable change → `need-release=true` with `VERSION` from Semantic Release; nothing to release on a dry run → falls back with a notice; nothing to release on a real run → `need-release=false` and the release halts.
