### PR TITLE
fix: tolerate a missing lease in the mirror node upgrade close path under one-shot

### DIFF
--- a/src/commands/mirror-node.ts
+++ b/src/commands/mirror-node.ts
@@ -1901,14 +1901,14 @@ export class MirrorNodeCommand extends BaseCommand {
         throw new SoloErrors.component.mirrorNodeUpgradeFailed(error);
       } finally {
         if (!this.oneShotState.isActive()) {
-          await lease.release();
+          await lease?.release();
         }
         await this.accountManager.close();
       }
     } else {
       this.taskList.registerCloseFunction(async (): Promise<void> => {
         if (!this.oneShotState.isActive()) {
-          await lease.release();
+          await lease?.release();
         }
         await this.accountManager.close();
       });

--- a/test/unit/commands/mirror-node.test.ts
+++ b/test/unit/commands/mirror-node.test.ts
@@ -13,6 +13,7 @@ import * as versions from '../../../version.js';
 import {resetForTest} from '../../test-container.js';
 import {HelmChartValues} from '../../../src/integration/helm/model/values.js';
 import {type SoloListrTask} from '../../../src/types/index.js';
+import {type ArgvStruct} from '../../../src/types/aliases.js';
 import path from 'node:path';
 import yaml from 'yaml';
 import {SemanticVersion} from '../../../src/business/utils/semantic-version.js';
@@ -78,6 +79,15 @@ interface MirrorNodeSchemaWaitTaskContext {
 interface MirrorNodeSchemaWaitPodsStub {
   waitForRunningPhase: sinon.SinonStub;
   waitForReadyStatus: sinon.SinonStub;
+}
+
+interface MirrorNodeCommandTrailingCloseInternal {
+  oneShotState: {isActive: () => boolean};
+  taskList: {
+    newTaskList: (...newTaskListParameters: unknown[]) => unknown;
+    registerCloseFunction: (trailingCloseFunction: () => Promise<void>) => void;
+  };
+  accountManager: {close: () => Promise<void>};
 }
 
 type MirrorNodeDatabaseSkip = (context: MirrorNodeDatabaseTaskContext) => boolean;
@@ -491,6 +501,34 @@ describe('MirrorNodeCommand unit tests', (): void => {
       await (task.task as (context: MirrorNodeSchemaWaitTaskContext) => Promise<void>)(schemaWaitContext);
 
       expect(podsStub.waitForReadyStatus.called).to.equal(false);
+    });
+  });
+
+  describe('upgrade trailing close function', (): void => {
+    it('should tolerate a missing lease when one-shot deactivates before the trailing close runs', async (): Promise<void> => {
+      const mirrorNodeCommandInternal: MirrorNodeCommandTrailingCloseInternal =
+        mirrorNodeCommand as unknown as MirrorNodeCommandTrailingCloseInternal;
+      const isActiveStub: sinon.SinonStub = sinon
+        .stub(mirrorNodeCommandInternal.oneShotState, 'isActive')
+        .returns(true);
+      sinon.stub(mirrorNodeCommandInternal.taskList, 'newTaskList').returns({isRoot: (): boolean => false});
+      let trailingCloseFunction: (() => Promise<void>) | undefined;
+      sinon
+        .stub(mirrorNodeCommandInternal.taskList, 'registerCloseFunction')
+        .callsFake((closeFunction: () => Promise<void>): void => {
+          trailingCloseFunction = closeFunction;
+        });
+      const accountManagerCloseStub: sinon.SinonStub = sinon
+        .stub(mirrorNodeCommandInternal.accountManager, 'close')
+        .resolves();
+
+      expect(await mirrorNodeCommand.upgrade({} as ArgvStruct)).to.equal(true);
+      expect(trailingCloseFunction).to.be.a('function');
+
+      // one-shot deactivates before trailing close functions run, so the release guard must tolerate a missing lease
+      isActiveStub.returns(false);
+      await trailingCloseFunction();
+      expect(accountManagerCloseStub.calledOnce).to.equal(true);
     });
   });
 });


### PR DESCRIPTION
## Description

Fixes the `TypeError: Cannot read properties of undefined (reading 'release')` logged as `Error during trailing close function` at the end of `one-shot single deploy`.

**Root cause:**

1. The one-shot deploy pipeline's *Enable mirror pinger* phase invokes `mirror node upgrade` while the one-shot state is active, so `MirrorNodeCommand.upgrade()` never creates a `lease` and registers a trailing close function that dereferences it guarded only by `!this.oneShotState.isActive()`.
2. In `DefaultOneShotCommand.deployInternal()`'s `finally` block, `oneShotState.deactivate()` runs **before** `taskList.callCloseFunctions()`, so at close time the guard passes and the undefined `lease` is dereferenced.

`add()` and `destroy()` in `mirror-node.ts` (and the equivalent close paths in `relay.ts` / `network.ts`) already guard with `lease?.release()` — `upgrade()` was the only remaining unguarded path. This PR applies the same guard to both the root `finally` and the registered close function, and adds a regression unit test that reproduces the exact failure (one-shot active during `upgrade()`, deactivated before the trailing close runs).

**Related Issues**

Fixes #5608