### PR TITLE
fix: fail fast when a consensus node container has crashed instead of waiting the full activeness timeout

### DIFF
--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -729,6 +729,7 @@ export class NodeCommandTasks {
 
     let attempt: number = 0;
     let success: boolean = false;
+    let fatalErrorStreak: number = 0;
     while (attempt < maxAttempts) {
       const controller: AbortController = new AbortController();
 
@@ -772,10 +773,27 @@ export class NodeCommandTasks {
           task.title = `${title} - status ${chalk.yellow(NodeStatusEnums[statusNumber])}, attempt: ${chalk.blueBright(`${attempt}/${maxAttempts}`)}`;
         }
         clearTimeout(timeoutId);
+        fatalErrorStreak = 0;
       } catch (error) {
         this.logger.debug(
           `${title} : Error in checking node activeness: attempt: ${attempt}/${maxAttempts}: ${JSON.stringify(error)}`,
         );
+
+        // The exec call above fails when the container is not currently running (e.g. mid-crash-restart),
+        // which is indistinguishable from a slow-starting node without inspecting the container state directly.
+        // Detect a non-recoverable crash (CrashLoopBackOff, OOMKilled, ...) and fail fast rather than
+        // exhausting the full attempt budget waiting for a process that will never resurrect itself.
+        const fatalError: string | undefined = await this.detectFatalNodeContainerError(podReference, context);
+        if (fatalError) {
+          fatalErrorStreak++;
+          if (fatalErrorStreak >= constants.NETWORK_NODE_ACTIVE_FATAL_ERROR_THRESHOLD) {
+            task.title = `${title} - status ${chalk.red('CRASHED')}, attempt: ${chalk.blueBright(`${attempt}/${maxAttempts}`)}`;
+            clearTimeout(timeoutId);
+            throw new SoloErrors.component.nodeContainerCrashed(nodeAlias, fatalError);
+          }
+        } else {
+          fatalErrorStreak = 0;
+        }
       }
 
       attempt++;
@@ -792,6 +810,25 @@ export class NodeCommandTasks {
     }
 
     return podReference;
+  }
+
+  /**
+   * Best-effort check of the node pod's container state for a non-recoverable crash (e.g.
+   * CrashLoopBackOff, OOMKilled). Returns the fatal error description, or undefined when the pod
+   * cannot be read or is not in a fatal state, so callers can fall back to normal retry handling.
+   */
+  private async detectFatalNodeContainerError(
+    podReference: PodReference,
+    context?: string,
+  ): Promise<string | undefined> {
+    try {
+      const k8: K8 = this.k8Factory.getK8(context);
+      const pod: Pod = await k8.pods().read(podReference);
+      return k8.pods().detectFatalContainerError(pod);
+    } catch {
+      // best-effort diagnostic only: if the pod lookup itself fails, defer to the normal retry/timeout handling
+      return undefined;
+    }
   }
 
   private async waitForGrpcReadiness(

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -493,6 +493,10 @@ export const NETWORK_NODE_ACTIVE_MAX_ATTEMPTS: number =
 export const NETWORK_NODE_ACTIVE_DELAY: number = +getEnvironmentVariable('NETWORK_NODE_ACTIVE_DELAY') || 1000;
 export const NETWORK_NODE_ACTIVE_TIMEOUT: number = +getEnvironmentVariable('NETWORK_NODE_ACTIVE_TIMEOUT') || 1000;
 
+// Number of consecutive fatal container states (e.g. CrashLoopBackOff, OOMKilled) detected while
+// polling node activeness before failing fast instead of waiting out the full attempt budget.
+export const NETWORK_NODE_ACTIVE_FATAL_ERROR_THRESHOLD: number = 3;
+
 // GRPC Healtcheck Checks
 export const NETWORK_NODE_GRPC_READINESS_MAX_ATTEMPTS: number =
   +getEnvironmentVariable('NETWORK_NODE_GRPC_READINESS_MAX_ATTEMPTS') || 20;

--- a/src/core/errors/classes/component/node-container-crashed-solo-error.ts
+++ b/src/core/errors/classes/component/node-container-crashed-solo-error.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {SoloError} from '../../solo-error.js';
+import {ErrorOwnership} from '../../error-ownership.js';
+import {ErrorCodeRegistry} from '../../error-code-registry.js';
+
+/**
+ * @description Thrown when solo detects that a consensus node's container has entered a
+ * non-recoverable crash state (e.g. CrashLoopBackOff, OOMKilled) while polling for the node to
+ * become active. The underlying process will never recover on its own, so solo fails fast
+ * instead of exhausting the full polling timeout.
+ */
+export class NodeContainerCrashedSoloError extends SoloError {
+  protected override readonly retryable: boolean = false;
+  protected override readonly ownership: ErrorOwnership = ErrorOwnership.Infrastructure;
+
+  public constructor(nodeAlias: string, reason: string) {
+    super({
+      message: `Node '${nodeAlias}' container has crashed and cannot become active: ${reason}`,
+      code: ErrorCodeRegistry.NODE_CONTAINER_CRASHED,
+      troubleshootingSteps:
+        'Check node pod status: kubectl get pods -n <namespace> -l solo.hedera.com/node-name=<nodeAlias>\n' +
+        'View previous container logs: kubectl logs -n <namespace> -l solo.hedera.com/node-name=<nodeAlias> --previous\n' +
+        'Review solo logs: tail -n 100 ~/.solo/logs/solo.log',
+    });
+  }
+}

--- a/src/core/errors/error-code-registry.ts
+++ b/src/core/errors/error-code-registry.ts
@@ -137,6 +137,7 @@ export const ErrorCodeRegistry: Record<string, string> = {
   GOSSIP_KEY_SECRET_RESTORE_FAILED: 'SOLO-3091',
   SDK_CLIENT_NO_HEALTHY_NODES: 'SOLO-3092',
   NODE_KEY_LOAD_FAILED: 'SOLO-3093',
+  NODE_CONTAINER_CRASHED: 'SOLO-3094',
 
   // 4xxx - Validation: User input, flags, IDs, formatting
   MISSING_ARGUMENT: 'SOLO-4001',

--- a/src/core/errors/solo-errors.ts
+++ b/src/core/errors/solo-errors.ts
@@ -201,6 +201,7 @@ import {HederaFileAppendFailedSoloError} from './classes/component/hedera-file-a
 import {NodeStatusEmptyResponseSoloError} from './classes/component/node-status-empty-response-solo-error.js';
 import {NodeStatusMissingLineSoloError} from './classes/component/node-status-missing-line-solo-error.js';
 import {PredefinedAccountsCreationFailedSoloError} from './classes/component/predefined-accounts-creation-failed-solo-error.js';
+import {NodeContainerCrashedSoloError} from './classes/component/node-container-crashed-solo-error.js';
 import {InvalidHbarAmountSoloError} from './classes/validation/invalid-hbar-amount-solo-error.js';
 import {InvalidFileIdFormatSoloError} from './classes/validation/invalid-file-id-format-solo-error.js';
 import {InvalidEndpointFormatSoloError} from './classes/validation/invalid-endpoint-format-solo-error.js';
@@ -493,6 +494,7 @@ export class SoloErrors {
     readonly nodeStatusEmptyResponse: typeof NodeStatusEmptyResponseSoloError;
     readonly nodeStatusMissingLine: typeof NodeStatusMissingLineSoloError;
     readonly predefinedAccountsCreationFailed: typeof PredefinedAccountsCreationFailedSoloError;
+    readonly nodeContainerCrashed: typeof NodeContainerCrashedSoloError;
   } = Object.freeze({
     nodeTransactionFailed: NodeTransactionFailedSoloError,
     nodeBuildUploadFailed: NodeBuildUploadFailedSoloError,
@@ -585,6 +587,7 @@ export class SoloErrors {
     nodeStatusEmptyResponse: NodeStatusEmptyResponseSoloError,
     nodeStatusMissingLine: NodeStatusMissingLineSoloError,
     predefinedAccountsCreationFailed: PredefinedAccountsCreationFailedSoloError,
+    nodeContainerCrashed: NodeContainerCrashedSoloError,
   });
 
   // 4xxx — Validation: User input, flags, IDs, formatting

--- a/src/integration/kube/k8-client/resources/pod/k8-client-pods.ts
+++ b/src/integration/kube/k8-client/resources/pod/k8-client-pods.ts
@@ -45,7 +45,8 @@ import {sleep} from '../../../../../core/helpers.js';
 
 export class K8ClientPods extends K8ClientBase implements Pods {
   /**
-   * Waiting reasons for container states that are non-recoverable (image unavailable in registry).
+   * Waiting reasons for container states that are non-recoverable (image unavailable in registry,
+   * or the container process has repeatedly crashed and will never restart cleanly on its own).
    */
   private static readonly FATAL_WAITING_REASONS: ReadonlySet<string> = new Set([
     'ImagePullBackOff',
@@ -53,6 +54,7 @@ export class K8ClientPods extends K8ClientBase implements Pods {
     'InvalidImageName',
     'ImageInspectError',
     'RegistryUnavailable',
+    'CrashLoopBackOff',
   ]);
 
   /**

--- a/test/unit/commands/node/check-network-node-activeness-fast-fail.test.ts
+++ b/test/unit/commands/node/check-network-node-activeness-fast-fail.test.ts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {describe, it, afterEach} from 'mocha';
+import {expect} from 'chai';
+import sinon from 'sinon';
+import {container} from 'tsyringe-neo';
+import {NodeCommandTasks} from '../../../../src/commands/node/tasks.js';
+import * as constants from '../../../../src/core/constants.js';
+import {NodeStatusCodes} from '../../../../src/core/enumerations.js';
+import {NamespaceName} from '../../../../src/types/namespace/namespace-name.js';
+import {type Pod} from '../../../../src/integration/kube/resources/pod/pod.js';
+import {type SoloListrTaskWrapper} from '../../../../src/types/index.js';
+import {type AnyListrContext} from '../../../../src/types/aliases.js';
+
+function createNodeCommandTasks(detectFatalContainerErrorStub: sinon.SinonStub): NodeCommandTasks {
+  const nodeCommandTasks: NodeCommandTasks = Object.create(NodeCommandTasks.prototype) as NodeCommandTasks;
+
+  (nodeCommandTasks as unknown as {logger: unknown}).logger = {
+    debug: (): void => {},
+  };
+
+  (nodeCommandTasks as unknown as {remoteConfig: unknown}).remoteConfig = {
+    getConsensusNodes: (): [] => [],
+  };
+
+  (nodeCommandTasks as unknown as {k8Factory: unknown}).k8Factory = {
+    getK8: (): {pods: () => {read: () => Promise<Pod>; detectFatalContainerError: sinon.SinonStub}} => ({
+      pods: (): {read: () => Promise<Pod>; detectFatalContainerError: sinon.SinonStub} => ({
+        read: async (): Promise<Pod> => ({}) as unknown as Pod,
+        detectFatalContainerError: detectFatalContainerErrorStub,
+      }),
+    }),
+  };
+
+  return nodeCommandTasks;
+}
+
+describe('NodeCommandTasks.checkNetworkNodeActiveness fast-fail on crashed container', (): void => {
+  afterEach((): void => {
+    sinon.restore();
+  });
+
+  it('fails fast once a fatal container error is detected repeatedly, without exhausting maxAttempts', async (): Promise<void> => {
+    const getNetworkNodePodStatusStub: sinon.SinonStub = sinon
+      .stub()
+      .rejects(new Error('command terminated with exit code 137'));
+    sinon.stub(container, 'resolve').returns({
+      getNetworkNodePodStatus: getNetworkNodePodStatusStub,
+    } as never);
+
+    const detectFatalContainerErrorStub: sinon.SinonStub = sinon
+      .stub()
+      .returns('container "root" was terminated due to: Error (exit code 135)');
+    const nodeCommandTasks: NodeCommandTasks = createNodeCommandTasks(detectFatalContainerErrorStub);
+
+    const maxAttempts: number = 50;
+    const task: SoloListrTaskWrapper<AnyListrContext> = {title: ''} as unknown as SoloListrTaskWrapper<AnyListrContext>;
+
+    try {
+      await nodeCommandTasks.checkNetworkNodeActiveness(
+        NamespaceName.of('solo'),
+        'node1',
+        task,
+        'Check network pod',
+        NodeStatusCodes.ACTIVE,
+        maxAttempts,
+        0,
+        1000,
+        'kind-solo',
+      );
+      expect.fail('Expected checkNetworkNodeActiveness to throw');
+    } catch (error: Error | unknown) {
+      expect((error as Error).message).to.include('node1');
+      expect((error as Error).message).to.include('crashed');
+    }
+
+    expect(getNetworkNodePodStatusStub.callCount).to.equal(constants.NETWORK_NODE_ACTIVE_FATAL_ERROR_THRESHOLD);
+    expect(detectFatalContainerErrorStub.callCount).to.equal(constants.NETWORK_NODE_ACTIVE_FATAL_ERROR_THRESHOLD);
+  });
+
+  it('keeps retrying up to maxAttempts when no fatal container error is detected', async (): Promise<void> => {
+    const getNetworkNodePodStatusStub: sinon.SinonStub = sinon.stub().rejects(new Error('transient exec error'));
+    sinon.stub(container, 'resolve').returns({
+      getNetworkNodePodStatus: getNetworkNodePodStatusStub,
+    } as never);
+
+    const detectFatalContainerErrorStub: sinon.SinonStub = sinon.stub();
+    const nodeCommandTasks: NodeCommandTasks = createNodeCommandTasks(detectFatalContainerErrorStub);
+
+    const maxAttempts: number = 5;
+    const task: SoloListrTaskWrapper<AnyListrContext> = {title: ''} as unknown as SoloListrTaskWrapper<AnyListrContext>;
+
+    try {
+      await nodeCommandTasks.checkNetworkNodeActiveness(
+        NamespaceName.of('solo'),
+        'node1',
+        task,
+        'Check network pod',
+        NodeStatusCodes.ACTIVE,
+        maxAttempts,
+        0,
+        1000,
+        'kind-solo',
+      );
+      expect.fail('Expected checkNetworkNodeActiveness to throw');
+    } catch (error: Error | unknown) {
+      expect((error as Error).message).to.include('node1');
+    }
+
+    expect(getNetworkNodePodStatusStub.callCount).to.equal(maxAttempts);
+  });
+});

--- a/test/unit/integration/kube/detect-fatal-container-error.test.ts
+++ b/test/unit/integration/kube/detect-fatal-container-error.test.ts
@@ -153,7 +153,7 @@ describe('detectFatalContainerError', (): void => {
     });
   });
 
-  for (const reason of ['InvalidImageName', 'RegistryUnavailable']) {
+  for (const reason of ['InvalidImageName', 'RegistryUnavailable', 'CrashLoopBackOff']) {
     it(`should detect fatal waiting reason: ${reason}`, (): void => {
       const pod: Pod = buildPod([buildWaiting('test-container', reason)]);
       const result: string | undefined = podsClient.detectFatalContainerError(pod);


### PR DESCRIPTION
## Description

This pull request changes the following:

* When polling a consensus node's platform status while waiting for it to become active, Solo now detects a non-recoverable container crash (e.g. `CrashLoopBackOff`, `OOMKilled`) via the pod's Kubernetes container status and fails fast instead of retrying for the full `NETWORK_NODE_ACTIVE_MAX_ATTEMPTS` (300 attempts, ~300s) budget.
* Added `CrashLoopBackOff` to the set of fatal container waiting reasons already used elsewhere for early pod-startup crash detection (`K8ClientPods.FATAL_WAITING_REASONS`).
* Added a new `NodeContainerCrashedSoloError` (`SOLO-3094`) that is thrown once 3 consecutive fatal container states are observed (`NETWORK_NODE_ACTIVE_FATAL_ERROR_THRESHOLD`), rather than waiting out the full attempt budget.

### Related Issues

* Closes #5887

### Pull request (PR) checklist

* [x] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [ ] Any technical debt has been documented as a separate issue and linked to this PR
* [ ] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [x] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [ ] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* This fix was not exercised against a real Latitude GHA runner reproducing the original SIGBUS crash; coverage relies on unit tests that stub the Kubernetes container status and the platform-status exec call.

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
