### PR TITLE
fix: use pull_request_target for PR automation to fix Dependabot secret access

### DIFF
--- a/.github/workflows/zxf-prs-automation.yaml
+++ b/.github/workflows/zxf-prs-automation.yaml
@@ -1,7 +1,10 @@
 name: "ZXF: PR Automation"
 
 on:
-  pull_request:
+  # Uses pull_request_target (not pull_request) because Dependabot-triggered pull_request runs
+  # get a read-only GITHUB_TOKEN and no repository secrets, which breaks the github-token input
+  # below. Neither job checks out PR code, so running in the base repo's context is safe.
+  pull_request_target:
     types:
       - opened
       - reopened
@@ -39,7 +42,7 @@ defaults:
 jobs:
   auto-assign-merge-queue:
     name: "Auto-Assign Merge Queue PRs"
-    if: github.event_name == 'pull_request' && startsWith(github.base_ref, 'trunk-merge/')
+    if: github.event_name == 'pull_request_target' && startsWith(github.base_ref, 'trunk-merge/')
     runs-on: hiero-solo-linux-medium
     steps:
       - name: Harden Runner
@@ -253,7 +256,7 @@ jobs:
               }
             }
 
-            const prEventNames = ['pull_request', 'pull_request_review', 'pull_request_review_comment'];
+            const prEventNames = ['pull_request_target', 'pull_request_review', 'pull_request_review_comment'];
             if (prEventNames.includes(context.eventName)) {
               const prNumber = context.payload.pull_request?.number;
               if (prNumber) {


### PR DESCRIPTION
## Description

This pull request changes the following:

* Switches the `pull_request` trigger on `.github/workflows/zxf-prs-automation.yaml` (`pr-automation` and `auto-assign-merge-queue` jobs) to `pull_request_target`. GitHub Actions withholds repository secrets and downgrades `GITHUB_TOKEN` to read-only for workflow runs triggered by Dependabot on `pull_request`, which caused `secrets.GH_ACCESS_TOKEN` to resolve empty and the `actions/github-script` step to fail with `Input required and not supplied: github-token`. Neither job checks out PR code, so running via `pull_request_target` (base-repo context) is safe and restores secret access for Dependabot-triggered runs.
* Updates the in-script `prEventNames` list and the `auto-assign-merge-queue` job's `if:` condition from `pull_request` to `pull_request_target` to match the new `context.eventName` / `github.event_name` value, so single-PR processing (rather than a full open-PR scan) still triggers correctly.

### Related Issues

* Closes #5921

### Pull request (PR) checklist

* [ ] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [ ] Any technical debt has been documented as a separate issue and linked to this PR
* [ ] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [ ] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [x] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* Validated the modified workflow YAML parses correctly.
* Traced the `context.eventName` / `github.event_name` usages in the workflow's script and job `if:` conditions to confirm they were updated consistently with the trigger rename.

The following was not tested:

* End-to-end run against a live Dependabot PR (GitHub Actions triggers are not runnable locally) — will confirm the fix once this PR merges and the next Dependabot PR is opened/updated, or by re-running the workflow on an existing Dependabot PR.

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>