### PR TITLE
fix: do not force mirror node image tags when using a local chart directory

### DIFF
--- a/src/commands/mirror-node.ts
+++ b/src/commands/mirror-node.ts
@@ -567,7 +567,7 @@ export class MirrorNodeCommand extends BaseCommand {
           .setLiteral('web3.image.pullPolicy', 'Never')
           .setLiteral('monitor.image.pullPolicy', 'Never');
       }
-    } else {
+    } else if (this.shouldApplyMirrorNodeImageTagOverrides(config.mirrorNodeChartDirectory)) {
       this.addMirrorNodeImageTagOverrides(chartValues, config.mirrorNodeVersion);
     }
 
@@ -678,6 +678,16 @@ export class MirrorNodeCommand extends BaseCommand {
     chartValues.add(this.prepareBlockNodeIntegrationValues(config));
 
     return chartValues;
+  }
+
+  /**
+   * A local/custom chart directory (`--mirror-node-chart-dir`) may carry its own SNAPSHOT image
+   * tags (e.g. for testing a locally built mirror node image). Forcing the tag to the resolved
+   * `mirrorNodeVersion` in that case would clobber the chart's own default, so the override is
+   * skipped unless the user explicitly requested a version. See issue #5892.
+   */
+  private shouldApplyMirrorNodeImageTagOverrides(mirrorNodeChartDirectory: string): boolean {
+    return !mirrorNodeChartDirectory || this.configManager.wasFlagProvidedByUser(flags.mirrorNodeVersion);
   }
 
   private addMirrorNodeImageTagOverrides(chartValues: HelmChartValues, mirrorNodeVersion: string): void {

--- a/test/unit/commands/mirror-node.test.ts
+++ b/test/unit/commands/mirror-node.test.ts
@@ -52,6 +52,8 @@ interface MirrorNodeCommandInternal {
     config: MirrorNodeMemoryOverrideConfig,
   ) => void;
   addMirrorNodeImageTagOverrides: (chartValues: HelmChartValues, mirrorNodeVersion: string) => void;
+  shouldApplyMirrorNodeImageTagOverrides: (mirrorNodeChartDirectory: string) => boolean;
+  configManager: {wasFlagProvidedByUser: sinon.SinonStub};
   initializeSharedPostgresDatabaseTask: () => SoloListrTask<MirrorNodeDatabaseTaskContext>;
   primePostgresSecretTask: () => SoloListrTask<MirrorNodeDatabaseTaskContext>;
   waitForMirrorNodeSchemaTask: () => SoloListrTask<MirrorNodeSchemaWaitTaskContext>;
@@ -320,6 +322,33 @@ describe('MirrorNodeCommand unit tests', (): void => {
     expect(valuesArguments).to.include('rest.image.tag=0.157.0');
     expect(valuesArguments).to.include('restjava.image.tag=0.157.0');
     expect(valuesArguments).to.include('web3.image.tag=0.157.0');
+  });
+
+  it('should apply mirror node image tag overrides when no local chart directory is used', (): void => {
+    const mirrorNodeCommandInternal: MirrorNodeCommandInternal =
+      mirrorNodeCommand as unknown as MirrorNodeCommandInternal;
+
+    expect(mirrorNodeCommandInternal.shouldApplyMirrorNodeImageTagOverrides('')).to.equal(true);
+  });
+
+  it('should skip mirror node image tag overrides for a local chart directory when the version flag was not provided', (): void => {
+    const mirrorNodeCommandInternal: MirrorNodeCommandInternal =
+      mirrorNodeCommand as unknown as MirrorNodeCommandInternal;
+    mirrorNodeCommandInternal.configManager = {wasFlagProvidedByUser: sinon.stub().returns(false)};
+
+    expect(
+      mirrorNodeCommandInternal.shouldApplyMirrorNodeImageTagOverrides('/home/user/hiero-mirror-node/charts'),
+    ).to.equal(false);
+  });
+
+  it('should apply mirror node image tag overrides for a local chart directory when the version flag was explicitly provided', (): void => {
+    const mirrorNodeCommandInternal: MirrorNodeCommandInternal =
+      mirrorNodeCommand as unknown as MirrorNodeCommandInternal;
+    mirrorNodeCommandInternal.configManager = {wasFlagProvidedByUser: sinon.stub().returns(true)};
+
+    expect(
+      mirrorNodeCommandInternal.shouldApplyMirrorNodeImageTagOverrides('/home/user/hiero-mirror-node/charts'),
+    ).to.equal(true);
   });
 
   it('should use block node importer endpoint properties for mirror node 0.157.0', (): void => {


### PR DESCRIPTION
## Description

This pull request changes the following:

* Skips the mirror node image tag override in `prepareHelmChartValues` when `--mirror-node-chart-dir` points to a local/custom chart and `--mirror-node-version` was not explicitly provided by the user, so the chart's own default image tag (e.g. a locally built SNAPSHOT tag) is preserved instead of being clobbered by solo's resolved default `mirrorNodeVersion`.
* Adds a small, independently testable predicate (`shouldApplyMirrorNodeImageTagOverrides`) that mirrors the existing "was flag explicitly provided by user" pattern already used for the mirror node `upgrade` path (`ConfigManager.wasFlagProvidedByUser`).
* Behavior is unchanged for the default (no local chart directory) case and when `--mirror-node-version` is explicitly passed — the tag override still applies in both of those cases.

### Related Issues

* Closes #5892

### Pull request (PR) checklist

* [x] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [ ] Any technical debt has been documented as a separate issue and linked to this PR
* [ ] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [x] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [ ] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* N/A — covered by new unit tests exercising the `shouldApplyMirrorNodeImageTagOverrides` predicate for: no chart directory (override applies), local chart directory without an explicit `--mirror-node-version` (override skipped), and local chart directory with an explicit `--mirror-node-version` (override applies).

The following was not tested:

* End-to-end verification against a real local mirror-node chart directory with a SNAPSHOT image tag was not performed in this environment.

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
