### PR TITLE
ci: publish maintenance releases to their own npm dist-tag

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -556,6 +556,27 @@ jobs:
       - name: Install NPM latest
         run: npm install -g npm@11.7.0
 
+      - name: Resolve NPM Dist Tag
+        id: dist-tag
+        run: |
+          # A maintenance release is older than whatever "latest" already points at, and
+          # npm refuses to move "latest" backwards:
+          #
+          #   npm error Cannot implicitly apply the "latest" tag because previously
+          #   published version 0.85.0 is higher than the new version 0.64.2.
+          #
+          # Publish those to the channel tag for their line instead, matching the
+          # release-<major>.<minor>.x tags already on the registry for earlier lines.
+          # The default branch keeps "latest".
+          if [[ "${{ github.ref_name }}" =~ ^release/([0-9]+)\.([0-9]+)$ ]]; then
+            NPM_DIST_TAG="release-${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.x"
+          else
+            NPM_DIST_TAG="latest"
+          fi
+
+          echo "Publishing from '${{ github.ref_name }}' to dist-tag '${NPM_DIST_TAG}'"
+          echo "npm-dist-tag=${NPM_DIST_TAG}" >> "${GITHUB_OUTPUT}"
+
       - name: Download Hashgraph NPM Package Artifact
         if: ${{ needs.create-github-release.outputs.need-hg-publish == 'true' && inputs.dry-run-enabled != true }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -580,7 +601,7 @@ jobs:
         if: ${{ inputs.dry-run-enabled == true || needs.create-github-release.outputs.need-hg-publish == 'true' }}
         run: |
           echo "::group::Set Publish Args"
-            FLAGS="--access=public"
+            FLAGS="--access=public --tag ${{ steps.dist-tag.outputs.npm-dist-tag }}"
             echo "flags=${FLAGS}"
           echo "::endgroup::"
 
@@ -602,7 +623,7 @@ jobs:
         if: ${{ inputs.dual-publish-enabled == true && (needs.create-github-release.outputs.need-hl-publish == 'true' || inputs.dry-run-enabled == true) }}
         run: |
           echo "::group::Set Publish Args"
-            FLAGS="--access=public"
+            FLAGS="--access=public --tag ${{ steps.dist-tag.outputs.npm-dist-tag }}"
             echo "flags=${FLAGS}"
           echo "::endgroup::"
 


### PR DESCRIPTION
Fixes the `Publish Release Packages` failure in [run 30972697194](https://github.com/hiero-ledger/solo/actions/runs/30972697194/job/92201446908).

## The failure

```
npm error Cannot implicitly apply the "latest" tag because previously published
version 0.85.0 is higher than the new version 0.64.2. You must specify a tag using --tag.
```

Both publish steps ran `npm publish ${TARBALL} --access=public` with no `--tag`, so npm fell back to `latest` implicitly. That is correct on the default branch, where every release is the newest — but never correct on a maintenance branch, whose releases are by definition older than the current `latest`. npm has a guard against silently moving `latest` backwards, and it fired.

Worth noting the rest of the release worked: the version resolved correctly to **0.64.2** (via #5658 — before that fix this run would have tried to publish 0.64.1), the tag `v0.64.2`, the GitHub release, and the `chore(release): 0.64.2` commit all landed. Only the npm publish failed.

## The fix

A new `Resolve NPM Dist Tag` step derives the tag from the branch and both publish steps pass it:

| branch | dist-tag |
|---|---|
| `release/0.64` | `release-0.64.x` |
| `release/0.84` | `release-0.84.x` |
| `main` | `latest` |
| anything else | `latest` |

The `release-<major>.<minor>.x` format is **not invented here** — it matches the tags already on the registry from earlier maintenance lines:

```
release-0.24.x -> 0.24.1     release-0.35.x -> 0.35.2
release-0.31.x -> 0.31.4     release-0.43.x -> 0.43.2
release-0.33.x -> 0.33.1
```

It is also what the manual recovery for this very run used: `@hashgraph/solo` now has `release-0.64.x -> 0.64.2` with `latest` still at 0.85.0. This change simply automates what was done by hand.

The branch pattern is anchored (`^release/([0-9]+)\.([0-9]+)$`) so only a well-formed maintenance branch matches and anything else falls through to `latest`.

## Verification

- Workflow still parses as YAML; both publish steps carry `--tag`
- Tag resolution simulated across `release/0.64`, `release/0.65`, `release/0.84`, `release/0.9`, `main`, `feature/foo` and a malformed `release/0.64.1` — all produce the expected value

## Two follow-ups this surfaced

**1. `@hiero-ledger/solo@0.64.2` was never published.** The job died on the Hashgraph step, so the Hiero-Ledger publish never ran. `@hashgraph/solo@0.64.2` exists but `@hiero-ledger/solo` is still missing 0.64.2 entirely. That needs a manual publish (with `--tag release-0.64.x`) or a re-run once this lands.

**2. `latest` is never advanced for a newer maintenance line.** With this change a maintenance branch *always* publishes to its channel tag. That is right for older lines, but if a patch is ever cut on the newest line it will not become `latest`. Handling that needs a comparison against the current `latest` rather than a branch-name rule, which is deliberately out of scope here — flagging it rather than silently picking a policy.

Committed as `ci:` so a workflow-only change does not itself cut a patch release on this line.
