### PR TITLE
fix: surface PVC mount diagnostics on pod readiness timeout

### DIFF
--- a/src/core/errors/classes/system/pod-not-ready-solo-error.ts
+++ b/src/core/errors/classes/system/pod-not-ready-solo-error.ts
@@ -18,17 +18,28 @@ export class PodNotReadySoloError extends SoloError {
   protected override readonly retryable: boolean = true;
   protected override readonly ownership: ErrorOwnership = ErrorOwnership.Infrastructure;
 
-  public constructor(podName: string, resource: string, phase: string, containerSummary: string, cause?: Error) {
+  public constructor(
+    podName: string,
+    resource: string,
+    phase: string,
+    containerSummary: string,
+    cause?: Error,
+    volumeMountDiagnostic?: string,
+  ) {
     super(
       {
         message:
           `Pod ${podName} matched ${resource} but did not become ready before the timeout` +
-          ` [phase: ${phase ?? 'Unknown'}${containerSummary ? `; containers: ${containerSummary}` : ''}]`,
+          ` [phase: ${phase ?? 'Unknown'}${containerSummary ? `; containers: ${containerSummary}` : ''}]` +
+          (volumeMountDiagnostic ? ` [volume mount diagnostic: ${volumeMountDiagnostic}]` : ''),
         code: ErrorCodeRegistry.POD_NOT_READY,
         troubleshootingSteps:
           'Describe the pod for probe failures and events: kubectl describe pod -n <namespace> <podName>\n' +
           'Check container logs, including the previous run: kubectl logs -n <namespace> <podName> --previous\n' +
           'If the readiness probe checks a dependency (e.g. a mirror node or database), verify that dependency is healthy\n' +
+          (volumeMountDiagnostic
+            ? 'Check PVC/PV binding and volume attach events: kubectl get pvc -n <namespace>; kubectl describe pvc -n <namespace> <pvcName>\n'
+            : '') +
           'Review solo logs: tail -n 100 ~/.solo/logs/solo.log',
       },
       cause,

--- a/src/core/errors/kube-error-translator.ts
+++ b/src/core/errors/kube-error-translator.ts
@@ -31,6 +31,7 @@ export class KubeErrorTranslator {
         error.phase,
         error.containerSummary,
         error,
+        error.volumeMountDiagnostic,
       );
     }
     if (error instanceof KubeContainerOperationFailedError) {

--- a/src/integration/kube/errors/kube-pod-not-ready-error.ts
+++ b/src/integration/kube/errors/kube-pod-not-ready-error.ts
@@ -15,19 +15,28 @@ export class KubePodNotReadyError extends KubeError {
   public readonly podName: string;
   public readonly phase: string;
   public readonly containerSummary: string;
+  public readonly volumeMountDiagnostic: string | undefined;
 
-  public constructor(resource: string, podName: string, phase: string, containerStatuses: ContainerStatus[] = []) {
+  public constructor(
+    resource: string,
+    podName: string,
+    phase: string,
+    containerStatuses: ContainerStatus[] = [],
+    volumeMountDiagnostic?: string,
+  ) {
     const containerSummary: string = KubePodNotReadyError.summarizeContainers(containerStatuses);
     super(
       `Pod ${podName} matched ${resource} but did not reach the required state before the timeout` +
-        ` [phase: ${phase ?? 'Unknown'}${containerSummary ? `; containers: ${containerSummary}` : ''}]`,
+        ` [phase: ${phase ?? 'Unknown'}${containerSummary ? `; containers: ${containerSummary}` : ''}]` +
+        (volumeMountDiagnostic ? ` [volume mount diagnostic: ${volumeMountDiagnostic}]` : ''),
       undefined,
-      {resource, podName, phase, containerSummary},
+      {resource, podName, phase, containerSummary, volumeMountDiagnostic},
     );
     this.resource = resource;
     this.podName = podName;
     this.phase = phase;
     this.containerSummary = containerSummary;
+    this.volumeMountDiagnostic = volumeMountDiagnostic;
   }
 
   private static summarizeContainers(containerStatuses: ContainerStatus[]): string {

--- a/src/integration/kube/k8-client/resources/pod/k8-client-pods.ts
+++ b/src/integration/kube/k8-client/resources/pod/k8-client-pods.ts
@@ -10,9 +10,11 @@ import {
   V1ExecAction,
   V1ObjectMeta,
   V1Pod,
+  type V1PersistentVolumeClaimList,
   type V1PodList,
   V1PodSpec,
   V1Probe,
+  type V1Volume,
 } from '@kubernetes/client-node';
 import {type Pods} from '../../../resources/pod/pods.js';
 import {NamespaceName} from '../../../../../types/namespace/namespace-name.js';
@@ -57,6 +59,15 @@ export class K8ClientPods extends K8ClientBase implements Pods {
    * Terminated reasons for container states that are non-recoverable (e.g. out-of-memory kill).
    */
   private static readonly FATAL_TERMINATED_REASONS: ReadonlySet<string> = new Set(['OOMKilled']);
+
+  /**
+   * Event reasons that indicate a stuck volume attach/mount rather than an application-level
+   * startup failure (e.g. a slow or stuck storage backend on the node).
+   */
+  private static readonly VOLUME_MOUNT_EVENT_REASONS: ReadonlySet<string> = new Set([
+    'FailedMount',
+    'FailedAttachVolume',
+  ]);
 
   private static readonly FATAL_ERROR_RETRY_THRESHOLD: number = 3;
 
@@ -166,6 +177,63 @@ export class K8ClientPods extends K8ClientBase implements Pods {
       return false;
     }
     return K8ClientPods.NON_RECOVERABLE_IMAGE_PULL_PATTERNS.some((pattern): boolean => pattern.test(message));
+  }
+
+  /**
+   * Best-effort diagnostic for a pod that never reached the required state: inspects the
+   * PersistentVolumeClaims the pod depends on and any FailedMount/FailedAttachVolume events, so a
+   * stuck or slow volume attach/mount (e.g. an mdadm-backed storage class with variable RAID
+   * resync latency) is distinguishable from a generic readiness timeout. Returns undefined when
+   * the pod has no PVC-backed volumes or nothing anomalous is found.
+   */
+  private async buildVolumeMountDiagnostic(
+    namespace: NamespaceName,
+    pod: V1Pod | undefined,
+  ): Promise<string | undefined> {
+    const claimNames: string[] = (pod?.spec?.volumes ?? [])
+      .map((volume: V1Volume): string | undefined => volume.persistentVolumeClaim?.claimName)
+      .filter(Boolean);
+
+    if (claimNames.length === 0) {
+      return undefined;
+    }
+
+    const diagnosticParts: string[] = [];
+
+    try {
+      const pvcList: V1PersistentVolumeClaimList = await this.kubeClient.listNamespacedPersistentVolumeClaim({
+        namespace: namespace.name,
+      });
+      for (const pvc of pvcList.items ?? []) {
+        const pvcName: string = pvc.metadata?.name ?? '';
+        const phase: string = pvc.status?.phase ?? 'Unknown';
+        if (claimNames.includes(pvcName) && phase !== 'Bound') {
+          diagnosticParts.push(`PVC "${pvcName}" is ${phase}`);
+        }
+      }
+    } catch {
+      // best-effort diagnostic only; a PVC lookup failure must not mask the original readiness timeout
+    }
+
+    try {
+      const eventList: {items?: CoreV1Event[]} = await this.kubeClient.listNamespacedEvent({
+        namespace: namespace.name,
+      });
+      const relevantNames: ReadonlySet<string> = new Set([pod?.metadata?.name ?? '', ...claimNames]);
+      const volumeEvents: CoreV1Event[] = (eventList.items ?? []).filter(
+        (event: CoreV1Event): boolean =>
+          K8ClientPods.VOLUME_MOUNT_EVENT_REASONS.has(event.reason ?? '') &&
+          relevantNames.has(event.involvedObject?.name ?? ''),
+      );
+      const latestEvent: CoreV1Event | undefined = volumeEvents.at(-1);
+      if (latestEvent) {
+        diagnosticParts.push(`event ${latestEvent.reason}: ${latestEvent.message ?? ''}`);
+      }
+    } catch {
+      // best-effort diagnostic only; an event lookup failure must not mask the original readiness timeout
+    }
+
+    return diagnosticParts.length > 0 ? diagnosticParts.join('; ') : undefined;
   }
 
   public readByReference(podReference: PodReference | null): Pod {
@@ -348,6 +416,9 @@ export class K8ClientPods extends K8ClientBase implements Pods {
       // Newest eligible pod seen on the most recent successful list, so a timeout can report
       // "found but never ready" instead of the misleading "no pod found".
       let lastObservedPod: Pod | undefined;
+      // Raw pod alongside lastObservedPod, kept only for its spec.volumes (the Pod wrapper does
+      // not retain it) so a timeout can inspect which PVCs the pod depends on.
+      let lastObservedRawPod: V1Pod | undefined;
       const fatalErrorStreakByPod: Map<string, {count: number; error: string}> = new Map<
         string,
         {count: number; error: string}
@@ -439,6 +510,7 @@ export class K8ClientPods extends K8ClientBase implements Pods {
                 this.kubectlInstallationDirectory,
               );
               lastObservedPod = pod;
+              lastObservedRawPod = newestItem;
               if (phases.has(newestItem.status?.phase) && (!podItemPredicate || podItemPredicate(pod))) {
                 return resolve([pod]);
               }
@@ -451,12 +523,17 @@ export class K8ClientPods extends K8ClientBase implements Pods {
         if (++attempts < maxAttempts) {
           setTimeout((): Promise<void> => check(resolve, reject), delay);
         } else if (lastObservedPod) {
+          const volumeMountDiagnostic: string | undefined = await this.buildVolumeMountDiagnostic(
+            namespace,
+            lastObservedRawPod,
+          );
           return reject(
             new KubePodNotReadyError(
               `labels:${labelSelector}`,
               lastObservedPod.podReference?.name?.toString() ?? '<unknown>',
               lastObservedPod.phase,
               lastObservedPod.allContainerStatuses ?? [],
+              volumeMountDiagnostic,
             ),
           );
         } else {

--- a/test/unit/integration/kube/k8-client-pods-wait-timeout.test.ts
+++ b/test/unit/integration/kube/k8-client-pods-wait-timeout.test.ts
@@ -21,6 +21,7 @@ interface RawPodFixture {
   };
   readonly spec: {
     readonly containers: {readonly name: string}[];
+    readonly volumes?: {readonly name: string; readonly persistentVolumeClaim?: {readonly claimName: string}}[];
   };
   readonly status: {
     phase?: string;
@@ -46,14 +47,45 @@ function buildUnreadyRunningPod(): RawPodFixture {
   };
 }
 
+/** A pod stuck in Pending whose only volume is a PersistentVolumeClaim that never binds. */
+function buildPendingPodWithPvcVolume(): RawPodFixture {
+  return {
+    metadata: {
+      name: 'network-node1-0',
+      namespace: 'solo',
+      creationTimestamp: new Date(),
+    },
+    spec: {
+      containers: [{name: 'root-container'}],
+      volumes: [{name: 'data', persistentVolumeClaim: {claimName: 'hgcapp-data-saved-network-node1-0'}}],
+    },
+    status: {
+      phase: 'Pending',
+      containerStatuses: [],
+    },
+  };
+}
+
 describe('K8ClientPods wait timeout errors', (): void => {
   let listNamespacedPodStub: SinonStub;
+  let listNamespacedPersistentVolumeClaimStub: SinonStub;
+  let listNamespacedEventStub: SinonStub;
   let pods: K8ClientPods;
 
   beforeEach((): void => {
     resetForTest();
     listNamespacedPodStub = sinon.stub();
-    pods = new K8ClientPods({listNamespacedPod: listNamespacedPodStub} as never, {} as never, '');
+    listNamespacedPersistentVolumeClaimStub = sinon.stub().resolves({items: []});
+    listNamespacedEventStub = sinon.stub().resolves({items: []});
+    pods = new K8ClientPods(
+      {
+        listNamespacedPod: listNamespacedPodStub,
+        listNamespacedPersistentVolumeClaim: listNamespacedPersistentVolumeClaimStub,
+        listNamespacedEvent: listNamespacedEventStub,
+      } as never,
+      {} as never,
+      '',
+    );
   });
 
   afterEach((): void => {
@@ -109,6 +141,53 @@ describe('K8ClientPods wait timeout errors', (): void => {
     }
   });
 
+  it('waitForRunningPhase includes a PVC/event diagnostic when the pod is stuck on an unbound volume', async (): Promise<void> => {
+    listNamespacedPodStub.resolves({items: [buildPendingPodWithPvcVolume()]});
+    listNamespacedPersistentVolumeClaimStub.resolves({
+      items: [{metadata: {name: 'hgcapp-data-saved-network-node1-0'}, status: {phase: 'Pending'}}],
+    });
+    listNamespacedEventStub.resolves({
+      items: [
+        {
+          reason: 'FailedMount',
+          involvedObject: {name: 'hgcapp-data-saved-network-node1-0'},
+          message: 'MountVolume.SetUp failed for volume "pvc-1234" : mount failed: exit status 32',
+        },
+      ],
+    });
+
+    try {
+      await pods.waitForRunningPhase(NamespaceName.of('solo'), ['app.kubernetes.io/name=network-node'], 2, 0);
+      expect.fail('Expected waitForRunningPhase to reject');
+    } catch (error: Error | unknown) {
+      expect(error).to.be.instanceOf(KubePodNotReadyError);
+      const notReadyError: KubePodNotReadyError = error as KubePodNotReadyError;
+      expect(notReadyError.volumeMountDiagnostic).to.include('hgcapp-data-saved-network-node1-0" is Pending');
+      expect(notReadyError.volumeMountDiagnostic).to.include('event FailedMount: MountVolume.SetUp failed');
+      expect(notReadyError.message).to.include('volume mount diagnostic');
+    }
+  });
+
+  it('waitForRunningPhase omits the diagnostic when the pod has no PVC-backed volumes', async (): Promise<void> => {
+    listNamespacedPodStub.resolves({items: [buildUnreadyRunningPod()]});
+
+    try {
+      await pods.waitForRunningPhase(
+        NamespaceName.of('solo'),
+        ['app.kubernetes.io/name=relay'],
+        2,
+        0,
+        (): boolean => false,
+      );
+      expect.fail('Expected waitForRunningPhase to reject');
+    } catch (error: Error | unknown) {
+      expect(error).to.be.instanceOf(KubePodNotReadyError);
+      expect((error as KubePodNotReadyError).volumeMountDiagnostic).to.be.undefined;
+      expect(listNamespacedPersistentVolumeClaimStub).to.not.have.been.called;
+      expect(listNamespacedEventStub).to.not.have.been.called;
+    }
+  });
+
   it('KubeErrorTranslator maps KubePodNotReadyError to PodNotReadySoloError with the pod details', (): void => {
     const kubeError: KubePodNotReadyError = new KubePodNotReadyError('labels:app=relay', 'relay-1-x', 'Running', [
       {name: 'relay', ready: false, restartCount: 2, waitingReason: 'CrashLoopBackOff'},
@@ -120,5 +199,20 @@ describe('K8ClientPods wait timeout errors', (): void => {
     expect(translated.message).to.include('relay-1-x');
     expect(translated.message).to.include('phase: Running');
     expect(translated.message).to.include('waiting: CrashLoopBackOff');
+  });
+
+  it('KubeErrorTranslator forwards the volume mount diagnostic to PodNotReadySoloError', (): void => {
+    const kubeError: KubePodNotReadyError = new KubePodNotReadyError(
+      'labels:app=network-node',
+      'network-node1-0',
+      'Pending',
+      [],
+      'PVC "hgcapp-data-saved-network-node1-0" is Pending; event FailedMount: mount failed: exit status 32',
+    );
+
+    const translated: SoloError | undefined = KubeErrorTranslator.tryTranslate(kubeError);
+
+    expect(translated.message).to.include('volume mount diagnostic');
+    expect(translated.message).to.include('hgcapp-data-saved-network-node1-0" is Pending');
   });
 });


### PR DESCRIPTION
## Description

This pull request changes the following:

* When a pod fails to reach the ready state before Solo's readiness-wait timeout, `K8ClientPods.waitForRunningPhase` now inspects the PersistentVolumeClaims the pod depends on (via `pod.spec.volumes[].persistentVolumeClaim.claimName`) and any `FailedMount`/`FailedAttachVolume` Kubernetes events, and surfaces the result as a `volumeMountDiagnostic` on `KubePodNotReadyError` and `PodNotReadySoloError`.
* This distinguishes a stuck or slow volume attach/mount (e.g. an mdadm-backed storage class with variable RAID resync latency, as seen intermittently on Latitude.sh bare-metal clusters) from a generic pod-readiness timeout, so the error message and troubleshooting steps point at the volume subsystem instead of leaving the user with an unexplained timeout.
* The lookup is best-effort: any PVC/event API failure is swallowed and the original readiness timeout still surfaces unmodified. When the pod has no PVC-backed volumes, no extra API calls are made and the diagnostic is `undefined`.

### Related Issues

* Closes #5842

### Pull request (PR) checklist

* [x] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [ ] Any technical debt has been documented as a separate issue and linked to this PR
* [ ] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [x] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [ ] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* N/A — this is a diagnostics-only change to an existing timeout path; verified via unit tests in `test/unit/integration/kube/k8-client-pods-wait-timeout.test.ts` covering both the diagnostic-present and diagnostic-absent cases, plus `task build`/`task format`/full unit test suite.

The following was not tested:

* Manual reproduction against a real Latitude.sh cluster with an mdadm-backed storage class was not performed (no such cluster available in this session); the fix was validated against mocked Kubernetes API responses only.

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
