### PR TITLE
fix: collect local diagnostics when the remote config ConfigMap is absent

### DIFF
--- a/src/commands/node/handlers.ts
+++ b/src/commands/node/handlers.ts
@@ -17,7 +17,7 @@ import {type ComponentId, type Optional, type SoloListr, type SoloListrTask} fro
 import {inject, injectable} from 'tsyringe-neo';
 import {patchInject} from '../../core/dependency-injection/container-helper.js';
 import {CommandHandler} from '../../core/command-handler.js';
-import {type NamespaceName} from '../../types/namespace/namespace-name.js';
+import {NamespaceName} from '../../types/namespace/namespace-name.js';
 import {type ConsensusNode} from '../../core/model/consensus-node.js';
 import {InjectTokens} from '../../core/dependency-injection/inject-tokens.js';
 import {type NodeDestroyContext} from './config-interfaces/node-destroy-context.js';
@@ -140,11 +140,12 @@ export class NodeCommandHandlers extends CommandHandler {
   }
 
   /**
-   * Collects the diagnostics that are available without a cluster connection
-   * (Solo logs and local configuration) and analyzes them. Used as a graceful
-   * fallback for the diagnostics commands when the Kubernetes cluster is not
-   * reachable — either no active context, or a stale context pointing at a
-   * cluster that has been torn down.
+   * Collects the diagnostics that are available without loading the remote
+   * configuration (Solo logs and local configuration) and analyzes them. Used as a
+   * graceful fallback for the diagnostics commands when full remote collection cannot
+   * proceed — either the Kubernetes cluster is not reachable (no active context, or a
+   * stale context pointing at a torn-down cluster), or the deployment's remote config
+   * is absent (for example after the deployment was destroyed, which deletes it).
    */
   private async collectLocalDiagnosticsOnly(argv: ArgvStruct, reason?: string): Promise<boolean> {
     const outputDirectory: string = this.resolveOutputDirectory(argv, constants.SOLO_LOGS_DIR);
@@ -152,9 +153,9 @@ export class NodeCommandHandlers extends CommandHandler {
     const reasonSuffix: string = reason ? ` (${reason})` : '';
     this.logger.showUser(
       chalk.yellow(
-        `\n⚠  No reachable Kubernetes cluster${reasonSuffix}. Collecting locally available\n` +
-          '   diagnostics only (Solo logs and local configuration). Remote consensus node\n' +
-          '   logs cannot be collected without a cluster connection.',
+        `\n⚠  Falling back to local diagnostics only${reasonSuffix}. Collecting the Solo logs\n` +
+          '   and local configuration. Remote consensus node logs and cluster state are not\n' +
+          '   being collected.',
       ),
     );
 
@@ -170,6 +171,74 @@ export class NodeCommandHandlers extends CommandHandler {
 
     this.logger.showUser(chalk.cyan(`\nLocal diagnostics collected to: ${outputDirectory}`));
     return true;
+  }
+
+  /**
+   * Shared preamble for the log-collecting diagnostics commands (`logs`, `all`). Ensures a
+   * deployment is selected in {@link argv} and decides whether full remote collection can run.
+   *
+   * Diagnostics must never hard-fail just because the cluster state is incomplete — they are
+   * most useful precisely when something is broken. Collection degrades to local-only when the
+   * cluster is unreachable, or when the selected deployment's `solo-remote-config` ConfigMap is
+   * absent (for example after the deployment was destroyed, which deletes it) — in either case
+   * loading the remote configuration would throw and abort the whole command.
+   *
+   * @returns the reason to fall back to local-only collection, or undefined to proceed with
+   *   full remote collection.
+   */
+  private async localDiagnosticsFallbackReason(argv: ArgvStruct): Promise<string | undefined> {
+    const reachability: ClusterReachability = await DiagnosticsCollector.isKubeClusterReachable(this.k8Factory);
+    if (!reachability.reachable) {
+      return reachability.reason ?? 'the Kubernetes cluster is not reachable';
+    }
+
+    if (!argv[flags.deployment.name]) {
+      argv[flags.deployment.name] = await this.resolveDeploymentForLogs(argv);
+    }
+
+    const deploymentName: string = String(argv[flags.deployment.name] ?? '');
+    if (deploymentName && !(await this.remoteConfigConfigMapExists(deploymentName))) {
+      return `the '${deploymentName}' deployment has no remote configuration — it may have been destroyed`;
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Best-effort, non-throwing check for whether a deployment's `solo-remote-config` ConfigMap is
+   * present. The namespace and context are resolved from local config only (a read-only lookup);
+   * when the deployment is not held locally it must have been discovered from a live remote scan,
+   * so its ConfigMap exists. Any inability to determine presence is reported as present so the
+   * normal collection path still runs and surfaces the real error rather than hiding it.
+   */
+  private async remoteConfigConfigMapExists(deploymentName: string): Promise<boolean> {
+    await this.localConfig.load();
+
+    let deployment: Deployment;
+    try {
+      deployment = this.localConfig.configuration.deploymentByName(deploymentName);
+    } catch {
+      // Not a locally-known deployment: it was resolved from a live remote-config scan, so it exists.
+      return true;
+    }
+
+    const clusterReference: string | undefined = deployment.clusters.get(0)?.toString();
+    const context: string | undefined = this.localConfig.configuration.clusterRefs.get(clusterReference)?.toString();
+    if (!context) {
+      // Cannot resolve a context for the deployment; let the normal path run and surface any error.
+      return true;
+    }
+
+    try {
+      return await this.k8Factory
+        .getK8(context)
+        .configMaps()
+        .exists(NamespaceName.of(deployment.namespace), constants.SOLO_REMOTE_CONFIGMAP_NAME);
+    } catch {
+      // Presence could not be determined (e.g. a transient API error); assume present so the real
+      // error surfaces through the normal collection path instead of being hidden by a fallback.
+      return true;
+    }
   }
 
   /** ******** Task Lists **********/
@@ -739,13 +808,9 @@ export class NodeCommandHandlers extends CommandHandler {
   public async logs(argv: ArgvStruct): Promise<boolean> {
     argv = addFlagsToArgv(argv, NodeFlags.LOGS_FLAGS);
 
-    const reachability: ClusterReachability = await DiagnosticsCollector.isKubeClusterReachable(this.k8Factory);
-    if (!reachability.reachable) {
-      return await this.collectLocalDiagnosticsOnly(argv, reachability.reason);
-    }
-
-    if (!argv[flags.deployment.name]) {
-      argv[flags.deployment.name] = await this.resolveDeploymentForLogs(argv);
+    const fallbackReason: string | undefined = await this.localDiagnosticsFallbackReason(argv);
+    if (fallbackReason !== undefined) {
+      return await this.collectLocalDiagnosticsOnly(argv, fallbackReason);
     }
 
     const outputDirectory: string = this.resolveOutputDirectory(argv);
@@ -857,14 +922,11 @@ export class NodeCommandHandlers extends CommandHandler {
   public async all(argv: ArgvStruct, excludeSensitiveData: boolean = false): Promise<boolean> {
     argv = addFlagsToArgv(argv, NodeFlags.DIAGNOSTICS_CONNECTIONS);
 
-    const reachability: ClusterReachability = await DiagnosticsCollector.isKubeClusterReachable(this.k8Factory);
-    if (!reachability.reachable) {
-      return await this.collectLocalDiagnosticsOnly(argv, reachability.reason);
+    const fallbackReason: string | undefined = await this.localDiagnosticsFallbackReason(argv);
+    if (fallbackReason !== undefined) {
+      return await this.collectLocalDiagnosticsOnly(argv, fallbackReason);
     }
 
-    if (!argv[flags.deployment.name]) {
-      argv[flags.deployment.name] = await this.resolveDeploymentForLogs(argv);
-    }
     const outputDirectory: string = this.resolveOutputDirectory(argv);
     await this.commandAction(
       argv,

--- a/test/unit/commands/node/handlers-diagnostics-local.test.ts
+++ b/test/unit/commands/node/handlers-diagnostics-local.test.ts
@@ -62,6 +62,17 @@ function makeK8WithListError(listError: Error): K8 {
 }
 
 /**
+ * Builds a K8 stub for a reachable cluster: a current context is set and the API call
+ * answers successfully.
+ */
+function makeReachableK8(): K8 {
+  return {
+    contexts: (): {readCurrent: () => string} => ({readCurrent: (): string => 'kind-solo'}),
+    namespaces: (): {list: () => Promise<unknown[]>} => ({list: (): Promise<unknown[]> => Promise.resolve([])}),
+  } as unknown as K8;
+}
+
+/**
  * A connection-refused error, as produced by the Kubernetes client when the API
  * server cannot be contacted (node network error code, no HTTP status).
  */
@@ -84,6 +95,7 @@ describe('NodeCommandHandlers - diagnostics local fallback', (): void => {
   let analyzeStub: SinonStub;
   let initializeStub: SinonStub;
   let resolveDeploymentForLogsStub: SinonStub;
+  let remoteConfigConfigMapExistsStub: SinonStub;
   let commandActionStub: SinonStub;
   let runDiagnosticsReportStub: SinonStub;
   let defaultK8Stub: SinonStub;
@@ -149,6 +161,13 @@ describe('NodeCommandHandlers - diagnostics local fallback', (): void => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       .stub(NodeCommandHandlers.prototype as any, 'resolveDeploymentForLogs')
       .resolves('should-not-be-called');
+
+    // Default: the deployment's remote config ConfigMap is present, so the reachable path
+    // proceeds with full remote collection. Tests that exercise the absent case override this.
+    remoteConfigConfigMapExistsStub = sinon
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .stub(NodeCommandHandlers.prototype as any, 'remoteConfigConfigMapExists')
+      .resolves(true);
 
     const dummyCollectTask: SoloListrTask<object> = {title: 'collect', task: async (): Promise<void> => {}};
     collectLocalDiagnosticsStub = sinon.stub(DiagnosticsCollector, 'collectLocalDiagnostics').returns(dummyCollectTask);
@@ -238,7 +257,49 @@ describe('NodeCommandHandlers - diagnostics local fallback', (): void => {
     expect(result).to.equal(true);
     expect(collectLocalDiagnosticsStub).to.not.have.been.called;
     expect(resolveDeploymentForLogsStub).to.have.been.calledOnce;
+    // The reachable path confirms the remote config exists before loading it...
+    expect(remoteConfigConfigMapExistsStub).to.have.been.calledOnce;
+    // ...and proceeds with full remote collection when it does.
     expect(initializeStub).to.have.been.calledOnce;
+  });
+
+  it('logs collects local diagnostics when the deployment has no remote config ConfigMap', async (): Promise<void> => {
+    // The cluster is reachable, but the deployment's solo-remote-config ConfigMap is gone
+    // (for example after a `network destroy`, which deletes it). Loading the remote config
+    // would throw, so diagnostics must degrade to local-only collection instead of failing.
+    defaultK8Stub.returns(makeReachableK8());
+    remoteConfigConfigMapExistsStub.resolves(false);
+
+    const argv: ArgvStruct = {
+      _: diagnosticsCommand(DeploymentCommandDefinition.DIAGNOSTICS_LOGS),
+    } as unknown as ArgvStruct;
+
+    const result: boolean = await handlers.logs(argv);
+
+    expect(result).to.equal(true);
+    expect(collectLocalDiagnosticsStub).to.have.been.calledOnce;
+    expect(analyzeStub).to.have.been.calledOnce;
+    // The deployment is resolved and probed, but the remote-config-dependent initialize is skipped.
+    expect(resolveDeploymentForLogsStub).to.have.been.calledOnce;
+    expect(remoteConfigConfigMapExistsStub).to.have.been.calledOnce;
+    expect(initializeStub).to.not.have.been.called;
+  });
+
+  it('all collects local diagnostics when the deployment has no remote config ConfigMap', async (): Promise<void> => {
+    defaultK8Stub.returns(makeReachableK8());
+    remoteConfigConfigMapExistsStub.resolves(false);
+
+    const argv: ArgvStruct = {
+      _: diagnosticsCommand(DeploymentCommandDefinition.DIAGNOSTICS_ALL),
+    } as unknown as ArgvStruct;
+
+    const result: boolean = await handlers.all(argv);
+
+    expect(result).to.equal(true);
+    expect(collectLocalDiagnosticsStub).to.have.been.calledOnce;
+    expect(analyzeStub).to.have.been.calledOnce;
+    expect(remoteConfigConfigMapExistsStub).to.have.been.calledOnce;
+    expect(initializeStub).to.not.have.been.called;
   });
 
   it('report resolves the deployment from local config when the cluster is unreachable', async (): Promise<void> => {
@@ -257,5 +318,107 @@ describe('NodeCommandHandlers - diagnostics local fallback', (): void => {
     // ...and still drive the report with that locally-resolved deployment name.
     expect(runDiagnosticsReportStub).to.have.been.calledOnce;
     expect(runDiagnosticsReportStub.firstCall.args[0].deployment).to.equal('solo-deployment');
+  });
+});
+
+describe('NodeCommandHandlers - remoteConfigConfigMapExists', (): void => {
+  let existsStub: SinonStub;
+  let getK8Stub: SinonStub;
+
+  /**
+   * Builds a NodeCommandHandlers whose local config resolves a deployment to namespace
+   * 'one-shot' / context 'kind-solo', and whose K8 client reports ConfigMap presence via
+   * existsStub. When deploymentPresent is false, the deployment is absent from local config.
+   */
+  function buildHandlers(deploymentPresent: boolean): NodeCommandHandlers {
+    const deployment: object = {
+      namespace: 'one-shot',
+      clusters: {get: (): {toString: () => string} => ({toString: (): string => 'cluster-ref-1'})},
+    };
+    const localConfigStub: LocalConfigRuntimeState = {
+      load: sinon.stub().resolves(),
+      configuration: {
+        deploymentByName: (name: string): object => {
+          if (!deploymentPresent) {
+            throw new Error(`Deployment ${name} not found in local config`);
+          }
+          return deployment;
+        },
+        clusterRefs: {get: (): {toString: () => string} => ({toString: (): string => 'kind-solo'})},
+      },
+    } as unknown as LocalConfigRuntimeState;
+
+    existsStub = sinon.stub().resolves(true);
+    getK8Stub = sinon.stub().returns({configMaps: (): {exists: SinonStub} => ({exists: existsStub})});
+    const k8FactoryStub: K8Factory = {getK8: getK8Stub} as unknown as K8Factory;
+
+    const configManagerStub: ConfigManager = sinon.createStubInstance(
+      class FakeConfigManager {
+        public update(): void {}
+        public getFlag<T>(): T {
+          return '' as unknown as T;
+        }
+      },
+    ) as unknown as ConfigManager;
+
+    const handlers: NodeCommandHandlers = new NodeCommandHandlers(
+      sinon.stub() as unknown as LockManager,
+      configManagerStub,
+      localConfigStub,
+      sinon.stub() as unknown as RemoteConfigRuntimeStateApi,
+      {} as unknown as NodeCommandTasks,
+      {} as unknown as NodeCommandConfigs,
+      k8FactoryStub,
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (handlers as any).logger = makeLoggerStub();
+    return handlers;
+  }
+
+  afterEach((): void => {
+    sinon.restore();
+  });
+
+  it('returns false when the solo-remote-config ConfigMap is absent', async (): Promise<void> => {
+    const handlers: NodeCommandHandlers = buildHandlers(true);
+    existsStub.resolves(false);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result: boolean = await (handlers as any).remoteConfigConfigMapExists('one-shot');
+
+    expect(result).to.equal(false);
+    // The context is resolved from local config and used to probe the correct cluster.
+    expect(getK8Stub).to.have.been.calledWith('kind-solo');
+  });
+
+  it('returns true when the solo-remote-config ConfigMap is present', async (): Promise<void> => {
+    const handlers: NodeCommandHandlers = buildHandlers(true);
+    existsStub.resolves(true);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result: boolean = await (handlers as any).remoteConfigConfigMapExists('one-shot');
+
+    expect(result).to.equal(true);
+  });
+
+  it('returns true (proceeds) when the deployment is not held in local config', async (): Promise<void> => {
+    const handlers: NodeCommandHandlers = buildHandlers(false);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result: boolean = await (handlers as any).remoteConfigConfigMapExists('unknown');
+
+    expect(result).to.equal(true);
+    // A deployment discovered from a live remote scan needs no probe; the cluster is not touched.
+    expect(getK8Stub).to.not.have.been.called;
+  });
+
+  it('returns true (proceeds) when the existence probe fails for a non-404 reason', async (): Promise<void> => {
+    const handlers: NodeCommandHandlers = buildHandlers(true);
+    existsStub.rejects(new Error('transient API error'));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result: boolean = await (handlers as any).remoteConfigConfigMapExists('one-shot');
+
+    expect(result).to.equal(true);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the intermittent CI failure where `deployment diagnostics logs` (and `all` / `debug` / `report`) hard-fails with:

```
ContainerOperationFailedSoloError: Container operation 'Error in downloading logs from nodes' failed:
  failed to read ConfigMap 'solo-remote-config' in namespace 'one-shot'
  caused by: ResourceNotFoundError   (HTTP 404)
```

## Root cause

The diagnostics log-collection commands begin with an `Initialize` task that calls
`remoteConfig.loadAndValidate()`, which reads the deployment's `solo-remote-config` ConfigMap.

Tracing the failing run's `solo.log`, the command that ran immediately before diagnostics was a full
teardown:

```
… → mirror node destroy → consensus node stop → consensus network destroy --force → deployment diagnostics logs  ✗
```

`consensus network destroy` **deletes the `solo-remote-config` ConfigMap** but leaves the namespace in
place. The very next step, `deployment diagnostics logs`, then tries to load that now-deleted ConfigMap
and aborts with a `ResourceNotFoundError` (404).

The failure is "intermittent" only because the collect-diagnostics step sometimes runs while the
deployment is still up (ConfigMap present → succeeds) and sometimes after teardown (ConfigMap gone →
fails). A diagnostics/log-collection command should never hard-fail in a torn-down state — that is
precisely when it is most useful.

## Fix

The handlers already degrade to **local-only diagnostics** when the cluster is unreachable (#4532). This
extends that same graceful-degradation pattern to the "remote config ConfigMap absent" case, in
`src/commands/node/handlers.ts`:

- `localDiagnosticsFallbackReason(argv)` — factors the shared preamble of `logs()` and `all()`
  (reachability probe + deployment resolution) and adds a check: when the resolved deployment's
  `solo-remote-config` ConfigMap is gone, return a reason to fall back instead of attempting to load it.
- `remoteConfigConfigMapExists(deploymentName)` — a best-effort, non-throwing probe that resolves the
  namespace and context from **local config only** (a read-only lookup) and calls the existing
  `configMaps().exists()`. On any uncertainty it reports "present", so a genuine error still surfaces
  through the normal path rather than being hidden behind a silent fallback.
- `logs()` and `all()` now degrade to `collectLocalDiagnosticsOnly` (which still collects **and analyzes
  `solo.log`** — the primary diagnostic value) when either condition holds. This also covers `debug()`
  and `report()`, which route through `all()`.

The user-facing fallback message was generalized so it no longer claims "no reachable cluster" for the
ConfigMap-absent case.

## Testing

- `task build:compile` — clean
- `npx eslint` on the changed files — 0 errors
- Unit tests — `test/unit/commands/node/handlers-diagnostics-local.test.ts` extended and green:
  - `logs`/`all` degrade to local diagnostics when the remote config ConfigMap is absent
  - `logs` still proceeds with full remote collection when the ConfigMap is present
  - direct coverage of `remoteConfigConfigMapExists` (absent → false, present → true,
    deployment-not-local → true, probe-throws → true)

Fixes #5736
