### PR TITLE
fix: pin the busybox init container image in the one-shot deploy override

### DIFF
--- a/src/commands/one-shot/orchestrator/deploy/deploy-argv-builders.ts
+++ b/src/commands/one-shot/orchestrator/deploy/deploy-argv-builders.ts
@@ -205,7 +205,10 @@ export class DeployArgvBuilders {
         initContainers: [
           {
             name: 'init-storage-dirs',
-            image: 'busybox',
+            // Pinned rather than tracking the block node chart's floating `busybox` default, so the
+            // override cannot pull a different image on a later deploy without a code change. Matches
+            // the tag used by the block node's other init container and already in the image cache.
+            image: 'busybox:1.36.1',
             command: [
               'sh',
               '-c',

--- a/test/unit/business/runtime-state/remote-config-runtime-state.test.ts
+++ b/test/unit/business/runtime-state/remote-config-runtime-state.test.ts
@@ -113,6 +113,7 @@ describe('RemoteConfigRuntimeState', (): void => {
       configManager,
       {} as unknown as RemoteConfigValidatorApi,
       {} as unknown as ObjectMapper,
+      {resumeStoppedClusterNode} as unknown as ContainerEngineClient,
     );
   }
 


### PR DESCRIPTION
## Description

This pull request changes the following:

* Pins the `init-storage-dirs` init container image in the one-shot deploy override from the floating `busybox` to `busybox:1.36.1`.
* Fixes a `RemoteConfigRuntimeState` unit test that hung for 20s and failed on Windows CI.

This override reconstructs the block node chart's `init-storage-dirs` container in order to extend its command with the RSA bootstrap file write (Helm replaces list values entirely, so the whole container has to be restated). It inherited the chart's floating `busybox` default, which means the image can change on any deploy with no code change on either side — the supply-chain risk the repository's "Pin All Container Image Tags" rule exists to prevent.

`1.36.1` is the tag already used by the other busybox init container in `src/commands/block-node.ts`, and it is already listed in `resources/config/solo-cache-images-target.yaml`, so the pinned image is cache-warm and this introduces no new pull.

Note that `resources/config/solo-cache-images-target.yaml` still prepulls `docker.io/library/busybox:latest` alongside `1.36.1`, and that entry is deliberately left in place: the block node chart's own default (`charts/block-node-server/values.yaml`) is still a floating `busybox`, so deploys that do not take this override path continue to resolve `latest`.

The `Unit Tests / windows-2022` job on this PR failed on `test/unit/business/runtime-state/remote-config-runtime-state.test.ts`'s "leaves an unrelated load failure untouched on a kind cluster" test, timing out after mocha's 20s limit. The test's `newRuntimeState` helper omitted the constructor's `containerEngine` argument, so `patchInject` fell back to resolving the real `DockerClient` from the DI container instead of using the `resumeStoppedClusterNode` stub already declared in the file (and used by the file's other helper, `buildRuntimeState`). That path is only exercised when the simulated ConfigMap read fails with a generic error on a `kind-` context, which this test does. On Windows CI, without Docker installed, that real call hangs until the test times out; on macOS/Linux it happens to fail fast enough not to be noticed. The fix passes the same stub into the constructor so the test no longer depends on the real Docker client.

### Related Issues

* N/A — drive-by fix found while reviewing image pinning during #5876; the test fix is a pre-existing flake this PR's Windows CI run surfaced.

### Pull request (PR) checklist

* [x] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [x] Any technical debt has been documented as a separate issue and linked to this PR
* [x] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

The busybox pin itself adds no tests: it is a one-line change to a pinned image tag with no branching behaviour to cover, and is exercised by the existing one-shot deploy end-to-end tests that take the block node path. The test fix corrects an existing unit test's DI stubbing so it no longer depends on the real Docker client.

### Testing

* [x] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [ ] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following was not tested:

* No manual deploy was run for the busybox pin. `task build` and `task format` are clean, and the pinned tag is confirmed present in the image cache target list.
* The fixed `remote-config-runtime-state.test.ts` was run locally (`npx mocha 'test/unit/business/runtime-state/remote-config-runtime-state.test.ts'`), passing all 10 tests; the Windows-specific timeout could not be reproduced locally, since it depends on Docker being absent from the runner.

### Remaining unpinned image reference

One other mutable tag exists in tracked files and is **not** changed here: `examples/local-build-with-custom-config/init-containers-values.yaml` uses `busybox:stable-musl`. `stable-musl` is a moving alias and should be pinned too, but choosing the replacement needs care — the musl variant is deliberate there, `1.36.1-musl` is not currently in the image cache target list, and the file feeds an example that runs in CI. Worth a follow-up rather than a blind substitution in this PR.