### PR TITLE
fix: coded error + capture path for corrupt or empty remote-config data

### DIFF
--- a/src/core/errors/classes/config/remote-config-data-invalid-solo-error.ts
+++ b/src/core/errors/classes/config/remote-config-data-invalid-solo-error.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {SoloError} from '../../solo-error.js';
+import {ErrorOwnership} from '../../error-ownership.js';
+import {ErrorCodeRegistry} from '../../error-code-registry.js';
+
+/**
+ * @description Thrown when the remote configuration stored in the `solo-remote-config` ConfigMap cannot be
+ * turned into a configuration object: the `remote-config-data` value is empty, is not parseable as YAML, or
+ * parses to something that is not a configuration object (a bare scalar, `null`, or a sequence). solo treats
+ * that ConfigMap as the source of truth for a deployment and reads it before almost any other work, so an
+ * unusable value blocks the whole command. The value is normally only written by solo itself, so this means it
+ * was hand-edited, truncated by a partial or interrupted write, or otherwise corrupted in the cluster. The
+ * offending value is captured on the error (`meta.capturedData`) so it can be inspected after the fact.
+ */
+export class RemoteConfigDataInvalidSoloError extends SoloError {
+  protected override readonly retryable: boolean = false;
+  protected override readonly ownership: ErrorOwnership = ErrorOwnership.Infrastructure;
+
+  /** Upper bound on the captured value retained on the error, so a large ConfigMap cannot bloat the log record. */
+  private static readonly CAPTURE_LIMIT: number = 8192;
+
+  /** Upper bound on the single-line excerpt embedded in the message, so the rendered error box stays readable. */
+  private static readonly EXCERPT_LIMIT: number = 240;
+
+  public constructor(key: string, reason: string, capturedData: string, cause?: Error) {
+    const data: string = capturedData ?? '';
+    super(
+      {
+        message:
+          `Remote configuration data in ConfigMap "solo-remote-config" under key "${key}" is unusable: ${reason}\n` +
+          `Captured value (${data.length} bytes): ${RemoteConfigDataInvalidSoloError.excerpt(data)}`,
+        code: ErrorCodeRegistry.REMOTE_CONFIG_DATA_INVALID,
+        troubleshootingSteps:
+          'Inspect the stored value: kubectl get configmap solo-remote-config -n <namespace> -o yaml\n' +
+          'The full captured value is recorded in ~/.solo/logs/solo.log\n' +
+          'Recover by deleting and recreating the cluster: solo one-shot single destroy, then solo one-shot single deploy\n' +
+          'Collect a diagnostics bundle: solo deployment diagnostics debug\n' +
+          `If this is reproducible or looks like a solo bug, open an issue or PR with the diagnostics bundle: ${SoloError.bugReportUrl}`,
+      },
+      cause,
+      {key, capturedData: data.slice(0, RemoteConfigDataInvalidSoloError.CAPTURE_LIMIT)},
+    );
+  }
+
+  /** Collapses the captured value to a single quoted line so it cannot break up the rendered error box. */
+  private static excerpt(data: string): string {
+    if (data.length === 0) {
+      return '<empty>';
+    }
+    const singleLine: string = data.replaceAll(/\s+/g, ' ').trim();
+    return singleLine.length > RemoteConfigDataInvalidSoloError.EXCERPT_LIMIT
+      ? `${JSON.stringify(singleLine.slice(0, RemoteConfigDataInvalidSoloError.EXCERPT_LIMIT))} (truncated)`
+      : JSON.stringify(singleLine);
+  }
+}

