### PR TITLE
fix: recognize ApiException 404s in killPod so an already-deleted pod is not an error

### DIFF
--- a/src/integration/kube/k8-client/resources/pod/k8-client-pod.ts
+++ b/src/integration/kube/k8-client/resources/pod/k8-client-pod.ts
@@ -4,6 +4,7 @@ import {type Pod} from '../../../resources/pod/pod.js';
 import {PortUtilities} from '../../../../../business/utils/port-utilities.js';
 import {PodReference} from '../../../resources/pod/pod-reference.js';
 import {KubeContainerOperationFailedError} from '../../../errors/kube-container-operation-failed-error.js';
+import {KubeApiResponse} from '../../../kube-api-response.js';
 import {sleep} from '../../../../../core/helpers.js';
 import {Duration} from '../../../../../core/time/duration.js';
 import {StatusCodes} from 'http-status-codes';
@@ -85,7 +86,13 @@ export class K8ClientPod implements Pod {
     } catch (error) {
       const errorMessage: string = `Failed to delete pod ${this.podReference.name.name} in namespace ${this.podReference.namespace}: ${error.message}`;
 
-      if (error.body?.code === StatusCodes.NOT_FOUND || error.response?.body?.code === StatusCodes.NOT_FOUND) {
+      // ApiException reports the HTTP status on error.code with an unparsed string body,
+      // so the body-based checks alone miss it and a pod that is already gone fails the kill.
+      if (
+        KubeApiResponse.isNotFound(error) ||
+        error.body?.code === StatusCodes.NOT_FOUND ||
+        error.response?.body?.code === StatusCodes.NOT_FOUND
+      ) {
         this.logger.info(`Pod not found: ${errorMessage}`, error);
         return;
       }

--- a/test/unit/integration/kube/k8-client-pod.test.ts
+++ b/test/unit/integration/kube/k8-client-pod.test.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {expect} from 'chai';
+import {afterEach, beforeEach, describe, it} from 'mocha';
+import sinon, {type SinonStub} from 'sinon';
+import {K8ClientPod} from '../../../../src/integration/kube/k8-client/resources/pod/k8-client-pod.js';
+import {KubeContainerOperationFailedError} from '../../../../src/integration/kube/errors/kube-container-operation-failed-error.js';
+import {PodReference} from '../../../../src/integration/kube/resources/pod/pod-reference.js';
+import {PodName} from '../../../../src/integration/kube/resources/pod/pod-name.js';
+import {type Pods} from '../../../../src/integration/kube/resources/pod/pods.js';
+import {NamespaceName} from '../../../../src/types/namespace/namespace-name.js';
+import {resetForTest} from '../../../test-container.js';
+
+/**
+ * Builds an error with the runtime shape of `@kubernetes/client-node`'s `ApiException` for an
+ * undocumented status code: the HTTP status on `error.code` and the response body as an
+ * unparsed JSON string on `error.body`.
+ */
+function apiException(code: number, body: object): Error {
+  return Object.assign(
+    new Error(`HTTP-Code: ${code}\nMessage: Unknown API Status Code!\nBody: ${JSON.stringify(body)}`),
+    {
+      code,
+      body: JSON.stringify(body),
+      headers: {},
+    },
+  );
+}
+
+describe('K8ClientPod killPod', (): void => {
+  const podReference: PodReference = PodReference.of(NamespaceName.of('test-namespace'), PodName.of('test-pod'));
+
+  let deleteNamespacedPodStub: SinonStub;
+  let podClient: K8ClientPod;
+
+  beforeEach((): void => {
+    resetForTest();
+    deleteNamespacedPodStub = sinon.stub();
+    const pods: Pods = {read: sinon.stub().resolves()} as unknown as Pods;
+    podClient = new K8ClientPod(
+      podReference,
+      pods,
+      {deleteNamespacedPod: deleteNamespacedPodStub} as never,
+      {} as never,
+      '',
+    );
+  });
+
+  afterEach((): void => {
+    sinon.restore();
+  });
+
+  it('treats an ApiException 404 (undocumented status code, string body) as pod already deleted', async (): Promise<void> => {
+    deleteNamespacedPodStub.rejects(
+      apiException(404, {kind: 'Status', status: 'Failure', reason: 'NotFound', code: 404}),
+    );
+
+    await expect(podClient.killPod()).to.eventually.be.fulfilled;
+  });
+
+  it('treats a parsed-body 404 as pod already deleted', async (): Promise<void> => {
+    deleteNamespacedPodStub.rejects(Object.assign(new Error('pod not found'), {body: {code: 404}}));
+
+    await expect(podClient.killPod()).to.eventually.be.fulfilled;
+  });
+
+  it('still throws KubeContainerOperationFailedError for non-404 failures', async (): Promise<void> => {
+    const cause: Error = apiException(500, {kind: 'Status', status: 'Failure', code: 500});
+    deleteNamespacedPodStub.rejects(cause);
+
+    await expect(podClient.killPod())
+      .to.eventually.be.rejectedWith(KubeContainerOperationFailedError)
+      .and.have.property('cause', cause);
+  });
+});


### PR DESCRIPTION
## Description

The **Node Add Local** E2E job failed in `Kill nodes to pick up updated configMaps` (issue #5605):
the test upgraded the deployment chart, then killed the node pods so they pick up the new
ConfigMap — and `network-node2-0` was already gone when its delete call went out (the pod was
recreated by the rollout race between the helm upgrade and the kill task). The Kubernetes API
answered 404, and `K8ClientPod.killPod()` escalated that into
`ContainerOperationFailedSoloError`, failing the whole run. A 404 on a *kill* is the desired
end state — the pod is dead — not an error.

`killPod()` already tries to swallow exactly this case (`k8-client-pod.ts`):

```ts
if (error.body?.code === StatusCodes.NOT_FOUND || error.response?.body?.code === StatusCodes.NOT_FOUND) {
```

but the check never matches what `@kubernetes/client-node` actually throws. 404 is not a
documented response code for `deleteNamespacedPod` (only 200/202/401 are), so the generated
client throws `ApiException(code, 'Unknown API Status Code!', await response.getBodyAsAny(), headers)`
— the HTTP status lives on **`error.code`**, and **`error.body` is the raw, unparsed JSON
string**, so `error.body?.code` is `undefined`. The CI log shows precisely this shape:

```
Caused by: Error: HTTP-Code: 404
Message: Unknown API Status Code!
Body: "{\"kind\":\"Status\",...,\"reason\":\"NotFound\",...,\"code\":404}\n"
```

### What changed

* **`src/integration/kube/k8-client/resources/pod/k8-client-pod.ts`** — the 404 check in
  `killPod()`'s catch now also consults `KubeApiResponse.isNotFound(error)`, the existing helper
  a few files over that reads `error.code` / `error.statusCode` — the fields `ApiException`
  actually populates. The two body-shaped checks are kept, so any call path that still surfaces a
  parsed body keeps working.
* **`test/unit/integration/kube/k8-client-pod.test.ts`** (new) — drives `killPod()` against a
  stubbed `CoreV1Api` and asserts: an `ApiException`-shaped 404 (status on `code`, string body)
  resolves instead of throwing; a parsed-body 404 still resolves; and a 500 still throws
  `KubeContainerOperationFailedError` with the original error preserved as `cause`.

Design notes:

* **Why fix it in `killPod()` and not the calling task.** Every kill path routes through this one
  catch block — `node/tasks.ts` (two kill-nodes tasks) and `network.ts` (two destroy/refresh
  paths) all call `killPod()`. One guard here fixes all four callers; a guard at the failing call
  site (`node/tasks.ts:4244`) would have left the three sibling paths carrying the same race.
* **The wait-loop below the delete is already safe.** After a successful delete, `killPod()` polls
  `pods.read()` until the pod disappears; `read()` is list-based and returns `undefined` for a
  vanished pod, so no change was needed there.
* **`KubeApiResponse.isNotFound()` is reused, not reimplemented** — it is the same predicate
  `K8ClientPods` already uses for its own API-error classification, so the two files now agree on
  what a 404 looks like.

### Related Issues

Fixes #5605

### Pull request (PR) checklist

- [x] This PR added tests (unit, integration, and/or end-to-end)
- [ ] This PR updated documentation
- [x] This PR added no TODOs or commented out code
- [x] This PR has no breaking changes
- [x] Any technical debt has been documented as a separate issue and linked to this PR
- [x] Any `package.json` changes have been explained to and approved by a repository manager
- [x] All related issues have been linked to this PR
- [x] All changes in this PR are included in the description
- [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

- [x] This PR added unit tests
- [ ] This PR added integration/end-to-end tests
- [ ] These changes required manual testing that is documented below
- [x] Anything not tested is documented

The following manual testing was done:

* `npx tsc --noEmit` — exit 0.
* `npx eslint` on both changed files — 0 errors, 0 warnings; `npx prettier --check` — clean.
* `npx mocha 'test/unit/**/*.ts' --exclude 'test/unit/core/helm/**/*.ts'` — **1442 passing, 0 failing**.
* The new ApiException-404 test was run against `main`'s `killPod()` (fix stashed) and fails there
  with the byte-identical error from the CI log — confirming it reproduces #5605.

The following was not tested:

* The failing E2E suite (`test-e2e-node-add-local`) was not re-run locally — the race needs a live
  cluster plus a chart upgrade mid-flight to reproduce. The unit test substitutes for it by
  replaying the exact error object the CI run recorded.
