### PR TITLE
fix: pin metallb chart and select migration baseline from this release line

### DIFF
--- a/.github/workflows/flow-migration-test.yaml
+++ b/.github/workflows/flow-migration-test.yaml
@@ -100,9 +100,42 @@ jobs:
           max_attempts: 3
           timeout_minutes: 5
           command: |
-            LATEST_VERSION=$(curl -s https://registry.npmjs.org/@hashgraph/solo/latest | jq -r '.version')
-            echo "Latest Version: ${LATEST_VERSION}"
-            echo "version=${LATEST_VERSION}" >> $GITHUB_OUTPUT
+            # The prior release has to come from this branch's own release line. The "latest"
+            # dist-tag points at whatever is newest across all lines, so on a maintenance branch
+            # it selects a newer release and the test migrates *down* into an older config
+            # schema, which is unsupported and fails with "schemaVersion: N not found".
+            CURRENT_VERSION=$(jq -r '.version' package.json)
+            RELEASE_LINE="${CURRENT_VERSION%.*}"
+
+            ALL_VERSIONS=$(curl -s https://registry.npmjs.org/@hashgraph/solo \
+              | jq -r '.versions | keys[]' \
+              | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$')
+
+            # Newest release on this line that is strictly older than the version being built.
+            # Appending CURRENT_VERSION and cutting the sorted list at its first occurrence
+            # leaves only genuinely older releases, whether or not it is itself published.
+            PRIOR_VERSION=$(printf '%s\n%s\n' \
+              "$(printf '%s\n' "${ALL_VERSIONS}" | grep -E "^${RELEASE_LINE}\.")" \
+              "${CURRENT_VERSION}" \
+              | grep -v '^$' | sort -V \
+              | awk -v current="${CURRENT_VERSION}" '$0 == current { exit } { print }' | tail -n 1)
+
+            # A line with no earlier publish (a freshly cut branch) falls back to the newest
+            # older release on any line, which is still never a downgrade.
+            if [[ -z "${PRIOR_VERSION}" ]]; then
+              PRIOR_VERSION=$(printf '%s\n%s\n' "${ALL_VERSIONS}" "${CURRENT_VERSION}" \
+                | grep -v '^$' | sort -V \
+                | awk -v current="${CURRENT_VERSION}" '$0 == current { exit } { print }' | tail -n 1)
+            fi
+
+            if [[ -z "${PRIOR_VERSION}" ]]; then
+              echo "No published release older than ${CURRENT_VERSION} was found" >&2
+              exit 1
+            fi
+
+            echo "Current Version: ${CURRENT_VERSION}"
+            echo "Prior Version: ${PRIOR_VERSION}"
+            echo "version=${PRIOR_VERSION}" >> $GITHUB_OUTPUT
 
       - name: Launch Network with Prior Release ${{ steps.get-version.outputs.version }}
         timeout-minutes: 60

--- a/examples/multicluster-backup-restore/Taskfile.yml
+++ b/examples/multicluster-backup-restore/Taskfile.yml
@@ -103,6 +103,7 @@ tasks:
           helm upgrade --install metallb metallb/metallb \
             --kube-context kind-solo-e2e-c1 \
             --namespace metallb-system --create-namespace --atomic --wait \
+            --version 0.15.3 \
             --set speaker.frr.enabled=true
       - cmd: kubectl apply -f metallb-cluster-1.yaml --context kind-solo-e2e-c1
 
@@ -116,6 +117,7 @@ tasks:
           helm upgrade --install metallb metallb/metallb \
             --kube-context kind-solo-e2e-c2 \
             --namespace metallb-system --create-namespace --atomic --wait \
+            --version 0.15.3 \
             --set speaker.frr.enabled=true
       - cmd: kubectl apply -f metallb-cluster-2.yaml --context kind-solo-e2e-c2
 

--- a/test/e2e/dual-cluster/setup-dual-e2e.sh
+++ b/test/e2e/dual-cluster/setup-dual-e2e.sh
@@ -12,6 +12,9 @@ readonly SCRIPT_PATH
 readonly KIND_CONFIG_RENDERER="${SCRIPT_PATH}/../../../.github/workflows/script/render_kind_config.sh"
 
 readonly CLUSTER_DIAGNOSTICS_PATH="${SCRIPT_PATH}/diagnostics/cluster"
+# Pinned rather than tracking latest: metallb 0.16.0 turned frrk8s on by default, which the
+# chart rejects as mutually exclusive with the speaker.frr.enabled=true set below.
+readonly METALLB_CHART_VERSION="0.15.3"
 readonly KIND_IMAGE="kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30"
 
 echo "SOLO_CHARTS_DIR: ${SOLO_CHARTS_DIR}"
@@ -141,6 +144,7 @@ for i in $(seq 1 "${SOLO_CLUSTER_DUALITY}"); do
   if [[ "${SOLO_CLUSTER_DUALITY}" -gt 1 ]]; then
     helm upgrade --install metallb metallb/metallb \
       --namespace metallb-system --create-namespace --atomic --wait \
+      --version "${METALLB_CHART_VERSION}" \
       --set speaker.frr.enabled=true
 
     kubectl apply -f "${SCRIPT_PATH}/metallb-cluster-${i}.yaml"

--- a/test/helpers/helm-metal-load-balancer.ts
+++ b/test/helpers/helm-metal-load-balancer.ts
@@ -5,6 +5,7 @@ import {NamespaceName} from '../../src/types/namespace/namespace-name.js';
 import {type K8ClientFactory} from '../../src/integration/kube/k8-client/k8-client-factory.js';
 import {InjectTokens} from '../../src/core/dependency-injection/inject-tokens.js';
 import {type ChartManager} from '../../src/core/chart-manager.js';
+import {METALLB_CHART_VERSION} from '../../version.js';
 
 export class HelmMetalLoadBalancer {
   public static readonly NAMESPACE: NamespaceName = NamespaceName.of('metallb-system');
@@ -13,7 +14,9 @@ export class HelmMetalLoadBalancer {
   public static readonly REPOSITORY_NAME: string = 'metallb';
   public static readonly REPOSITORY_URL: string = 'https://metallb.github.io/metallb/';
   public static readonly INSTALL_ARGS: string = '--set speaker.frr.enabled=true';
-  public static readonly VERSION: string = ''; // latest version
+  // Pinned rather than tracking latest: metallb 0.16.0 turned frrk8s on by default, which the
+  // chart rejects as mutually exclusive with the speaker.frr.enabled=true set in INSTALL_ARGS.
+  public static readonly VERSION: string = METALLB_CHART_VERSION;
 
   public static async installMetalLoadBalancer(testName: string): Promise<void> {
     try {

--- a/version.ts
+++ b/version.ts
@@ -27,6 +27,7 @@ export const HEDERA_JSON_RPC_RELAY_VERSION: string = constants.getEnvironmentVar
 export const INGRESS_CONTROLLER_VERSION: string =
   constants.getEnvironmentVariable('INGRESS_CONTROLLER_VERSION') || '0.14.5';
 export const BLOCK_NODE_VERSION: string = constants.getEnvironmentVariable('BLOCK_NODE_VERSION') || 'v0.28.1';
+export const METALLB_CHART_VERSION: string = constants.getEnvironmentVariable('METALLB_CHART_VERSION') || '0.15.3';
 export const NETWORK_LOAD_GENERATOR_CHART_VERSION: string =
   constants.getEnvironmentVariable('NETWORK_LOAD_GENERATOR_CHART_VERSION') || '0.8.0';
 


### PR DESCRIPTION
Stacked on the dependency-pinning PR — base is `fix/pin-indirect-dependencies-0.69`, so this diff shows only the CI test fixes. The release-workflow fixes are separate, in #5682.

`release/0.69` needs **both** fixes, like `release/0.64` and `release/0.65`: it never received the metallb pin, and its migration workflow predates the restructure on `main`.

## 1. metallb chart was installed unpinned

```
execution error at (metallb/templates/speaker.yaml:3:4):
speaker.frr.enabled and frrk8s.enabled / external are mutually exclusive!
```

metallb 0.16.0 made frrk8s the default BGP backend, and the chart refuses to render alongside `speaker.frr.enabled=true`, which the tests set. 0.15.3 defaults it to `false`. Nothing pinned the version, so this breaks on its own once 0.16.0 ships. Four unpinned call sites:

| site | before | after |
|---|---|---|
| `test/helpers/helm-metal-load-balancer.ts` | `VERSION = ''` ("no `--version`") | `METALLB_CHART_VERSION` |
| `test/e2e/dual-cluster/setup-dual-e2e.sh` | no `--version` | `--version "${METALLB_CHART_VERSION}"` |
| `examples/multicluster-backup-restore/Taskfile.yml` (×2) | no `--version` | `--version 0.15.3` |

## 2. Migration test selected a newer release as its baseline

The workflow resolved the prior release from the npm `latest` dist-tag — the newest across *all* lines, i.e. **0.85.0** — so it migrated *down* into a config schema this code cannot read.

Now derives the baseline from `package.json`: newest published release on the same `major.minor` line strictly older than the version being built, falling back to the newest older release on any line. Both paths compare with `sort -V`, so a downgrade can never be selected.

**This branch uses the fallback path.** 0.69.0 is the only release published on the 0.69 line, so the baseline resolves to **0.68.0** — a genuine prior release.

This branch carries the older workflow form (no `from-solo-version` input, no `helper.sh` function), so it takes the inline variant used on 0.64/0.65 rather than the `resolve_prior_release` helper. Same logic, same guarantees.

## Verification

- `task build --force` — exit 0, **0 errors**
- unit suite — **644 passing, exit 0**
- `bash -n` on the modified shell script — clean
- baseline selection exercised against the live registry, including the fallback this branch depends on