--- a/src/core/errors/error-code-registry.ts
+++ b/src/core/errors/error-code-registry.ts
@@ -7,6 +7,7 @@ export const ErrorCodeRegistry: Record<string, string> = {
   REFRESH_LOCAL_CONFIG_SOURCE: 'SOLO-1003',
   REMOTE_CONFIGS_MISMATCH: 'SOLO-1004',
   INCOMPLETE_LOCAL_CONFIG: 'SOLO-1005',
+  REMOTE_CONFIG_DATA_INVALID: 'SOLO-1006',
 
   // 2xxx - Deployment / Infrastructure: Cluster, namespace, pod lifecycle
   CREATE_DEPLOYMENT: 'SOLO-2001',

--- a/src/core/errors/solo-errors.ts
+++ b/src/core/errors/solo-errors.ts
@@ -35,6 +35,7 @@ import {IncompleteLocalConfigError} from './classes/config/incomplete-local-conf
 import {LocalConfigNotFoundSoloError} from './classes/config/local-config-not-found-solo-error.js';
 import {ReadRemoteConfigBeforeLoadError} from './classes/internal/read-remote-config-before-load-error.js';
 import {RefreshLocalConfigSourceError} from './classes/config/refresh-local-config-source-error.js';
+import {RemoteConfigDataInvalidSoloError} from './classes/config/remote-config-data-invalid-solo-error.js';
 import {RemoteConfigsMismatchSoloError} from './classes/config/remote-configs-mismatch-solo-error.js';
 import {WriteLocalConfigFileError} from './classes/config/write-local-config-file-error.js';
 import {WriteRemoteConfigBeforeLoadError} from './classes/internal/write-remote-config-before-load-error.js';
@@ -310,12 +311,14 @@ export class SoloErrors {
     readonly incompleteLocalConfig: typeof IncompleteLocalConfigError;
     readonly localNotFound: typeof LocalConfigNotFoundSoloError;
     readonly refreshLocalConfigSource: typeof RefreshLocalConfigSourceError;
+    readonly remoteDataInvalid: typeof RemoteConfigDataInvalidSoloError;
     readonly remoteMismatch: typeof RemoteConfigsMismatchSoloError;
     readonly writeLocalConfig: typeof WriteLocalConfigFileError;
   } = Object.freeze({
     incompleteLocalConfig: IncompleteLocalConfigError,
     localNotFound: LocalConfigNotFoundSoloError,
     refreshLocalConfigSource: RefreshLocalConfigSourceError,
+    remoteDataInvalid: RemoteConfigDataInvalidSoloError,
     remoteMismatch: RemoteConfigsMismatchSoloError,
     writeLocalConfig: WriteLocalConfigFileError,
   });

--- a/src/data/backend/impl/yaml-config-map-storage-backend.ts
+++ b/src/data/backend/impl/yaml-config-map-storage-backend.ts
@@ -14,19 +14,30 @@ import {type ConfigMap} from '../../../integration/kube/resources/config-map/con
 export class YamlConfigMapStorageBackend extends ConfigMapStorageBackend implements ObjectStorageBackend {
   public async readObject(key: string): Promise<object> {
     const data: Buffer = await this.readBytes(key);
-    if (!data) {
-      throw new StorageBackendError(`failed to read key: ${key} from config map`);
+    const content: string = data?.toString('utf8') ?? '';
+
+    if (content.length === 0) {
+      throw new SoloErrors.config.remoteDataInvalid(key, 'the value is empty', content);
     }
 
-    if (data.length === 0) {
-      throw new StorageBackendError(`data is empty for key: ${key}`);
-    }
-
+    let parsed: unknown;
     try {
-      return yaml.parse(data.toString('utf8'));
+      parsed = yaml.parse(content);
     } catch (error) {
-      throw new StorageBackendError(`error parsing yaml from key: ${key}`, error);
+      throw new SoloErrors.config.remoteDataInvalid(key, 'the value is not parseable as YAML', content, error);
     }
+
+    // yaml.parse() resolves whitespace-only, comment-only, scalar, and sequence documents without
+    // throwing; returning those would defer the failure to the schema layer with no trace of the cause.
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new SoloErrors.config.remoteDataInvalid(
+        key,
+        'the value is valid YAML but does not describe a configuration object',
+        content,
+      );
+    }
+
+    return parsed;
   }
 
   public async writeObject(key: string, data: object): Promise<void> {

--- a/test/unit/data/backend/impl/yaml-config-map-storage-backend.test.ts
+++ b/test/unit/data/backend/impl/yaml-config-map-storage-backend.test.ts
@@ -5,6 +5,7 @@ import {expect} from 'chai';
 import sinon from 'sinon';
 import {K8ClientConfigMap} from '../../../../../src/integration/kube/k8-client/resources/config-map/k8-client-config-map.js';
 import {NamespaceName} from '../../../../../src/types/namespace/namespace-name.js';
+import {RemoteConfigDataInvalidSoloError} from '../../../../../src/core/errors/classes/config/remote-config-data-invalid-solo-error.js';
 
 describe('YamlConfigMapStorageBackend', (): void => {
   let backend: YamlConfigMapStorageBackend;
@@ -26,19 +27,72 @@ describe('YamlConfigMapStorageBackend', (): void => {
 
     it('should throw if readBytes returns empty buffer', async (): Promise<void> => {
       sinon.stub(backend, 'readBytes').resolves(Buffer.from('', 'utf8'));
-      await expect(backend.readObject('empty-key')).to.be.rejectedWith('data is empty for key: empty-key');
+      await expect(backend.readObject('empty-key')).to.be.rejectedWith('the value is empty');
     });
 
     it('should throw if readBytes returns undefined', async (): Promise<void> => {
       sinon.stub(backend, 'readBytes').resolves(undefined as never);
-      await expect(backend.readObject('missing-key')).to.be.rejectedWith(
-        'failed to read key: missing-key from config map',
-      );
+      await expect(backend.readObject('missing-key')).to.be.rejectedWith('the value is empty');
     });
 
     it('should throw on invalid YAML', async (): Promise<void> => {
       sinon.stub(backend, 'readBytes').resolves(Buffer.from('not: [valid, yaml', 'utf8'));
-      await expect(backend.readObject('bad-yaml')).to.be.rejectedWith('error parsing yaml from key: bad-yaml');
+      await expect(backend.readObject('bad-yaml')).to.be.rejectedWith('the value is not parseable as YAML');
+    });
+
+    for (const [label, value] of [
+      ['whitespace-only', '   \n  \n'],
+      ['comment-only', '# nothing here\n'],
+      ['a bare scalar', 'truncated-value'],
+      ['a sequence', '- one\n- two\n'],
+    ] as [string, string][]) {
+      it(`should throw when the value is ${label}`, async (): Promise<void> => {
+        sinon.stub(backend, 'readBytes').resolves(Buffer.from(value, 'utf8'));
+        await expect(backend.readObject('remote-config-data')).to.be.rejectedWith(
+          'does not describe a configuration object',
+        );
+      });
+    }
+
+    it('should raise a coded error carrying the captured value and recovery guidance', async (): Promise<void> => {
+      const corrupt: string = 'schemaVersion: 1\nclusters: [broken';
+      sinon.stub(backend, 'readBytes').resolves(Buffer.from(corrupt, 'utf8'));
+
+      let thrown: RemoteConfigDataInvalidSoloError;
+      try {
+        await backend.readObject('remote-config-data');
+      } catch (error) {
+        thrown = error as RemoteConfigDataInvalidSoloError;
+      }
+
+      expect(thrown).to.be.instanceOf(RemoteConfigDataInvalidSoloError);
+      expect(thrown.getFormattedCode()).to.equal('SOLO-1006');
+      expect(thrown.getDocumentUrl()).to.equal('https://solo.hiero.org/docs/troubleshooting/errors/config/SOLO-1006/');
+      expect(thrown.meta).to.deep.equal({key: 'remote-config-data', capturedData: corrupt});
+      expect(thrown.message).to.include('schemaVersion: 1 clusters: [broken');
+      expect(thrown.cause).to.be.instanceOf(Error);
+
+      const steps: string = (thrown.getTroubleshootingSteps() ?? []).join('\n');
+      expect(steps).to.include('kubectl get configmap solo-remote-config');
+      expect(steps).to.include('solo one-shot single destroy');
+      expect(steps).to.include('solo deployment diagnostics debug');
+      expect(steps).to.include('https://github.com/hiero-ledger/solo/issues');
+    });
+
+    it('should truncate an oversized captured value', async (): Promise<void> => {
+      const oversized: string = `key: ${'x'.repeat(20_000)}\nclusters: [broken`;
+      sinon.stub(backend, 'readBytes').resolves(Buffer.from(oversized, 'utf8'));
+
+      let thrown: RemoteConfigDataInvalidSoloError;
+      try {
+        await backend.readObject('remote-config-data');
+      } catch (error) {
+        thrown = error as RemoteConfigDataInvalidSoloError;
+      }
+
+      expect(thrown.meta.capturedData).to.have.lengthOf(8192);
+      expect(thrown.message).to.include('(truncated)');
+      expect(thrown.message).to.include(`Captured value (${oversized.length} bytes)`);
     });
   });
 


### PR DESCRIPTION
Fixes #5451

## Root cause

`YamlConfigMapStorageBackend.readObject()` is the single read path for the `remote-config-data` value in
the `solo-remote-config` ConfigMap — the source of truth for a deployment, loaded before almost any other
work. It had three defects.

**1. Both documented failure modes threw an uncoded `StorageBackendError`.**

```ts
if (data.length === 0) {
  throw new StorageBackendError(`data is empty for key: ${key}`);       // empty value
}
try {
  return yaml.parse(data.toString('utf8'));
} catch (error) {
  throw new StorageBackendError(`error parsing yaml from key: ${key}`, error);  // corrupt YAML
}
```

`StorageBackendError` passes a bare string to `SoloError`, so `code` and `troubleshootingSteps` are both
left `undefined`. `SoloError.getDocumentUrl()` returns early without a code, and the renderer in
[`solo-pino-logger.ts:298`](src/core/logging/solo-pino-logger.ts#L298) only emits `→` remediation lines when
a `SoloError` in the cause chain has troubleshooting steps. The result is a one-line error box with no code,
no documentation link, and no remediation.

The corrupt value itself was also discarded. It is the only evidence of *how* the ConfigMap broke, and once
the operator follows the (previously unstated) recovery path of recreating the cluster, it is gone forever —
so the failure was unreportable and undiagnosable after the fact.

**2. A related silent-failure gap: `yaml.parse()` does not throw on degenerate documents.**

The `try/catch` assumed any unusable value raises `YAMLParseError`. It does not:

| ConfigMap value | `yaml.parse()` result |
| --- | --- |
| `'   \n  \n'` (whitespace-only) | `null` — no throw |
| `'# comment\n'` (comment-only) | `null` — no throw |
| `'truncated-value'` (bare scalar) | `'truncated-value'` — no throw |
| `'- one\n- two'` (sequence) | `['one', 'two']` — no throw |

Each of these was returned to the caller, violating the declared `Promise<object>` contract. `null` then
flowed into [`layered-model-config-source.ts:56`](src/data/configuration/impl/layered-model-config-source.ts#L56)
→ `SchemaDefinitionBase.transform()`, which maps `null` straight back to `null`
([`schema-definition-base.ts:19-21`](src/data/schema/migration/api/schema-definition-base.ts#L19-L21)).
The corrupt ConfigMap was accepted at the point of read and resurfaced later as an unrelated-looking
failure in the schema/runtime layer, with no trace of the real cause.

**3. Dead branch.** `if (!data)` guarded against a falsy `Buffer`, but `readBytes()` either returns a
`Buffer` (always truthy, even at zero length) or throws — so the "empty" branch below it was doing all the
real work.

## The fix

Fold every unusable-value case into one coded remote-config error family,
`RemoteConfigDataInvalidSoloError` (**SOLO-1006**, in the existing `1xxx` config range).

A single code rather than one per failure mode: the remediation is identical in all cases (the ConfigMap is
unusable and must be recreated), so separate codes would duplicate one documentation page. The specific
reason is carried in the message.

- **Captures the broken value.** The full value (capped at 8 KiB so a large ConfigMap cannot bloat a log
  record) is attached as `meta.capturedData`, following the established `meta` convention used by
  `ResourceNotFoundError` and `IllegalArgumentError`. Pino serialises it into `~/.solo/logs/solo.log`, so it
  survives the cluster teardown that recovery requires and travels with a diagnostics bundle. A whitespace-
  collapsed, 240-char-capped excerpt goes in the message so it is visible in the terminal without keeping a
  multi-KiB YAML blob in the error box.
- **States the recovery path** — delete and recreate the cluster.
- **Points at diagnostics** — `solo deployment diagnostics debug`, plus an explicit ask to open an
  issue/PR with the bundle if the failure is reproducible or looks like a solo bug.
- **Rejects degenerate documents at the point of read**, so defect 2 can no longer defer a corrupt
  ConfigMap into the schema layer.
- Ownership is `Infrastructure` and `retryable: false` — the value is only ever written by solo, so a broken
  one means external corruption, and retrying cannot help.

`readObject()` now returns only genuine objects, honouring its `Promise<object>` signature.

## Proof of fix

Verified end-to-end against a live kind cluster, reading **real Kubernetes ConfigMaps** through the real
K8s client and the real `readObject()` path — not mocks. Four hand-corrupted `remote-config-data` variants
were applied to a throwaway namespace, and the same harness was run on `main` and on this branch.

### What the operator sees (truncated real config, rendered through `SoloLogger.showUserError`)

Before — no code, no capture, no remediation:

```
╭─ ERROR ────────────────────────────────────────────────────────────╮
│ error parsing yaml from key: remote-config-data                    │
╰────────────────────────────────────────────────────────────────────╯
```

After:

```
╭─ ERROR ─────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ [SOLO-1006] Remote configuration data in ConfigMap "solo-remote-config" under key "remote-config-data" is unusable: │
│ the value is not parseable as YAML                                                                                  │
│ Captured value (249 bytes): "clusters: - deployment: performance-tests-deployment dnsBaseDomain: cluster.local      │
│ dnsConsensusNodePattern: network-{nodeAlias}-svc.{namespace}.svc name: one-shot namespace: one-shot history:        │
│ commands:clusters: [ {name: one-shot,"                                                                              │
│   → Inspect the stored value: kubectl get configmap solo-remote-config -n <namespace> -o yaml                       │
│   → The full captured value is recorded in ~/.solo/logs/solo.log                                                    │
│   → Recover by deleting and recreating the cluster: solo one-shot single destroy, then solo one-shot single deploy  │
│   → Collect a diagnostics bundle: solo deployment diagnostics debug                                                 │
│   → If this is reproducible or looks like a solo bug, open an issue or PR with the diagnostics bundle:              │
│   https://github.com/hiero-ledger/solo/issues                                                                       │
│                                                                                                                     │
│ Learn more: https://solo.hiero.org/docs/troubleshooting/errors/config/SOLO-1006/                                    │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

### All four cases

| ConfigMap value | `main` | This branch |
| --- | --- | --- |
| Truncated / partial YAML | `StorageBackendError`, code `(none)`, remediation `(none)`, captured `{}` | `RemoteConfigDataInvalidSoloError` **SOLO-1006** + capture + 5 steps |
| Empty value | `StorageBackendError`, code `(none)`, remediation `(none)`, captured `{}` | `RemoteConfigDataInvalidSoloError` **SOLO-1006** + capture + 5 steps |
| Whitespace-only value | **returned `null`, no error raised** | `RemoteConfigDataInvalidSoloError` **SOLO-1006** + capture + 5 steps |
| Valid config (control) | loads | loads — unchanged |

Raw harness output on `main`, showing the silent `null` for the whitespace-only case:

```
CASE: truncated / partial YAML (hand-corrupted)  [configmap: rc-corrupt]
THROWN class        : StorageBackendError
  code              : (none)
  docs              : (none)
  message           : error parsing yaml from key: remote-config-data
  captured data     : {}
  remediation steps : (none)

CASE: empty data value  [configmap: rc-empty]
THROWN class        : StorageBackendError
  code              : (none)
  docs              : (none)
  message           : data is empty for key: remote-config-data
  captured data     : {}
  remediation steps : (none)

CASE: whitespace-only data value  [configmap: rc-whitespace]
RETURNED (no error): null...
  typeof            : object
  is null           : true
```

And on this branch:

```
CASE: truncated / partial YAML (hand-corrupted)  [configmap: rc-corrupt]
THROWN class        : RemoteConfigDataInvalidSoloError
  code              : SOLO-1006
  docs              : https://solo.hiero.org/docs/troubleshooting/errors/config/SOLO-1006/
  message           : Remote configuration data in ConfigMap "solo-remote-config" under key "remote-config-data" is unusable: the value is not parseable as YAML
Captured value (249 bytes): "clusters: - deployment: performance-tests-deployment ... commands:clusters: [ {name: one-shot,"
  captured data     : {"key":"remote-config-data","capturedData":"clusters:\n  - deployment: performance-tests-deployment\n ...
  remediation steps :
     -> Inspect the stored value: kubectl get configmap solo-remote-config -n <namespace> -o yaml
     -> The full captured value is recorded in ~/.solo/logs/solo.log
     -> Recover by deleting and recreating the cluster: solo one-shot single destroy, then solo one-shot single deploy
     -> Collect a diagnostics bundle: solo deployment diagnostics debug
     -> If this is reproducible or looks like a solo bug, open an issue or PR with the diagnostics bundle: https://github.com/hiero-ledger/solo/issues

CASE: whitespace-only data value  [configmap: rc-whitespace]
THROWN class        : RemoteConfigDataInvalidSoloError
  code              : SOLO-1006
  message           : ... the value is valid YAML but does not describe a configuration object
  captured data     : {"key":"remote-config-data","capturedData":"   \n  \n"}

CASE: valid config (control — must still load)  [configmap: rc-valid]
RETURNED (no error): {"clusters":[{"deployment":"performance-tests-deployment", ...
  typeof            : object
  is null           : false
```

### Capture survives to disk

The `~/.solo/logs/solo.log` pointer in the remediation steps was verified, not assumed — the full value is
present in the log record with newlines intact:

```
$ grep -o 'capturedData[^,]*' ~/.solo/logs/solo.log
capturedData": "clusters:\n  - deployment: performance-tests-deployment\n    dnsBaseDomain: cluster.local\n
    dnsConsensusNodePattern: network-{nodeAlias}-svc.{namespace}.svc\n    name: one-shot\n
    namespace: one-shot\nhistory:\n  commands:clusters: [ {name: one-shot
```

### Automated tests

`test/unit/data/backend/impl/yaml-config-map-storage-backend.test.ts` grows from 7 to 13 cases, covering
every degenerate document shape plus assertions on the code, documentation URL, `meta.capturedData`,
preserved `cause`, all four remediation strings, and the 8 KiB truncation bound.

```
$ npx mocha 'test/unit/data/backend/impl/yaml-config-map-storage-backend.test.ts'
  13 passing
```

Full unit suite after the rebase: **1806 passing, 0 failing**. `npx tsc` and
`eslint` are both clean on the changed files.

## Rebase note (conflicts resolved)

Rebased onto `main` at `de6f94e5`. Two upstream PRs had landed in the meantime:

- **#5316** (`fix: handle parseable-but-partial local config…`) took **SOLO-1005** for
  `INCOMPLETE_LOCAL_CONFIG`. This error is renumbered to **SOLO-1006**; the registry has no duplicate
  codes across all 301 entries. Worth noting for reviewers: #5316 is the *local config file* analogue of
  this change — same failure shape (a partial config that "would silently load as a valid-but-empty
  config and only surface later as a confusing error"), fixed for `~/.solo/local-config.yaml`. This PR is
  the *remote ConfigMap* counterpart. They are complementary, not overlapping.
- **#5565** added a `typeof value !== 'string'` guard to `ConfigMapStorageBackend.readBytes()`, so an
  absent key now throws `StorageBackendError: config map is missing key: …` before `readObject()` runs.
  The empty-value branch here is therefore only reachable for a key that exists with an empty value, and
  its wording was tightened from "the value is missing or empty" to "the value is empty" to match. The
  two changes compose correctly — re-verified against the cluster, including a key-absent case.

`npx tsc --noEmit` and `eslint` are clean, and the full proof was re-run end-to-end against the live
cluster on the rebased commit.

<sub>The proof harness and the throwaway namespace were scratch-only and are not part of this PR; the
namespace was deleted afterwards and no pre-existing deployment state was modified.</sub>

