### PR TITLE
fix: retry mirror node chart upgrade to ride out transient API server outages

### DIFF
--- a/src/commands/mirror-node.ts
+++ b/src/commands/mirror-node.ts
@@ -10,7 +10,8 @@ import {type AccountManager} from '../core/account-manager.js';
 import {BaseCommand} from './base.js';
 import {Flags as flags} from './flags.js';
 import {resolveNamespaceFromDeployment} from '../core/resolvers.js';
-import {entityId, showVersionBanner} from '../core/helpers.js';
+import {entityId, showVersionBanner, sleep} from '../core/helpers.js';
+import {Duration} from '../core/time/duration.js';
 import {type AnyListrContext, type ArgvStruct} from '../types/aliases.js';
 import {type Rbacs} from '../integration/kube/resources/rbac/rbacs.js';
 import {ListrLock} from '../core/lock/listr-lock.js';
@@ -716,6 +717,53 @@ export class MirrorNodeCommand extends BaseCommand {
     return true;
   }
 
+  /** Upgrades the mirror node chart with bounded retries to ride out transient API server outages. */
+  private async upgradeMirrorNodeChart(
+    config: MirrorNodeDeployConfigClass | MirrorNodeUpgradeConfigClass,
+    shouldReuseValues: boolean,
+  ): Promise<void> {
+    for (let attempt: number = 1; attempt <= constants.MIRROR_NODE_CHART_UPGRADE_MAX_ATTEMPTS; attempt++) {
+      try {
+        await this.chartManager.upgrade(
+          config.namespace,
+          config.releaseName,
+          constants.MIRROR_NODE_CHART,
+          config.mirrorNodeChartDirectory || constants.MIRROR_NODE_RELEASE_NAME,
+          config.mirrorNodeVersion,
+          config.chartValues,
+          config.clusterContext,
+          shouldReuseValues,
+          true,
+          false,
+          Boolean(config.mirrorNodeChartDirectory),
+        );
+        return;
+      } catch (error) {
+        if (attempt === constants.MIRROR_NODE_CHART_UPGRADE_MAX_ATTEMPTS) {
+          throw error;
+        }
+
+        this.logger.warn(
+          `Attempt ${attempt} of ${constants.MIRROR_NODE_CHART_UPGRADE_MAX_ATTEMPTS} to upgrade chart ` +
+            `'${config.releaseName}' failed, retrying in ` +
+            `${constants.MIRROR_NODE_CHART_UPGRADE_RETRY_DELAY_SECS} seconds`,
+          error,
+        );
+        await sleep(Duration.ofSeconds(constants.MIRROR_NODE_CHART_UPGRADE_RETRY_DELAY_SECS));
+
+        if (!config.isChartInstalled) {
+          try {
+            // remove the release left behind by the failed fresh install so the retry starts from a clean state
+            await this.chartManager.uninstall(config.namespace, config.releaseName, config.clusterContext);
+          } catch (uninstallError) {
+            // best-effort cleanup: a persistent failure will surface on the next upgrade attempt
+            this.logger.warn(`Failed to uninstall chart '${config.releaseName}' before retry`, uninstallError);
+          }
+        }
+      }
+    }
+  }
+
   private async deployMirrorNode(
     {config}: MirrorNodeDeployContext | MirrorNodeUpgradeContext,
     commandType: MirrorNodeCommandType,
@@ -733,19 +781,7 @@ export class MirrorNodeCommand extends BaseCommand {
       await this.kindLoadComponentImage(config.componentImage, config.clusterContext);
     }
 
-    await this.chartManager.upgrade(
-      config.namespace,
-      config.releaseName,
-      constants.MIRROR_NODE_CHART,
-      config.mirrorNodeChartDirectory || constants.MIRROR_NODE_RELEASE_NAME,
-      config.mirrorNodeVersion,
-      config.chartValues,
-      config.clusterContext,
-      shouldReuseValues,
-      true,
-      false,
-      Boolean(config.mirrorNodeChartDirectory),
-    );
+    await this.upgradeMirrorNodeChart(config, shouldReuseValues);
 
     this.eventBus.emit(new MirrorNodeDeployedEvent(config.deployment));
 

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -569,6 +569,11 @@ export const NETWORK_CHART_INSTALL_MAX_ATTEMPTS: number =
 export const NETWORK_CHART_INSTALL_RETRY_DELAY_SECS: number =
   +getEnvironmentVariable('NETWORK_CHART_INSTALL_RETRY_DELAY_SECS') || 15;
 
+export const MIRROR_NODE_CHART_UPGRADE_MAX_ATTEMPTS: number =
+  +getEnvironmentVariable('MIRROR_NODE_CHART_UPGRADE_MAX_ATTEMPTS') || 3;
+export const MIRROR_NODE_CHART_UPGRADE_RETRY_DELAY_SECS: number =
+  +getEnvironmentVariable('MIRROR_NODE_CHART_UPGRADE_RETRY_DELAY_SECS') || 15;
+
 export const NETWORK_DESTROY_WAIT_TIMEOUT: number = +getEnvironmentVariable('NETWORK_DESTROY_WAIT_TIMEOUT') || 120;
 
 export const DEFAULT_LOCAL_CONFIG_FILE: string = 'local-config.yaml';

--- a/test/unit/commands/mirror-node.test.ts
+++ b/test/unit/commands/mirror-node.test.ts
@@ -16,6 +16,7 @@ import {type SoloListrTask} from '../../../src/types/index.js';
 import path from 'node:path';
 import yaml from 'yaml';
 import {SemanticVersion} from '../../../src/business/utils/semantic-version.js';
+import {Duration} from '../../../src/core/time/duration.js';
 
 interface MirrorNodeMemoryOverrideConfig {
   mirrorNodeVersion: string;
@@ -80,6 +81,24 @@ interface MirrorNodeSchemaWaitPodsStub {
   waitForReadyStatus: sinon.SinonStub;
 }
 
+interface MirrorNodeChartUpgradeTestConfig {
+  namespace: {name: string};
+  releaseName: string;
+  mirrorNodeChartDirectory?: string;
+  mirrorNodeVersion: string;
+  chartValues: HelmChartValues;
+  clusterContext: string;
+  isChartInstalled: boolean;
+}
+
+interface MirrorNodeChartUpgradeInternal {
+  chartManager: {
+    upgrade: sinon.SinonStub;
+    uninstall: sinon.SinonStub;
+  };
+  upgradeMirrorNodeChart: (config: MirrorNodeChartUpgradeTestConfig, shouldReuseValues: boolean) => Promise<void>;
+}
+
 type MirrorNodeDatabaseSkip = (context: MirrorNodeDatabaseTaskContext) => boolean;
 
 function getSkipFunction(task: SoloListrTask<MirrorNodeDatabaseTaskContext>): MirrorNodeDatabaseSkip {
@@ -96,6 +115,32 @@ function stubImporterPods(
     getK8: (): {pods: () => MirrorNodeSchemaWaitPodsStub} => ({
       pods: (): MirrorNodeSchemaWaitPodsStub => podsStub,
     }),
+  };
+  return mirrorNodeCommandInternal;
+}
+
+function buildChartUpgradeConfig(isChartInstalled: boolean): MirrorNodeChartUpgradeTestConfig {
+  return {
+    namespace: {name: 'one-shot'},
+    releaseName: 'mirror-1',
+    mirrorNodeVersion: 'v0.159.0',
+    chartValues: new HelmChartValues(),
+    clusterContext: 'kind-kind',
+    isChartInstalled,
+  };
+}
+
+function stubChartUpgrade(command: MirrorNodeCommand): MirrorNodeChartUpgradeInternal {
+  // collapse the retry backoff so the test does not wait for the real delay
+  const ofSecondsStub: sinon.SinonStub = sinon.stub(Duration, 'ofSeconds');
+  ofSecondsStub.callThrough();
+  ofSecondsStub.withArgs(constants.MIRROR_NODE_CHART_UPGRADE_RETRY_DELAY_SECS).returns(Duration.ofMillis(1));
+
+  const mirrorNodeCommandInternal: MirrorNodeChartUpgradeInternal =
+    command as unknown as MirrorNodeChartUpgradeInternal;
+  mirrorNodeCommandInternal.chartManager = {
+    upgrade: sinon.stub().resolves(true),
+    uninstall: sinon.stub().resolves(true),
   };
   return mirrorNodeCommandInternal;
 }
@@ -491,6 +536,50 @@ describe('MirrorNodeCommand unit tests', (): void => {
       await (task.task as (context: MirrorNodeSchemaWaitTaskContext) => Promise<void>)(schemaWaitContext);
 
       expect(podsStub.waitForReadyStatus.called).to.equal(false);
+    });
+  });
+
+  describe('upgradeMirrorNodeChart', (): void => {
+    const transientError: Error = new Error(
+      'Post "https://127.0.0.1:33745/api/v1/namespaces/one-shot/secrets?fieldManager=helm": unexpected EOF',
+    );
+
+    it('retries the chart upgrade after a transient failure and cleans up the fresh install', async (): Promise<void> => {
+      const mirrorNodeCommandInternal: MirrorNodeChartUpgradeInternal = stubChartUpgrade(mirrorNodeCommand);
+      mirrorNodeCommandInternal.chartManager.upgrade.onFirstCall().rejects(transientError);
+
+      await mirrorNodeCommandInternal.upgradeMirrorNodeChart(buildChartUpgradeConfig(false), false);
+
+      expect(mirrorNodeCommandInternal.chartManager.upgrade.callCount).to.equal(2);
+      expect(mirrorNodeCommandInternal.chartManager.uninstall.callCount).to.equal(1);
+      expect(mirrorNodeCommandInternal.chartManager.uninstall.firstCall.args[1]).to.equal('mirror-1');
+    });
+
+    it('does not uninstall a previously installed release between retries', async (): Promise<void> => {
+      const mirrorNodeCommandInternal: MirrorNodeChartUpgradeInternal = stubChartUpgrade(mirrorNodeCommand);
+      mirrorNodeCommandInternal.chartManager.upgrade.onFirstCall().rejects(transientError);
+
+      await mirrorNodeCommandInternal.upgradeMirrorNodeChart(buildChartUpgradeConfig(true), true);
+
+      expect(mirrorNodeCommandInternal.chartManager.upgrade.callCount).to.equal(2);
+      expect(mirrorNodeCommandInternal.chartManager.uninstall.called).to.equal(false);
+    });
+
+    it('throws the last error once all attempts are exhausted', async (): Promise<void> => {
+      const mirrorNodeCommandInternal: MirrorNodeChartUpgradeInternal = stubChartUpgrade(mirrorNodeCommand);
+      mirrorNodeCommandInternal.chartManager.upgrade.rejects(transientError);
+
+      let thrownError: Error | undefined;
+      try {
+        await mirrorNodeCommandInternal.upgradeMirrorNodeChart(buildChartUpgradeConfig(false), false);
+      } catch (error) {
+        thrownError = error as Error;
+      }
+
+      expect(thrownError).to.equal(transientError);
+      expect(mirrorNodeCommandInternal.chartManager.upgrade.callCount).to.equal(
+        constants.MIRROR_NODE_CHART_UPGRADE_MAX_ATTEMPTS,
+      );
     });
   });
 });


