### PR TITLE
fix: collect network-node current log and JVM hs_err crash logs in diagnostics

### DIFF
--- a/resources/support-zip.sh
+++ b/resources/support-zip.sh
@@ -28,8 +28,28 @@ readonly UPGRADE_DIR=${DATA_DIR}/upgrade
 readonly STATS_DIR=${DATA_DIR}/stats
 readonly JOURNAL_CTL_LOG=${HAPI_DIR}/${OUTPUT_DIR}/journalctl.log
 readonly LOG_FILE=${HAPI_DIR}/${OUTPUT_DIR}/support-zip.log
+# svlogd's actively-written log for the consensus node's supervised process;
+# carries the tail end of stdout/stderr, including native crash signal output.
+readonly NETWORK_NODE_CURRENT_LOG=/var/log/network-node/current
+# JVM writes one hs_err_pid<PID>.log per native crash directly in the CWD.
+readonly HS_ERR_LOG_GLOB="${HAPI_DIR}"/hs_err_*.log
 rm ${LOG_FILE} 2>/dev/null || true
 rm ${FILE_LIST} 2>/dev/null || true
+
+# Copies crash-diagnostic artifacts that live outside the directories already
+# bundled below into ${OUTPUT_DIR}, which is added to the file list as-is.
+CollectCrashArtifacts()
+{
+  if [[ -f "${NETWORK_NODE_CURRENT_LOG}" ]]; then
+    cp "${NETWORK_NODE_CURRENT_LOG}" "${HAPI_DIR}/${OUTPUT_DIR}/network-node-current.log" 2>/dev/null || true
+  fi
+
+  for hsErrLog in ${HS_ERR_LOG_GLOB}; do
+    if [[ -f "${hsErrLog}" ]]; then
+      cp "${hsErrLog}" "${HAPI_DIR}/${OUTPUT_DIR}/" 2>/dev/null || true
+    fi
+  done
+}
 
 AddToFileList()
 {
@@ -57,6 +77,7 @@ cd ${HAPI_DIR}
 pwd | tee -a ${LOG_FILE}
 echo -n > ${FILE_LIST}
 (journalctl > ${JOURNAL_CTL_LOG} 2>/dev/null) || true
+CollectCrashArtifacts
 AddToFileList ${SETTINGS_TXT}
 AddToFileList ${SETTINGS_USED_TXT}
 if [[ "${excludeSensitiveData}" != "true" ]]; then


### PR DESCRIPTION
## Description

This pull request changes the following:

* Adds `/var/log/network-node/current` (the actively-written supervised-process log, which carries native crash signal output) and any `hs_err_pid*.log` files (JVM native-crash reports written directly under `HapiApp2.0`) to the consensus-node diagnostics archive produced by `resources/support-zip.sh`. Both files are copied into the pod's existing `output/` directory before it is bundled, so they're included without any changes to the file-list plumbing itself.

### Related Issues

* Closes #5889

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[x] This PR updated documentation
* \[x] This PR added no TODOs or commented out code
* \[x] This PR has no breaking changes
* \[x] Any technical debt has been documented as a separate issue and linked to this PR
* \[x] Any `package.json` changes have been explained to and approved by a repository manager
* \[x] All related issues have been linked to this PR
* \[x] All changes in this PR are included in the description
* \[x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[x] These changes required manual testing that is documented below
* \[x] Anything not tested is documented

The following manual testing was done:

* Verified the modified script with `bash -n` (syntax check passes). `shellcheck` was not available locally.

The following was not tested:

* Running the script inside a live consensus-node pod against real `/var/log/network-node/current` and `hs_err_pid*.log` files, since reproducing a native JVM crash was out of scope for this fix.
