### PR TITLE
fix: set up node on self hosted runner

### DIFF
--- a/.github/workflows/flow-codeql-analysis.yaml
+++ b/.github/workflows/flow-codeql-analysis.yaml
@@ -61,6 +61,14 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # The CodeQL TypeScript extractor requires Node.js on the PATH, which the
+      # self-hosted runners do not provide by default.
+      - name: Setup Node
+        if: ${{ matrix.language == 'javascript-typescript' }}
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:


### PR DESCRIPTION
CodeQl workflow failed analysing the JS code, maybe because the self hosted runner requires installation of node

https://github.com/hiero-ledger/solo/actions/runs/33171135259/job/98848311290

Gated in this case to just the javascript language check