### PR TITLE
fix: disable haproxy strict-limits so the ingress controller survives runners with huge FD limits

### DIFF
--- a/resources/ingress-controller-values.yaml
+++ b/resources/ingress-controller-values.yaml
@@ -6,3 +6,12 @@ controller:
     # fails and haproxy exits on reload ("Cannot raise FD limit"), leaving the ingress
     # controller permanently unready. 256 connections (~700 FDs) stays under the limit.
     max-connections: "256"
+    # haproxy 2.4 enables strict-limits by default, turning ANY failed setrlimit into
+    # exit(1). On runners where containerd grants RLIMIT_NOFILE=2^30 (> fs.nr_open),
+    # every setrlimit fails with EPERM regardless of the target value, so the
+    # max-connections cap above cannot help there and haproxy dies on reload
+    # ("Cannot raise FD limit to 709, limit is 1073741816"). no strict-limits downgrades
+    # the failure to a warning: haproxy keeps the inherited FD limit, which always
+    # covers the ~700 FDs the capped maxconn needs.
+    config-global: |
+      no strict-limits


### PR DESCRIPTION
## Description

The **Docs Automation / Command Output** job failed on `solo relay node add` (issue #5606). The
reported error — `RelayDeployFailedSoloError: ... No pod found for:
labels:app.kubernetes.io/instance=relay-1,app.kubernetes.io/name=relay` — is three layers away
from the actual defect. From the run's `solo-logs` artifact (pod describes, container logs, helm
values), the failure chain is:

1. **The relay pod existed the whole time** (`relay-1-bc544d79d-vkmgq`, Running, never Ready). Its
   startup probe (`/health/readiness`) failed **840 consecutive times** over ~15 minutes and
   kubelet kept killing the container (`Container relay failed startup probe, will be restarted`,
   exit 137). The relay could not become ready because it could not reach the mirror node —
   `MIRROR_NODE_URL` points at the mirror ingress controller service.
2. **The mirror ingress controller was in CrashLoopBackOff** (7 restarts). Its haproxy died on
   every config reload:

   ```
   [NOTICE] (53) : haproxy version is 2.4.24-d175670
   [ALERT]  (53) : [haproxy.main()] Cannot raise FD limit to 709, limit is 1073741816.
   E0803 18:34:14.280426 14 instance.go:381] error reloading server: exit status 1
   ```

3. **Why haproxy exits.** haproxy 2.4 sets `strict-limits` **unconditionally at startup**
   (`haproxy.c`: `global.tune.options |= GTUNE_STRICT_LIMITS;`), which turns any failed
   `setrlimit(RLIMIT_NOFILE, …)` into `exit(1)`. On this runner, containerd granted the container
   `RLIMIT_NOFILE = 1073741816` (2^30, the `LimitNOFILE=infinity` default) while the kernel's
   `fs.nr_open` stays at its 1048576 default — and the kernel rejects **any**
   `setrlimit(RLIMIT_NOFILE)` whose `rlim_max` exceeds `fs.nr_open`, even one that only *lowers*
   the soft limit (`do_prlimit()`: `if (resource == RLIMIT_NOFILE && new_rlim->rlim_max >
   sysctl_nr_open) return -EPERM;`). So every `setrlimit` haproxy attempts on such a runner fails,
   no matter the target value.

This is why the existing mitigation from #5245 (`max-connections: "256"`, which brings the FD
target down to ~709) did not help here: that fix assumed the failure mode was *asking for more FDs
than the limit allows* (true on ARC runners with a 1024 soft limit). On the 2^30-limit runner
class the `setrlimit` call fails regardless of the requested value, and `strict-limits` escalates
the harmless failure into a fatal one.

### What changed

* **`resources/ingress-controller-values.yaml`** — appends `no strict-limits` to haproxy's global
  section via the chart's documented `config-global` snippet key. With the flag cleared,
  haproxy 2.4.24 downgrades the failed `setrlimit` to a warning and continues with the inherited
  FD limit — which on every runner class (1024 soft or 2^30) covers the ~709 FDs the capped
  `maxconn` needs. The later "FD limit too low for maxconn/maxsock" fatal check only trips when
  the current limit is *below* maxsock (~709), which cannot happen on the affected runners.

