### PR TITLE
docs: improve README and npm discoverability for AI assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,17 @@
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/hiero-ledger/solo/badge)](https://scorecard.dev/viewer/?uri=github.com/hiero-ledger/solo)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/10697/badge)](https://bestpractices.coreinfrastructure.org/projects/10697)
 
-An opinionated CLI tool to deploy and manage standalone test networks.
+A CLI tool to deploy and manage local Hiero (Hedera) test networks for
+development and testing. Runs on Kubernetes — Mac, Linux, and Windows.
+
+## Quick Start
+
+```bash
+npm install -g @hiero-ledger/solo@latest
+solo one-shot single deploy
+```
+
+Full guide: [Simple Solo Setup](https://solo.hiero.org/docs/simple-solo-setup/)
 
 ## Homebrew Deprecation Notice
 
@@ -28,6 +38,10 @@ If Solo is currently installed with Homebrew, switch over with:
 brew uninstall solo
 npm install -g @hiero-ledger/solo
 ```
+
+## Documentation
+
+Our documentation is available here: [solo.hiero.org](https://solo.hiero.org/)
 
 ## Releases
 
@@ -49,10 +63,6 @@ Solo releases are supported for one month after their release date. LTS (Long-Te
 | 0.74.0 (LTS) | >= 22.0.0 (lts/jod) | v0.73.0        | >= v1.32.2 | Memory >= 12GB, CPU cores >= 6 | 2026-05-26   | 2026-08-26     |
 
 To see a list of legacy releases, please check the [legacy versions documentation page](legacy-versions.md).
-
-## Documentation
-
-Our documentation is available here: [solo.hiero.org](https://solo.hiero.org/)
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@hiero-ledger/solo",
   "version": "0.87.1",
-  "description": "An opinionated CLI tool to deploy and manage private Hedera Networks.",
+  "description": "Kubernetes-based local Hiero (Hedera) network for development and testing",
+  "homepage": "https://solo.hiero.org",
   "main": "./dist/src/index.js",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Updates the README description to name Hiero/Hedera and Kubernetes explicitly
- Adds a Quick Start section with install + `solo one-shot single deploy`, linking Simple Solo Setup
- Moves Documentation above the Releases table
- Adds `homepage` to `package.json` and sharpens its `description` for the npm package page

**Held back:** the AI Assistants section pointing at `https://solo.hiero.org/llms.txt` — that URL is not live yet (pending [solo-docs#305](https://github.com/hiero-ledger/solo-docs/pull/305)). Can be added in a follow-up after Initiative 1 deploys.

**Not in this PR:** GitHub About description / topics (repo settings; see strategy Initiative 7).

Related: [hiero-ledger/solo-docs#304](https://github.com/hiero-ledger/solo-docs/issues/304) (priority 2 / strategy Initiative 7)

## Test plan

- [ ] README renders correctly on GitHub (badges, code blocks, section order)
- [ ] Quick Start links resolve (`solo.hiero.org` Simple Solo Setup)
- [ ] `package.json` is valid JSON
- [ ] After next npm publish, package page shows updated description and homepage