### PR TITLE
fix(dev-node-add): prevent node activeness checks from hanging CI

### DIFF
--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -543,6 +543,13 @@ export class NodeCommandTasks {
     const enableDebugger: boolean = context_.config.debugNodeAlias && status !== NodeStatusCodes.FREEZE_COMPLETE;
     const debugNodeAlias: NodeAlias | undefined = context_.config.debugNodeAlias;
 
+    // When running sequential ACTIVE checks, enforce a shared deadline so the total time
+    // across all nodes is bounded regardless of node count (fixes #5822).
+    const runSequentially: boolean = enableDebugger || status === NodeStatusCodes.ACTIVE;
+    const deadlineMs: number | undefined = runSequentially
+      ? Date.now() + constants.NETWORK_NODE_ACTIVE_TOTAL_DEADLINE_MS
+      : undefined;
+
     const subTasks: {
       title: string;
       task: (context_: AnyListrContext, task: SoloListrTaskWrapper<AnyListrContext>) => Promise<void>;
@@ -578,13 +585,12 @@ export class NodeCommandTasks {
               undefined,
               undefined,
               context,
+              deadlineMs,
             );
           },
         };
       },
     );
-
-    const runSequentially: boolean = enableDebugger || status === NodeStatusCodes.ACTIVE;
 
     return task.newListr(subTasks, {
       concurrent: !runSequentially, // ACTIVE checks include SDK readiness through shared AccountManager state.
@@ -604,6 +610,7 @@ export class NodeCommandTasks {
     delay: number = constants.NETWORK_NODE_ACTIVE_DELAY,
     timeout: number = constants.NETWORK_NODE_ACTIVE_TIMEOUT,
     context?: string,
+    deadlineMs?: number,
   ): Promise<PodReference> {
     const podName: PodName = Templates.renderNetworkPodName(nodeAlias);
     const podReference: PodReference = PodReference.of(namespace, podName);
@@ -618,6 +625,13 @@ export class NodeCommandTasks {
     let attempt: number = 0;
     let success: boolean = false;
     while (attempt < maxAttempts) {
+      // Enforce shared deadline across all sequential node checks (fixes #5822)
+      if (deadlineMs !== undefined && Date.now() > deadlineMs) {
+        throw new SoloErrors.system.timeout(
+          `Node '${nodeAlias}' activeness check timed out after exceeding the shared deadline of ${constants.NETWORK_NODE_ACTIVE_TOTAL_DEADLINE_MS}ms (attempt = ${attempt}/${maxAttempts})`,
+        );
+      }
+
       const controller: AbortController = new AbortController();
 
       const timeoutId: NodeJS.Timeout = setTimeout((): void => {
@@ -726,9 +740,11 @@ export class NodeCommandTasks {
       await sleep(Duration.ofMillis(constants.NETWORK_NODE_GRPC_READINESS_DELAY));
     }
 
-    this.logger.showUser(
-      `node '${nodeAlias}' failed gRPC readiness check ` +
-        `[ attempt = ${chalk.blueBright(`${attempt}/${constants.NETWORK_NODE_GRPC_READINESS_MAX_ATTEMPTS}`)} ]`,
+    throw new SoloErrors.component.nodeNotReady(
+      nodeAlias,
+      'gRPC readiness',
+      attempt,
+      constants.NETWORK_NODE_GRPC_READINESS_MAX_ATTEMPTS,
     );
   }
 

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -464,6 +464,8 @@ export const NETWORK_NODE_ACTIVE_MAX_ATTEMPTS: number =
   +getEnvironmentVariable('NETWORK_NODE_ACTIVE_MAX_ATTEMPTS') || 300;
 export const NETWORK_NODE_ACTIVE_DELAY: number = +getEnvironmentVariable('NETWORK_NODE_ACTIVE_DELAY') || 1000;
 export const NETWORK_NODE_ACTIVE_TIMEOUT: number = +getEnvironmentVariable('NETWORK_NODE_ACTIVE_TIMEOUT') || 1000;
+export const NETWORK_NODE_ACTIVE_TOTAL_DEADLINE_MS: number =
+  +getEnvironmentVariable('NETWORK_NODE_ACTIVE_TOTAL_DEADLINE_MS') || 600_000; // 10 minutes
 
 // GRPC Healtcheck Checks
 export const NETWORK_NODE_GRPC_READINESS_MAX_ATTEMPTS: number =

--- a/test/unit/commands/node/check-node-activeness-deadline.test.ts
+++ b/test/unit/commands/node/check-node-activeness-deadline.test.ts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {expect} from 'chai';
+import {afterEach, beforeEach, describe, it} from 'mocha';
+import sinon from 'sinon';
+import {container} from 'tsyringe-neo';
+
+import {NodeCommandTasks} from '../../../../src/commands/node/tasks.js';
+import {InjectTokens} from '../../../../src/core/dependency-injection/inject-tokens.js';
+import {NodeStatusCodes} from '../../../../src/core/enumerations.js';
+import {SoloErrors} from '../../../../src/core/errors/solo-errors.js';
+import {NamespaceName} from '../../../../src/types/namespace/namespace-name.js';
+import {type SoloLogger} from '../../../../src/core/logging/solo-logger.js';
+import {type NetworkNodes} from '../../../../src/core/network-nodes.js';
+import {type AccountManager} from '../../../../src/core/account-manager.js';
+
+describe('NodeCommandTasks node activeness and gRPC readiness', (): void => {
+  let nodeCommandTasks: NodeCommandTasks;
+  let loggerStub: SoloLogger;
+  let networkNodesStub: NetworkNodes;
+  let accountManagerStub: AccountManager;
+  let containerStub: sinon.SinonStub;
+
+  beforeEach((): void => {
+    loggerStub = {
+      debug: sinon.stub(),
+      warn: sinon.stub(),
+      showUser: sinon.stub(),
+      error: sinon.stub(),
+      info: sinon.stub(),
+    } as unknown as SoloLogger;
+
+    networkNodesStub = {
+      getNetworkNodePodStatus: sinon.stub(),
+    } as unknown as NetworkNodes;
+
+    accountManagerStub = {
+      refreshNodeClient: sinon.stub(),
+    } as unknown as AccountManager;
+
+    containerStub = sinon.stub(container, 'resolve');
+    containerStub.withArgs(InjectTokens.NetworkNodes).returns(networkNodesStub);
+
+    nodeCommandTasks = Object.create(NodeCommandTasks.prototype) as NodeCommandTasks;
+    (nodeCommandTasks as any).logger = loggerStub;
+    (nodeCommandTasks as any).accountManager = accountManagerStub;
+    (nodeCommandTasks as any).remoteConfig = {
+      getConsensusNodes: sinon.stub().returns([{name: 'node1'}]),
+      getClusterRefs: sinon.stub().returns({}),
+    };
+    (nodeCommandTasks as any).configManager = {
+      getFlag: sinon.stub().returns('deployment'),
+    };
+  });
+
+  afterEach((): void => {
+    sinon.restore();
+  });
+
+  it('should abort early if shared deadline expires during checkNetworkNodeActiveness', async (): Promise<void> => {
+    // Make it always return UNKNOWN or empty so it keeps looping
+    (networkNodesStub.getNetworkNodePodStatus as sinon.SinonStub).resolves('');
+
+    const taskWrapper: any = {
+      title: '',
+    };
+
+    const maxAttempts: number = 300;
+    const delay: number = 10;
+    const timeout: number = 10;
+
+    // Set a deadline that expires immediately
+    const deadlineMs: number = Date.now() - 1000;
+
+    try {
+      await nodeCommandTasks.checkNetworkNodeActiveness(
+        NamespaceName.of('test'),
+        'node1',
+        taskWrapper,
+        'title',
+        NodeStatusCodes.ACTIVE,
+        maxAttempts,
+        delay,
+        timeout,
+        'context',
+        deadlineMs,
+      );
+      expect.fail('Should have thrown an error');
+    } catch (error: any) {
+      expect(error).to.be.instanceOf(SoloErrors.system.timeout);
+      expect(error.message).to.include('activeness check timed out after exceeding the shared deadline');
+    }
+
+    // Verify it aborted immediately rather than doing 300 attempts
+    // We removed the warn log in favor of explicit throw, so no log check is needed.
+  });
+
+  it('waitForGrpcReadiness should throw NodeNotReadySoloError if it fails all attempts', async (): Promise<void> => {
+    // Make refreshNodeClient always throw to simulate failure
+    (accountManagerStub.refreshNodeClient as sinon.SinonStub).rejects(new Error('Connection refused'));
+
+    const taskWrapper: any = {
+      title: '',
+    };
+
+    // Fast-forward sleep so we don't actually wait 20s during the test
+    const clock = sinon.useFakeTimers();
+
+    const promise = (nodeCommandTasks as any).waitForGrpcReadiness(
+      NamespaceName.of('test'),
+      'node1',
+      taskWrapper,
+      'title',
+    );
+
+    // Tick the clock 25 times to ensure all 20 attempts exhaust
+    for (let index = 0; index < 25; index++) {
+      await clock.tickAsync(1000);
+    }
+
+    try {
+      await promise;
+      expect.fail('Should have thrown an error');
+    } catch (error: any) {
+      expect(error).to.be.instanceOf(SoloErrors.component.nodeNotReady);
+      expect(error.message).to.include("Node 'node1' is not gRPC readiness [attempt = ");
+    }
+  });
+});


### PR DESCRIPTION
#5822 
## Summary
#5822 

Fixes an issue where the **Node Add Local** E2E test could run until GitHub Actions' 30-minute timeout instead of failing cleanly.

The issue was caused by sequential node activeness checks taking too long when nodes were unhealthy or slow to become ready. In addition, gRPC readiness failures were being swallowed, allowing the workflow to continue in an invalid state.

## What Changed

* Added a shared **10-minute deadline** for ACTIVE node activeness checks so the overall operation cannot run indefinitely.
* Added explicit `TimeoutSoloError` handling when the shared deadline is exceeded.
* Updated `waitForGrpcReadiness` to throw `NodeNotReadySoloError` when readiness attempts are exhausted instead of silently continuing.
* Added regression tests covering both the activeness timeout and gRPC readiness failure scenarios.

## Validation

The affected test suite passes successfully:

```text
npx mocha "test/unit/commands/node/**/*.ts"

  36 passing
```

Linting completed with no errors:

```text
npx eslint "src/commands/node/tasks.ts" \
  "src/core/constants.ts" \
  "test/unit/commands/node/check-node-activeness-deadline.test.ts"

0 errors
```

Compilation also completed successfully:

```text
task build:compile

Build completed successfully
```

And the final diff check is clean:

```text
git diff --check

No issues found
```

## Result

Instead of waiting for the CI runner to terminate the E2E job with `exit status 143`, Solo now fails the node activeness check deterministically with a clear error when the deadline or readiness condition is not met.
