### PR TITLE
fix: persist consensus node version to remote config after network upgrade

### DIFF
--- a/src/commands/node/handlers.ts
+++ b/src/commands/node/handlers.ts
@@ -450,6 +450,7 @@ export class NodeCommandHandlers extends CommandHandler {
       this.tasks.downloadNodeUpgradeFiles(),
       this.tasks.upgradeNodeConfigurationFilesWithChart(),
       this.tasks.fetchPlatformSoftware('nodeAliases'),
+      this.tasks.updateConsensusNodeVersionInRemoteConfig(),
       this.tasks.addWrapsLib(),
       this.markNodesConfiguredWhenNodeStartSkipped(),
       this.skipTaskWhenNodeStartSkipped(this.tasks.startNodes('allNodeAliases')),

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -1756,7 +1756,17 @@ export class NodeCommandTasks {
   public updateConsensusNodeVersionInRemoteConfig(): SoloListrTask<NodeUpgradeContext> {
     return {
       title: 'Update consensus node version in remote config',
-      task: async ({config}): Promise<void> => {
+      task: async ({config}, task): Promise<void> => {
+        if (!config.releaseTag) {
+          // upgrades performed with --local-build-path do not resolve a semantic release tag,
+          // so there is no version to record in remote config
+          task.skip(
+            `${task.title} ${chalk.yellow('[SKIPPING]')} ${chalk.grey('no release tag resolved for this upgrade')}`,
+          );
+
+          return;
+        }
+
         this.remoteConfig.updateComponentVersion(
           ComponentTypes.ConsensusNode,
           new SemanticVersion<string>(config.releaseTag),

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -1753,6 +1753,19 @@ export class NodeCommandTasks {
     };
   }
 
+  public updateConsensusNodeVersionInRemoteConfig(): SoloListrTask<NodeUpgradeContext> {
+    return {
+      title: 'Update consensus node version in remote config',
+      task: async ({config}): Promise<void> => {
+        this.remoteConfig.updateComponentVersion(
+          ComponentTypes.ConsensusNode,
+          new SemanticVersion<string>(config.releaseTag),
+        );
+        await this.remoteConfig.persist();
+      },
+    };
+  }
+
   public populateServiceMap(): SoloListrTask<NodeAddContext | NodeDestroyContext> {
     return {
       title: 'Populate serviceMap',

--- a/test/unit/commands/node/update-consensus-node-version-in-remote-config.test.ts
+++ b/test/unit/commands/node/update-consensus-node-version-in-remote-config.test.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {NodeCommandTasks} from '../../../../src/commands/node/tasks.js';
+import {ComponentTypes} from '../../../../src/core/config/remote/enumerations/component-types.js';
+import {type SemanticVersion} from '../../../../src/business/utils/semantic-version.js';
+import {type NodeUpgradeContext} from '../../../../src/commands/node/config-interfaces/node-upgrade-context.js';
+
+describe('NodeCommandTasks.updateConsensusNodeVersionInRemoteConfig', (): void => {
+  it('persists the upgraded consensus node version to remote config', async (): Promise<void> => {
+    const updateComponentVersionCalls: {type: ComponentTypes; version: SemanticVersion<string>}[] = [];
+    let persistCallCount: number = 0;
+
+    const nodeCommandTasks: NodeCommandTasks = Object.create(NodeCommandTasks.prototype) as NodeCommandTasks;
+
+    (nodeCommandTasks as unknown as {remoteConfig: unknown}).remoteConfig = {
+      updateComponentVersion: (type: ComponentTypes, version: SemanticVersion<string>): void => {
+        updateComponentVersionCalls.push({type, version});
+      },
+      persist: async (): Promise<void> => {
+        persistCallCount++;
+      },
+    };
+
+    const context: NodeUpgradeContext = {
+      config: {releaseTag: '0.75.1'},
+    } as unknown as NodeUpgradeContext;
+
+    await nodeCommandTasks.updateConsensusNodeVersionInRemoteConfig().task(context, undefined as never);
+
+    expect(updateComponentVersionCalls).to.have.lengthOf(1);
+    expect(updateComponentVersionCalls[0].type).to.equal(ComponentTypes.ConsensusNode);
+    expect(updateComponentVersionCalls[0].version.toString()).to.equal('0.75.1');
+    expect(persistCallCount).to.equal(1);
+  });
+});

--- a/test/unit/commands/node/update-consensus-node-version-in-remote-config.test.ts
+++ b/test/unit/commands/node/update-consensus-node-version-in-remote-config.test.ts
@@ -34,4 +34,38 @@ describe('NodeCommandTasks.updateConsensusNodeVersionInRemoteConfig', (): void =
     expect(updateComponentVersionCalls[0].version.toString()).to.equal('0.75.1');
     expect(persistCallCount).to.equal(1);
   });
+
+  it('skips without persisting when no release tag was resolved (e.g. --local-build-path upgrades)', async (): Promise<void> => {
+    let updateComponentVersionCallCount: number = 0;
+    let persistCallCount: number = 0;
+    let skipMessage: string | undefined;
+
+    const nodeCommandTasks: NodeCommandTasks = Object.create(NodeCommandTasks.prototype) as NodeCommandTasks;
+
+    (nodeCommandTasks as unknown as {remoteConfig: unknown}).remoteConfig = {
+      updateComponentVersion: (): void => {
+        updateComponentVersionCallCount++;
+      },
+      persist: async (): Promise<void> => {
+        persistCallCount++;
+      },
+    };
+
+    const context: NodeUpgradeContext = {
+      config: {releaseTag: ''},
+    } as unknown as NodeUpgradeContext;
+
+    const task: {title: string; skip: (message: string) => void} = {
+      title: 'Update consensus node version in remote config',
+      skip: (message: string): void => {
+        skipMessage = message;
+      },
+    };
+
+    await nodeCommandTasks.updateConsensusNodeVersionInRemoteConfig().task(context, task as never);
+
+    expect(updateComponentVersionCallCount).to.equal(0);
+    expect(persistCallCount).to.equal(0);
+    expect(skipMessage).to.include('SKIPPING');
+  });
 });


### PR DESCRIPTION
## Description

This pull request changes the following:

* `consensus network upgrade` (`solo consensus network upgrade`) fetches and starts the new consensus node platform software but never wrote the new version back into the `solo-remote-config` ConfigMap, so `versions.consensusNode` kept reporting the pre-upgrade version indefinitely. Added a task, `NodeCommandTasks.updateConsensusNodeVersionInRemoteConfig()`, that persists the upgraded version to remote config right after the platform software is fetched, mirroring the existing pattern used by the node add/update flow (`setupNetworkNodeFolders`).

### Related Issues

* Closes #5882

### Pull request (PR) checklist

* [x] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [ ] Any technical debt has been documented as a separate issue and linked to this PR
* [ ] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [x] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [x] These changes required manual testing that is documented below
* [ ] Anything not tested is documented

The following manual testing was done:

* Reproduced the bug locally: deployed a single-node network at `v0.74.0`, ran `consensus network upgrade --upgrade-version v0.75.1` (completed successfully, platform software updated to `v0.75.1`), and confirmed `solo-remote-config`'s `versions.consensusNode` incorrectly stayed at `0.74.0`.
* Applied the fix and re-ran the same scenario; `solo-remote-config`'s `versions.consensusNode` correctly updated to `0.75.1` after the upgrade completed.
* Added `test/unit/commands/node/update-consensus-node-version-in-remote-config.test.ts` covering the new task in isolation.
* Ran `task build` and `task format` with no errors.

The following was not tested:

* Multi-node / multi-cluster upgrade scenarios were not exercised manually (only a single-node kind cluster), though the fix uses the same remote-config API already exercised by those flows elsewhere.