This one file feeds every haproxy-ingress install in solo: the mirror ingress
(`mirror-node.ts` → `INGRESS_CONTROLLER_VALUES_FILE`), the explorer ingress (`explorer.ts`, same
constant), and the one-shot NodePort overlay (`resources/one-shot/mirror-ingress-controller-nodeport-values.yaml`),
which merges per-key on top and does not touch `config-global`.

Design notes:

* **Why not raise `fs.nr_open` or lower `LimitNOFILE` on the runner.** Those are host-level fixes
  solo does not control — the failing job ran on a shared GitHub runner, and solo's ingress must
  survive whatever FD limit the container runtime hands it. `no strict-limits` restores haproxy's
  pre-2.4 behavior of adapting to the environment instead of dying on it.
* **Why not upgrade haproxy-ingress.** The current chart pin (0.14.5) bundles haproxy 2.4;
  `strict-limits` stays default-on in every later haproxy, so an upgrade alone would not fix this,
  and a controller version bump has a far larger blast radius than a one-key config change.
* **`no strict-limits` is verified against the exact pinned versions**: haproxy 2.4.24's
  `cfgparse-global.c` accepts the `no` prefix and clears `GTUNE_STRICT_LIMITS`; the non-strict
  branch of the failing code path warns and continues; and the haproxy-ingress v0.14.5 template
  does not itself emit `strict-limits`, so the snippet cannot conflict.

### Deliberately not included

`waitForRunningPhase` reports `No pod found for: labels:…` when it times out — even when, as
here, pods matching the labels existed for the entire wait and simply never became Ready. That
misleading message is what pointed the auto-filed issue (and any human reader) away from the real
failure. It is a separate diagnostics defect in `k8-client-pods.ts`, not part of this
environment fix, and is left to its own change so this one stays a single-key config fix.

### Related Issues

Fixes #5606

### Pull request (PR) checklist

- [ ] This PR added tests (unit, integration, and/or end-to-end)
- [ ] This PR updated documentation
- [x] This PR added no TODOs or commented out code
- [x] This PR has no breaking changes
- [x] Any technical debt has been documented as a separate issue and linked to this PR
- [x] Any `package.json` changes have been explained to and approved by a repository manager
- [x] All related issues have been linked to this PR
- [x] All changes in this PR are included in the description
- [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

- [ ] This PR added unit tests
- [ ] This PR added integration/end-to-end tests
- [x] These changes required manual testing that is documented below
- [x] Anything not tested is documented

The following manual testing was done:

* `helm template haproxy-ingress --repo https://haproxy-ingress.github.io/charts --version 0.14.5 -f resources/ingress-controller-values.yaml`
  — the rendered ConfigMap carries `config-global: |\n  no strict-limits` alongside the existing
  `max-connections: "256"`.
* The same render with the one-shot NodePort overlay stacked on top — `config-global` survives the
  merge next to the overlay's `http-port`/`https-port`/`ssl-redirect` keys.
* haproxy 2.4.24 source (the exact version in the `quay.io/jcmoraisjr/haproxy-ingress:v0.14.5`
  image) was read to confirm all three claims above: strict-limits default-on, the `no` prefix
  clearing it, and the warn-and-continue fallback.

The following was not tested:

* **No reproduction on an affected runner.** The failure needs a host whose container runtime
  grants `RLIMIT_NOFILE` above `fs.nr_open`; that combination was not reproducible locally. The
  evidence that this is the failing configuration is the ALERT line itself (target 709, limit
  1073741816 — the limit was already vastly above the target, so only a rejected `setrlimit`
  syscall, not an exhausted limit, reaches that branch).
* The unchanged happy path (runners where `setrlimit` succeeds) is unaffected by construction —
  `no strict-limits` only changes behavior after a `setrlimit` failure.
