### PR TITLE
ci: publish maintenance releases to their own npm dist-tag

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -556,6 +556,27 @@ jobs:
       - name: Install NPM latest
         run: npm install -g npm@11.7.0
 
+      - name: Resolve NPM Dist Tag
+        id: dist-tag
+        run: |
+          # A maintenance release is older than whatever "latest" already points at, and
+          # npm refuses to move "latest" backwards:
+          #
+          #   npm error Cannot implicitly apply the "latest" tag because previously
+          #   published version 0.85.0 is higher than the new version 0.64.2.
+          #
+          # Publish those to the channel tag for their line instead, matching the
+          # release-<major>.<minor>.x tags already on the registry for earlier lines.
+          # The default branch keeps "latest".
+          if [[ "${{ github.ref_name }}" =~ ^release/([0-9]+)\.([0-9]+)$ ]]; then
+            NPM_DIST_TAG="release-${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.x"
+          else
+            NPM_DIST_TAG="latest"
+          fi
+
+          echo "Publishing from '${{ github.ref_name }}' to dist-tag '${NPM_DIST_TAG}'"
+          echo "npm-dist-tag=${NPM_DIST_TAG}" >> "${GITHUB_OUTPUT}"
+
       - name: Download Hashgraph NPM Package Artifact
         if: ${{ needs.create-github-release.outputs.need-hg-publish == 'true' && inputs.dry-run-enabled != true }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -580,7 +601,7 @@ jobs:
         if: ${{ inputs.dry-run-enabled == true || needs.create-github-release.outputs.need-hg-publish == 'true' }}
         run: |
           echo "::group::Set Publish Args"
-            FLAGS="--access=public"
+            FLAGS="--access=public --tag ${{ steps.dist-tag.outputs.npm-dist-tag }}"
             echo "flags=${FLAGS}"
           echo "::endgroup::"
 
@@ -602,7 +623,7 @@ jobs:
         if: ${{ inputs.dual-publish-enabled == true && (needs.create-github-release.outputs.need-hl-publish == 'true' || inputs.dry-run-enabled == true) }}
         run: |
           echo "::group::Set Publish Args"
-            FLAGS="--access=public"
+            FLAGS="--access=public --tag ${{ steps.dist-tag.outputs.npm-dist-tag }}"
             echo "flags=${FLAGS}"
           echo "::endgroup::"
 


### PR DESCRIPTION
Applies the fix from #5668 to `release/0.79`.

## The defect

Both npm publish steps ran `npm publish ${TARBALL} --access=public` with **no `--tag`**, so npm applied `latest` implicitly. On `release/0.64` that failed outright:

```
npm error Cannot implicitly apply the "latest" tag because previously published
version 0.85.0 is higher than the new version 0.64.2. You must specify a tag using --tag.
```

npm guards against silently moving `latest` backwards, and a maintenance release is by definition older than the current `latest`.

`release/0.79` is affected: its next publish would attempt to move `latest` backwards from 0.85.0 and fail the same way. Resolves to `release-0.79.x`.

## The fix

A `Resolve NPM Dist Tag` step derives the tag from the branch, and both publish steps consume it:

| branch | dist-tag |
|---|---|
| `release/0.64` | `release-0.64.x` |
| `release/0.84` | `release-0.84.x` |
| `main` | `latest` |
| anything else | `latest` |

The `release-<major>.<minor>.x` format is **not invented** — it matches tags already on the registry from earlier maintenance lines (`release-0.24.x`, `release-0.31.x`, `release-0.33.x`, `release-0.35.x`, `release-0.43.x`), and it is what the manual recovery for the failed 0.64.2 publish used (`@hashgraph/solo` now has `release-0.64.x -> 0.64.2` with `latest` still at 0.85.0).

The branch pattern is anchored (`^release/([0-9]+)\.([0-9]+)$`) so only a well-formed maintenance branch matches; anything else falls through to `latest`.

## Verification

- Workflow parses as YAML; the `dist-tag` step is present and **both** publish steps carry `--tag`
- The 23 added lines are byte-identical to those on every other branch in this set
- Tag resolution simulated across `release/0.64`, `release/0.65`, `release/0.84`, `release/0.9`, `main`, `feature/foo` and a malformed `release/0.64.1`

## Known limitation

A maintenance branch now *always* publishes to its channel tag. That is right for older lines, but a patch cut on the newest line will not become `latest`. Handling that needs a comparison against the current `latest` rather than a branch-name rule — deliberately out of scope, flagged rather than silently deciding a policy.

Committed as `ci:` so a workflow-only change does not itself cut a patch release.
