### PR TITLE
fix: use pre-installed task binary instead of npx @go-task/cli

### DIFF
--- a/scripts/docs/wrapper-for-command-output.ts
+++ b/scripts/docs/wrapper-for-command-output.ts
@@ -19,7 +19,17 @@ async function runCommandOutput(): Promise<void> {
   }
 
   console.log(chalk.cyan('ℹ Running task build:compile'));
-  await run('npx @go-task/cli build:compile');
+  // Invoke the `task` binary that the workflow's "Install Task" step (arduino/setup-task) already put on
+  // PATH, instead of `npx @go-task/cli`. This script only ever runs inside a `task build:solo:command:output`
+  // invocation (see docs/site/Taskfile.yaml), so `task` is guaranteed to be resolvable here. `npx` bypassed
+  // that pre-installed binary and made npm resolve, fetch, and postinstall a brand-new copy of `@go-task/cli`
+  // (plus its `jszip`/`proxy-agent`/`tar` dependencies) from the registry on every single run, right after the
+  // job's own `npm ci` had just finished hammering the runner's npm cache/network path. Any transient registry
+  // hiccup during that redundant fetch failed the whole step with a bare "exit code 1" and no diagnostic
+  // output, because `run()` only reports the exit code and npx installs run at a suppressed log level, so the
+  // underlying npm error never reached the CI log (see #5850 / #5852). Using the pre-installed binary removes
+  // the extra network round-trip entirely, eliminating that flake surface.
+  await run('task build:compile');
 
   console.log(chalk.cyan('ℹ Installing and linking @hiero-ledger/solo'));
   await run('npx cross-env SOLO_NO_CACHE=true npm install -g @hiero-ledger/solo');


### PR DESCRIPTION
## Description

This pull request changes the following:

* `scripts/docs/wrapper-for-command-output.ts` now invokes `task build:compile` directly instead of
  `npx @go-task/cli build:compile`, so the CI "Docs Automation / Command Output" job's "Solo Command
  Output" step uses the `task` binary the workflow already installs via `arduino/setup-task` in its
  "Install Task" step, rather than making npx resolve, fetch, and postinstall a brand-new copy of
  `@go-task/cli` from the npm registry on every run.

### Why this is needed

#5850 reported this step failing intermittently with a bare `Command failed: npx @go-task/cli
build:compile (exit code 1)` and no further detail. #5852 traced the failure to the CI job itself
(the earlier `NoDeploymentsFoundError` cited in #5850 comes from an unrelated, expected-to-fail
diagnostics step later in the same job and is a red herring).

Digging into *why* the npx invocation only fails intermittently rather than every time:

* This script is only ever invoked from `docs/site/Taskfile.yaml`'s `build:solo:command:output`
  target when `SOLO_CI=true`, i.e. it always runs inside an already-running `task` process. The
  `task` binary is therefore guaranteed to already be on `PATH` — the `npx @go-task/cli` call was
  pure redundancy, not a fallback for a missing binary. (The `else` branch of the same Taskfile
  target, used for local/non-CI runs, already calls `task build:compile` directly — CI was the only
  path still going through npx.)
* Because it's *not* a project dependency, `npx @go-task/cli` has no local cache to fall back on: it
  resolves and fetches `@go-task/cli` plus its `jszip`/`proxy-agent`/`tar` dependencies from the npm
  registry fresh on every single run — immediately after the job's own `npm ci` had just finished
  pulling 957 packages and stressing the runner's npm cache/network path.
* I pulled `@go-task/cli@3.53.1`'s actual `install.js`: its postinstall script downloads the real Go
  binary from `github.com/go-task/task/releases/...` and logs `Downloading ...` / throws descriptive
  errors (`HTTP ${statusCode}`, `Extraction failed`, checksum mismatch, etc.) on failure. In the
  failing run's log ([job #95771429834](https://github.com/hiero-ledger/solo/actions/runs/32155395145/job/95771429834)),
  none of that postinstall output ever appears — the log jumps straight from `npm warn exec: ...
  will be installed` to the wrapper's terminal error, ~1.4s later, with nothing in between. That
  means the failure happened during npm's own package resolution/fetch of `@go-task/cli` itself
  (a transient registry blip), not during the Go-binary download — and it's exactly the kind of
  failure that only shows up under registry/network pressure, which is why it's intermittent rather
  than deterministic.
* `run()` in `scripts/docs/utilities.ts` only surfaces the child process's exit code on failure, and
  `npx` installs run at a suppressed log level by default, so the underlying npm error text never
  reached the CI log — making this genuinely hard to diagnose from the job log alone.

Removing the `npx` call entirely (this PR) eliminates the redundant network round-trip and the flake
surface it created, regardless of which specific registry hiccup caused any individual failure.

### Related Issues

* Closes #5852
* Related to #5850

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[x] This PR added no TODOs or commented out code
* \[x] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[x] All related issues have been linked to this PR
* \[x] All changes in this PR are included in the description
* \[x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[x] These changes required manual testing that is documented below
* \[x] Anything not tested is documented

The following manual testing was done:

* Ran `task format` and `task build` locally to confirm the repo still lints and compiles cleanly
  with the change.
* This is a one-line change to a CI-only script (only exercised when `SOLO_CI=true`); the real
  validation is watching the "Docs Automation / Command Output" job succeed on this PR's own CI run.

The following was not tested:

* The specific transient npm-registry failure mode itself is not reproducible on demand — it depends
  on registry/network conditions at the moment `npx` runs, which is the whole point of this fix (the
  redundant network call is removed rather than retried).

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