### PR DESCRIPTION
## Description

The *One Shot Single - using Podman* job failed because the mirror-node chart deploy hit a transient kube API server connection drop mid-`helm upgrade`:

```
UPGRADE FAILED: failed to create resource: Post "https://127.0.0.1:33745/api/v1/namespaces/one-shot/secrets?fieldManager=helm": unexpected EOF
```

This is the same failure class already handled for the solo-deployment chart in #5238, so this PR applies the same bounded-retry pattern to the mirror-node chart upgrade in `MirrorNodeCommand.deployMirrorNode()`:

- New `upgradeMirrorNodeChart()` helper retries the chart upgrade up to `MIRROR_NODE_CHART_UPGRADE_MAX_ATTEMPTS` (default 3) with a `MIRROR_NODE_CHART_UPGRADE_RETRY_DELAY_SECS` (default 15s) delay, both env-var tunable.
- Between attempts, the release left behind by a failed **fresh install** is uninstalled (best-effort) so the retry starts from a clean state — avoiding helm's "has no deployed releases" dead end. When the release was already installed before the command started (the upgrade path), no destructive cleanup is performed; the retry upgrades from the last deployed revision.
- The last error is rethrown once attempts are exhausted, preserving the existing failure behavior.

Unit tests cover the retry-then-succeed path (including fresh-install cleanup), the no-uninstall guarantee for pre-existing releases, and error propagation after exhausted attempts.

**Related Issues**

Fixes #5607

Docs PR: hiero-ledger/solo-docs#295
