### PR TITLE
fix: `--zip-password` is written to `solo.log`

### DIFF
--- a/src/core/shell-runner.ts
+++ b/src/core/shell-runner.ts
@@ -26,7 +26,7 @@ export class ShellRunner {
    */
   public static redactArguments(arguments_: string[]): string[] {
     return SensitiveDataRedactor.redactArguments(arguments_, {
-      flagsToRedactNextArgument: ['--password', '-p'],
+      flagsToRedactNextArgument: ['--password', '-p', '-P'],
       setStyleFlags: ['--set', '--set-string', '--set-file'],
     });
   }

--- a/src/core/util/sensitive-data-redactor.ts
+++ b/src/core/util/sensitive-data-redactor.ts
@@ -44,17 +44,25 @@ export class SensitiveDataRedactor {
    * @returns A new array with sensitive values replaced by the redact mask
    */
   public static redactArguments(arguments_: string[], options: RedactOptions = {}): string[] {
+    const {flagsToRedactNextArgument = [], setStyleFlags = []} = options;
+
     // Split composite arguments that contain multiple key-value pairs within a single argument
     const splitArguments: string[] = [];
-    for (const argument of arguments_) {
-      if (argument.includes(' ')) {
+    for (let index: number = 0; index < arguments_.length; index++) {
+      const argument: string = arguments_[index];
+      const precedingArgument: string | undefined = arguments_[index - 1];
+      const preserveArgumentBoundaries: boolean =
+        precedingArgument !== undefined &&
+        (flagsToRedactNextArgument.includes(precedingArgument) || setStyleFlags.includes(precedingArgument));
+
+      // Preserve values paired with flags because a single spawn argument can contain literal spaces.
+      if (argument.includes(' ') && !preserveArgumentBoundaries) {
         splitArguments.push(...argument.split(' '));
       } else {
         splitArguments.push(argument);
       }
     }
 
-    const {flagsToRedactNextArgument = [], setStyleFlags = []} = options;
     const redacted: string[] = [];
 
     for (let index: number = 0; index < splitArguments.length; index++) {

--- a/test/unit/core/shell-runner.test.ts
+++ b/test/unit/core/shell-runner.test.ts
@@ -83,8 +83,8 @@ describe('ShellRunner', (): void => {
       expect(redacted).to.deep.equal(['-p', '******']);
     });
 
-    it('should redact -P and its value', (): void => {
-      const arguments_: string[] = ['-rX', '-P', 'myZipSecret', 'backup.zip', '.'];
+    it('should redact -P and its space-containing value', (): void => {
+      const arguments_: string[] = ['-rX', '-P', 'my Zip Secret', 'backup.zip', '.'];
       const redacted: string[] = ShellRunner.redactArguments(arguments_);
       expect(redacted).to.deep.equal(['-rX', '-P', '******', 'backup.zip', '.']);
     });

--- a/test/unit/core/shell-runner.test.ts
+++ b/test/unit/core/shell-runner.test.ts
@@ -83,6 +83,12 @@ describe('ShellRunner', (): void => {
       expect(redacted).to.deep.equal(['-p', '******']);
     });
 
+    it('should redact -P and its value', (): void => {
+      const arguments_: string[] = ['-rX', '-P', 'myZipSecret', 'backup.zip', '.'];
+      const redacted: string[] = ShellRunner.redactArguments(arguments_);
+      expect(redacted).to.deep.equal(['-rX', '-P', '******', 'backup.zip', '.']);
+    });
+
     it('should redact sensitive key=value pairs', (): void => {
       const arguments_: string[] = [
         '--set',


### PR DESCRIPTION
## Description

`ShellRunner.redactArguments` redacted only `--password` and `-p`, matched exactly and case sensitively. The backup and restore commands pass the zip password with uppercase `-P` (`zip -rX -P <password>` and `unzip -o -P <password>`), so the password was logged in plaintext at info level to `~/.solo/logs/solo.log`, which is bundled into the diagnostics zip users attach to bug reports.

This change adds `-P` to the list of flags whose next argument is redacted, and adds a unit test mirroring the real `zip` invocation.

### Related Issues

Closes #5870