### PR TITLE
fix: wait for node pod recreation based on observed rollout, not CLI flags

### DIFF
--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -160,6 +160,7 @@ import {ClusterSchema} from '../../data/schema/model/common/cluster-schema.js';
 import {LockManager} from '../../core/lock/lock-manager.js';
 import {type NodeServiceMapping} from '../../types/mappings/node-service-mapping.js';
 import {Pod} from '../../integration/kube/resources/pod/pod.js';
+import {type Pods} from '../../integration/kube/resources/pod/pods.js';
 import {type Container} from '../../integration/kube/resources/container/container.js';
 import {SemanticVersion} from '../../business/utils/semantic-version.js';
 import {DeploymentStateSchema} from '../../data/schema/model/remote/deployment-state-schema.js';
@@ -2660,6 +2661,42 @@ export class NodeCommandTasks {
     return value === defaultValue;
   }
 
+  /**
+   * `helm upgrade` only triggers a StatefulSet rollout when the rendered pod template actually
+   * changes (root container image/tag, a volume mount toggled by application.env, resources,
+   * etc). Rather than guessing from which CLI flags were passed, poll briefly for evidence the
+   * node's pod is actually being recreated, so a chart-version/image bump is waited on even
+   * without --application-env, and an unrelated values change that never touches the pod
+   * template doesn't block on a restart that will never happen.
+   */
+  private static async didNodePodRolloutStart(
+    podsApi: Pods,
+    namespace: NamespaceName,
+    labels: string[],
+    previousPod: Pod | undefined,
+  ): Promise<boolean> {
+    for (let attempt: number = 1; attempt <= constants.NODE_POD_ROLLOUT_DETECTION_MAX_ATTEMPTS; attempt++) {
+      const [currentPod]: Pod[] = await podsApi.list(namespace, labels);
+
+      if (!previousPod || !currentPod) {
+        return true;
+      }
+
+      const recreated: boolean =
+        Boolean(currentPod.deletionTimestamp) ||
+        currentPod.creationTimestamp?.getTime() !== previousPod.creationTimestamp?.getTime() ||
+        currentPod.containerImage !== previousPod.containerImage;
+
+      if (recreated) {
+        return true;
+      }
+
+      await sleep(Duration.ofMillis(constants.NODE_POD_ROLLOUT_DETECTION_DELAY));
+    }
+
+    return false;
+  }
+
   public upgradeNodeConfigurationFilesWithChart(): SoloListrTask<NodeUpgradeContext> {
     return {
       title: 'Update node configuration files',
@@ -2823,6 +2860,23 @@ export class NodeCommandTasks {
           config.valuesFile,
         ).chartValuesMap;
 
+        // Snapshot each node's current pod before the helm upgrade runs, so that afterward we can
+        // detect whether the upgrade actually triggered a StatefulSet rollout (see
+        // didNodePodRolloutStart) rather than assuming it did or didn't based on which config
+        // file flags were passed.
+        const previousPods: Map<NodeAlias, Pod | undefined> = new Map();
+        await Promise.all(
+          config.consensusNodes.map(async (node): Promise<void> => {
+            const labels: string[] = [`solo.hedera.com/node-name=${node.name}`, 'solo.hedera.com/type=network-node'];
+            const [previousPod]: Pod[] = await this.k8Factory
+              .getK8(node.context)
+              .pods()
+              .list(NamespaceName.of(node.namespace), labels);
+            previousPods.set(node.name, previousPod);
+          }),
+        );
+        const upgradeTimestamp: Date = new Date();
+
         const subTasks: SoloListrTask<NodeConnectionsContext>[] = [
           {
             title: 'Update all charts',
@@ -2857,24 +2911,37 @@ export class NodeCommandTasks {
           {
             title: 'Re-apply configuration files to nodes after chart update',
             task: async (): Promise<void> => {
-              // The Helm chart upgrade triggers a StatefulSet rolling update, which restarts pods
-              // and runs the init-copier init container. That container copies the ConfigMap
-              // (which may have stale values) to the PVC, overwriting what was copied above.
-              // Wait for each pod to be Ready, then re-copy the staging application.properties
-              // so that CN reads the correct values on startup.
-              if (!this.isDefaultFlagValue(flags.applicationProperties)) {
-                for (const node of config.consensusNodes) {
-                  const labels: string[] = [
-                    `solo.hedera.com/node-name=${node.name}`,
-                    'solo.hedera.com/type=network-node',
-                  ];
-                  await this.k8Factory
-                    .getK8(node.context)
-                    .pods()
-                    .waitForReadyStatus(NamespaceName.of(node.namespace), labels, 120, 1000, undefined, true);
+              // The helm upgrade only triggers a StatefulSet rolling update, which restarts the pod
+              // and runs the init-copier init container, when it actually changed the rendered pod
+              // template (root container image/tag, application.env's volume mount, etc). That
+              // init container copies the ConfigMap (which may have stale values) to the PVC,
+              // overwriting what was copied above. So: wait for a real rollout only when one was
+              // actually observed, then re-copy the staging application.properties so that CN reads
+              // the correct values on startup.
+              for (const node of config.consensusNodes) {
+                const labels: string[] = [
+                  `solo.hedera.com/node-name=${node.name}`,
+                  'solo.hedera.com/type=network-node',
+                ];
+                const namespace: NamespaceName = NamespaceName.of(node.namespace);
+                const podsApi: Pods = this.k8Factory.getK8(node.context).pods();
 
+                const rolloutStarted: boolean = await NodeCommandTasks.didNodePodRolloutStart(
+                  podsApi,
+                  namespace,
+                  labels,
+                  previousPods.get(node.name),
+                );
+
+                if (!rolloutStarted) {
+                  continue;
+                }
+
+                await podsApi.waitForReadyStatus(namespace, labels, 120, 1000, upgradeTimestamp, true);
+
+                if (!this.isDefaultFlagValue(flags.applicationProperties)) {
                   const container: Container = await new K8Helper(node.context).getConsensusNodeRootContainer(
-                    NamespaceName.of(node.namespace),
+                    namespace,
                     node.name,
                   );
 

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -2701,10 +2701,24 @@ export class NodeCommandTasks {
     return {
       title: 'Update node configuration files',
       task: async ({config}, task): Promise<Listr<NodeConnectionsContext, any, any> | void> => {
-        if (![...flags.nodeConfigFileFlags.values()].some((flag): boolean => !this.isDefaultFlagValue(flag))) {
+        // This task also owns the only `helm upgrade` call in the `node upgrade` flow, so it must
+        // still run when the user is only bumping the chart version, chart directory, or supplying
+        // a custom values file -- none of which are node config file flags -- even though no
+        // config file needs to be copied in that case.
+        const chartUpgradeTriggerFlags: CommandFlag[] = [
+          flags.soloChartVersion,
+          flags.chartDirectory,
+          flags.networkDeploymentValuesFile,
+        ];
+
+        if (
+          ![...flags.nodeConfigFileFlags.values(), ...chartUpgradeTriggerFlags].some(
+            (flag): boolean => !this.isDefaultFlagValue(flag),
+          )
+        ) {
           task.skip(
             `${task.title} ${chalk.yellow('[SKIPPING]')} ` +
-              chalk.grey('no consensus node configuration files to be updated'),
+              chalk.grey('no consensus node configuration files or chart changes to apply'),
           );
 
           return;

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -487,6 +487,14 @@ export const JVM_DEBUG_PORT: number = 5005;
 export const PODS_RUNNING_MAX_ATTEMPTS: number = +getEnvironmentVariable('PODS_RUNNING_MAX_ATTEMPTS') || 60 * 15;
 export const PODS_RUNNING_DELAY: number = +getEnvironmentVariable('PODS_RUNNING_DELAY') || 1000;
 
+// Used during `node upgrade` to detect whether a helm upgrade actually triggered a node pod
+// rollout before waiting on its readiness, so an upgrade that never changes the pod template
+// doesn't block waiting for a restart that will never happen.
+export const NODE_POD_ROLLOUT_DETECTION_MAX_ATTEMPTS: number =
+  +getEnvironmentVariable('NODE_POD_ROLLOUT_DETECTION_MAX_ATTEMPTS') || 20;
+export const NODE_POD_ROLLOUT_DETECTION_DELAY: number =
+  +getEnvironmentVariable('NODE_POD_ROLLOUT_DETECTION_DELAY') || 1500;
+
 // Node Checks
 export const NETWORK_NODE_ACTIVE_MAX_ATTEMPTS: number =
   +getEnvironmentVariable('NETWORK_NODE_ACTIVE_MAX_ATTEMPTS') || 300;


### PR DESCRIPTION
## Description

This pull request changes the following:

* In `upgradeNodeConfigurationFilesWithChart()` (`src/commands/node/tasks.ts`), replace the CLI-flag-based guess for "did the helm upgrade trigger a pod restart" with an actual observation of the Kubernetes API. Previously the post-upgrade readiness wait (and the re-copy of `application.properties`) was gated on whether `--application-properties` differed from its default, which is wrong in both directions:
  * A `--solo-chart-version`/image bump correctly causes Kubernetes to recreate the pod, but Solo had no awareness of it and proceeded straight to `kubectl exec`/`kubectl cp` against the (possibly still-restarting or crash-looping) pod.
  * `--application-properties` alone never actually changes the StatefulSet's pod template (that ConfigMap is always mounted, unconditionally), so waiting on it could block for a restart that would never happen.
* Added `NodeCommandTasks.didNodePodRolloutStart()`, which snapshots each node's pod (creation timestamp + root container image) before the helm upgrade and polls briefly afterward for evidence a rollout actually started (new pod, deletion timestamp, or a changed image). The readiness wait and config re-apply now only run when a rollout was actually observed, regardless of which flag caused it.
* Added `NODE_POD_ROLLOUT_DETECTION_MAX_ATTEMPTS` / `NODE_POD_ROLLOUT_DETECTION_DELAY` constants (`src/core/constants.ts`) to bound the detection polling window.
* Found while writing a local reproduction script and fixed a second, more fundamental bug in the same function: the task's early-exit guard only checked the six *node config file* flags (`--application-env`, `--application-properties`, etc.) and skipped the **entire** task -- including the only `helm upgrade` call in the whole `node upgrade` flow -- whenever none of those were passed. So a `--solo-chart-version`/`--chart-directory`/`--values-file`-only upgrade (the exact scenario in the issue) never even ran `helm upgrade`, let alone recreated the pod. Broadened the guard to also run when any of those chart-affecting flags differ from default.

### Related Issues

* Closes #5884

### Pull request (PR) checklist

* [ ] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [x] Any technical debt has been documented as a separate issue and linked to this PR
* [x] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [ ] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [x] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* `npx tsc --noEmit` and `npx eslint src/commands/node/tasks.ts src/core/constants.ts` pass with no new errors/warnings introduced by this change.
* Ran the existing `test/unit/commands/node/*` suites touching `NodeCommandTasks`; all pass.
* Wrote and ran a local reproduction script (`test_issue_5884.sh`, not included in this PR, modeled after `test_issue_5882.sh`) against a real kind cluster:
  * deploys a single-node network with the root-container image pinned to an older tag,
  * runs `consensus network upgrade` with a `--values-file` that bumps only the root-container image tag (no `--application-env`), and `--skip-node-start` to isolate the step this issue is about,
  * records the node pod's UID/readiness immediately before and after the upgrade command returns.
  * Before this PR's fixes: `helm upgrade` never ran (1 chart revision total, image never changed) -- the first bug above blocked even reaching the scenario.
  * After both fixes: `helm upgrade` runs, the pod is recreated (new UID, new image), "Re-apply configuration files to nodes after chart update" waits ~34s for the new pod's readiness via the new rollout-detection logic, and `fetchPlatformSoftware` (the `kubectl exec`/`kubectl cp` step) then succeeds against the ready pod. Command exits 0.

The following was not tested:

* A unit test covering `didNodePodRolloutStart` or the broadened skip guard was not added in this PR.
* The local reproduction script itself was not committed to the repo.