### PR TITLE
feat: add --wraps-copy-parallel to choose how the WRAPs library is copied

### DIFF
--- a/src/commands/flags.ts
+++ b/src/commands/flags.ts
@@ -1211,6 +1211,18 @@ export class Flags {
     prompt: undefined,
   };
 
+  public static readonly wrapsCopyParallel: CommandFlag = {
+    constName: 'wrapsCopyParallel',
+    name: 'wraps-copy-parallel',
+    definition: {
+      describe:
+        'Copy the WRAPs library to all consensus nodes at once instead of one node after another. Faster on large networks, at the cost of running every transfer over the same link simultaneously',
+      defaultValue: false,
+      type: 'boolean',
+    },
+    prompt: undefined,
+  };
+
   public static readonly tssEnabled: CommandFlag = {
     constName: 'tssEnabled',
     name: 'tss',
@@ -3088,6 +3100,7 @@ export class Flags {
     Flags.skipGrpcWebEndpoint,
     Flags.wrapsEnabled,
     Flags.wrapsKeyPath,
+    Flags.wrapsCopyParallel,
     Flags.tssEnabled,
     Flags.javaFlightRecorderConfiguration,
     Flags.forceBlockNodeIntegration,

--- a/src/commands/network-deploy-config-class.ts
+++ b/src/commands/network-deploy-config-class.ts
@@ -77,6 +77,7 @@ export interface NetworkDeployConfigClass {
   javaFlightRecorderConfiguration: string;
   wrapsEnabled: boolean;
   wrapsKeyPath: string;
+  wrapsCopyParallel: boolean;
   tssEnabled: boolean;
   minioEnabled: boolean;
 }

--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -175,6 +175,7 @@ export class NetworkCommand extends BaseCommand {
       flags.javaFlightRecorderConfiguration,
       flags.wrapsEnabled,
       flags.wrapsKeyPath,
+      flags.wrapsCopyParallel,
       flags.tssEnabled,
       flags.blockNodeMessageSizeSoftLimitBytes,
       flags.blockNodeMessageSizeHardLimitBytes,
@@ -908,6 +909,7 @@ export class NetworkCommand extends BaseCommand {
       flags.domainNames,
       flags.gossipEndpointPort,
       flags.serviceEndpointPort,
+      flags.wrapsCopyParallel,
     ];
 
     // disable the prompts that we don't want to prompt the user for
@@ -1858,7 +1860,7 @@ export class NetworkCommand extends BaseCommand {
         {
           title: 'Copy wraps lib into consensus node',
           skip: (): boolean => !this.remoteConfig.configuration.state.wrapsEnabled,
-          task: async ({config}): Promise<void> => {
+          task: async ({config}, task): Promise<SoloListr<NetworkDeployContext>> => {
             const wraps: Wraps = this.soloConfig.tss.wraps;
             const extractedDirectory: string = PathEx.join(constants.SOLO_CACHE_DIR, wraps.directoryName);
 
@@ -1931,18 +1933,33 @@ export class NetworkCommand extends BaseCommand {
               }
             }
 
-            for (const consensusNode of config.consensusNodes) {
-              const rootContainer: Container = await new K8Helper(consensusNode.context).getConsensusNodeRootContainer(
-                config.namespace,
-                consensusNode.name,
-              );
+            // The library is hundreds of megabytes per node, so on a large network the copies
+            // dominate deploy time. Running them concurrently is much faster but puts every
+            // transfer on the same link at once, which is the wrong trade on a constrained
+            // connection -- hence the flag rather than a fixed choice.
+            const subTasks: SoloListrTask<NetworkDeployContext>[] = config.consensusNodes.map(
+              (consensusNode: ConsensusNode): SoloListrTask<NetworkDeployContext> => ({
+                title: `Copy wraps lib to node: ${chalk.yellow(consensusNode.name)}, cluster: ${chalk.yellow(consensusNode.cluster)}`,
+                task: async (): Promise<void> => {
+                  const rootContainer: Container = await new K8Helper(
+                    consensusNode.context,
+                  ).getConsensusNodeRootContainer(config.namespace, consensusNode.name);
 
-              await rootContainer.copyTo(extractedDirectory, `${constants.HEDERA_HAPI_PATH}/data/keys`);
+                  await rootContainer.copyTo(extractedDirectory, `${constants.HEDERA_HAPI_PATH}/data/keys`);
 
-              if (wrapsTarball) {
-                await rootContainer.copyTo(wrapsTarball, `${constants.HEDERA_HAPI_PATH}/data/keys`);
-              }
-            }
+                  if (wrapsTarball) {
+                    await rootContainer.copyTo(wrapsTarball, `${constants.HEDERA_HAPI_PATH}/data/keys`);
+                  }
+                },
+              }),
+            );
+
+            return task.newListr(subTasks, {
+              concurrent: config.wrapsCopyParallel,
+              rendererOptions: {
+                collapseSubtasks: false,
+              },
+            });
           },
         },
         {

--- a/test/unit/commands/network-wraps-copy-flag.test.ts
+++ b/test/unit/commands/network-wraps-copy-flag.test.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {expect} from 'chai';
+import {beforeEach, describe, it} from 'mocha';
+import {Flags} from '../../../src/commands/flags.js';
+import {NetworkCommand} from '../../../src/commands/network.js';
+import {type CommandFlag} from '../../../src/types/command-flag.js';
+import {resetForTest} from '../../test-container.js';
+
+describe('wraps copy parallel flag', (): void => {
+  beforeEach((): void => {
+    resetForTest();
+  });
+
+  it('is registered in the flag registry', (): void => {
+    expect(Flags.allFlags).to.include(Flags.wrapsCopyParallel);
+    expect(Flags.allFlagsMap.get(Flags.wrapsCopyParallel.name)).to.equal(Flags.wrapsCopyParallel);
+  });
+
+  it('defaults to the sequential copy that predates the flag', (): void => {
+    expect(Flags.wrapsCopyParallel.definition.type).to.equal('boolean');
+    expect(Flags.wrapsCopyParallel.definition.defaultValue).to.be.false;
+  });
+
+  it('is offered by consensus network deploy', (): void => {
+    const deployFlags: CommandFlag[] = [
+      ...NetworkCommand.DEPLOY_FLAGS_LIST.optional,
+      ...NetworkCommand.DEPLOY_FLAGS_LIST.required,
+    ];
+
+    expect(deployFlags).to.include(Flags.wrapsCopyParallel);
+  });
+
+  it('does not prompt, so a non-interactive deploy keeps the default', (): void => {
+    expect(Flags.wrapsCopyParallel.prompt).to.be.undefined;
+  });
+});


### PR DESCRIPTION
## Description

This pull request changes the following:

* Adds `--wraps-copy-parallel` to `solo consensus network deploy`, letting the user choose whether the "Copy wraps lib into consensus node" step copies the WRAPs library to all consensus nodes at once or to one node after another.
* Converts that step's per-node copies into Listr subtasks — the same shape as the neighbouring "Copy JFR config file to nodes" step — with the flag selecting `concurrent`. Each node now gets its own titled subtask, so progress and any failure are attributable to a specific node instead of being hidden inside one opaque step.

The library is hundreds of megabytes per node, so on a large network these transfers dominate deploy time; running them concurrently is considerably faster. But concurrent copies put every transfer on the same link simultaneously, which is the wrong trade on a constrained or metered connection, and each copy shells out to `kubectl cp`. Neither choice is correct for every cluster, which is why this is a flag rather than a change of behaviour.

**Default is `false`**, preserving exactly the sequential behaviour that exists today. Deployments that do not pass the flag are unaffected.

### Related Issues

* N/A — requested directly.

### Pull request (PR) checklist

* [x] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [x] Any technical debt has been documented as a separate issue and linked to this PR
* [x] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

No documentation update is included: the flag is picked up by the generated CLI help, which is not a tracked artifact, and this adds no environment variable and no command, subcommand, or operation — so neither `docs/site/content/en/docs/env.md` nor `presentation_layer_cli_architecture.md` has a trigger.

The flag registry checklist from `CLAUDE.md` was followed: the `CommandFlag` is defined, added to `Flags.allFlags`, added to `NetworkCommand.DEPLOY_FLAGS_LIST.optional`, and added to the deploy step's disabled-prompt list so a non-interactive deploy is never blocked on it. It belongs to no special registry (`nodeConfigFileFlags`, `integerFlags`).

### Testing

* [x] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [x] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* `npx tsx solo.ts consensus network deploy --help` renders `--wraps-copy-parallel [boolean] [default: false]`, confirming the flag reaches the CLI surface and not just the registry.
* New unit tests cover the wiring that is easy to get wrong: the flag is in `Flags.allFlags` and `Flags.allFlagsMap`, its type is `boolean` with a `false` default, it is offered by `consensus network deploy`, and it has no prompt. `task build` and `task format` are clean — zero lint errors.

The following was not tested:

* No test asserts the resulting Listr concurrency, and no deploy was run in either mode. The concurrency decision is a single value passed to `task.newListr`, and the surrounding step is covered by the existing consensus network deploy end-to-end tests; asserting it directly would mean either exposing the private task builder or driving a full deploy. Worth exercising `--wraps-copy-parallel true` on a multi-node cluster before relying on it for a large network.
