### PR TITLE
fix: install validation podman runtime workflow

### DIFF
--- a/.github/workflows/flow-install-validation-runtime.yaml
+++ b/.github/workflows/flow-install-validation-runtime.yaml
@@ -144,6 +144,18 @@ jobs:
           BREW_PREFIX='/home/linuxbrew/.linuxbrew'
           HELPER_DIRECTORY='/opt/podman-helpers'
 
+          # netavark v2.0.0 only supports nftables. Ensure the kernel module is loaded before any
+          # podman invocation so nftables is available when netavark initialises.
+          sudo modprobe nf_tables
+
+          # The runner image's system podman 4.x may have pre-created the default "podman" network
+          # in /var/lib/containers/storage/network/ with firewall_driver = "iptables". Brew's
+          # podman 6.x shares the same rootful graph root and picks up that stored definition,
+          # passing "iptables" to netavark v2.0.0 — which no longer supports it — regardless of
+          # what containers.conf says. Removing it here forces brew's podman to recreate the
+          # network from scratch using our containers.conf (firewall_driver = "nftables").
+          sudo podman network rm --force podman 2>/dev/null || true
+
           for BINARY in /usr/bin/crun "${BREW_PREFIX}/bin/crun" "${BREW_PREFIX}/bin/conmon"; do
             if [[ -x "${BINARY}" ]]; then
               echo "${BINARY}: $("${BINARY}" --version 2> /dev/null | head -n 1)"
@@ -165,7 +177,14 @@ jobs:
           printf 'unqualified-search-registries = ["docker.io"]\n' |
             sudo tee /etc/containers/registries.conf > /dev/null
 
-          sudo tee /etc/containers/containers.conf > /dev/null << EOF
+          # Write the same config to both the system path and root's user config. The user config
+          # ($HOME/.config/containers/containers.conf → /root/.config/containers/containers.conf)
+          # is the highest-priority source for rootful podman and is never touched by package
+          # managers. Writing only to /etc/containers/containers.conf is not enough: `brew install
+          # podman` overwrites that file during the next step, dropping our firewall_driver setting
+          # and causing netavark v2.0.0 to fall back to iptables — which it no longer supports —
+          # with "Must provide a valid firewall backend, got iptables".
+          CONTAINERS_CONF_CONTENT=$(cat << EOF
           [engine]
           runtime = "crun"
           conmon_path = ["${BREW_PREFIX}/bin/conmon"]
@@ -177,6 +196,10 @@ jobs:
           [network]
           firewall_driver = "nftables"
           EOF
+          )
+          echo "${CONTAINERS_CONF_CONTENT}" | sudo tee /etc/containers/containers.conf > /dev/null
+          sudo mkdir -p /root/.config/containers
+          echo "${CONTAINERS_CONF_CONTENT}" | sudo tee /root/.config/containers/containers.conf > /dev/null
 
       - name: Validate Homebrew Podman Install
         env:


### PR DESCRIPTION
## Description

This PR stabilizes the `Install Validation (Podman Runtime) / Install Validation (Podman Runtime) ` CI.

Two sources caused netavark v2.0.0 (which dropped iptables support) to receive "iptables" as the firewall backend despite containers.conf being set correctly:

1. Pre-existing network definition — the runner's system podman 4.x stores the default podman network in
/var/lib/containers/storage/network/ with firewall_driver = "iptables". Brew's podman 6.x uses the same rootful graph
root and reads that stored value, bypassing containers.conf entirely. Fixed by removing the network before brew runs
so it is recreated fresh.
2. brew install podman overwrites /etc/containers/containers.conf — dropping the firewall_driver = "nftables" setting
written earlier in the step. Fixed by also writing to /root/.config/containers/containers.conf, which rootful podman
reads at highest priority and brew never touches.

### Related Issues

* Closes #5755 
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
