### PR TITLE
fix: two kind flags miss their -- and process.env is mutated globally

### DIFF
--- a/src/business/runtime-state/services/metrics-server-impl.ts
+++ b/src/business/runtime-state/services/metrics-server-impl.ts
@@ -23,6 +23,7 @@ import {container} from 'tsyringe-neo';
 import {Duration} from '../../../core/time/duration.js';
 import path from 'node:path';
 import {type PodMetricsItem} from '../../../integration/kube/resources/pod/pod-metrics-item.js';
+import {SubprocessEnvironment} from '../../../core/subprocess-environment.js';
 
 @injectable()
 export class MetricsServerImpl implements MetricsServer {
@@ -248,7 +249,7 @@ export class MetricsServerImpl implements MetricsServer {
       verbose: true,
       commandProfile: SubprocessCommandProfile.KUBECTL,
       environmentVariablesToAppend: {
-        PATH: `${this.installationDirectory}${path.delimiter}${process.env.PATH}`,
+        PATH: `${this.installationDirectory}${path.delimiter}${SubprocessEnvironment.currentPath()}`,
       },
     });
     if (results?.length > 0) {

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -3129,7 +3129,7 @@ export class NodeCommandTasks {
                     cwd: process.cwd(),
                     maxBuffer: 1024 * 1024 * 10, // 10MB buffer
                     env: SubprocessEnvironment.forCommand(SubprocessCommandProfile.HELM, {
-                      PATH: `${container.resolve(InjectTokens.HelmInstallationDirectory)}${PathEx.delimiter}${process.env.PATH}`,
+                      PATH: `${container.resolve(InjectTokens.HelmInstallationDirectory)}${PathEx.delimiter}${SubprocessEnvironment.currentPath()}`,
                     }),
                   },
                 ).toString();

--- a/src/core/cluster-task-manager.ts
+++ b/src/core/cluster-task-manager.ts
@@ -3,6 +3,7 @@
 import {inject, injectable} from 'tsyringe-neo';
 import {ShellRunner} from './shell-runner.js';
 import {SubprocessCommandProfile} from './subprocess-command-profile.js';
+import {SubprocessEnvironment} from './subprocess-environment.js';
 import {InjectTokens} from './dependency-injection/inject-tokens.js';
 import {OsPackageManager} from './package-managers/os-package-manager.js';
 import {BrewPackageManager} from './package-managers/brew-package-manager.js';
@@ -152,7 +153,7 @@ export class ClusterTaskManager extends ShellRunner {
             this.logger.info('Podman not found, installing Podman...');
             await this.brewPackageManager.installPackages(['podman']);
             const brewBin: string[] = await this.run('which', ['podman']);
-            process.env.PATH = `${process.env.PATH}:${brewBin.join('').replace('/podman', '')}`;
+            SubprocessEnvironment.appendSessionPath(brewBin.join('').replace('/podman', ''));
           }
         },
       } as SoloListrTask<AnyObject>,
@@ -172,7 +173,7 @@ export class ClusterTaskManager extends ShellRunner {
           const sudoEnvironment: Record<string, string> = {
             PATH:
               `${this.podmanInstallationDirectory}${path.delimiter}` +
-              `${this.kindInstallationDirectory}${path.delimiter}${process.env.PATH}`,
+              `${this.kindInstallationDirectory}${path.delimiter}${SubprocessEnvironment.currentPath()}`,
           };
           // PATH must include both kindInstallationDirectory (for kind) and podmanPath (for podman).
           const kindRuntimePath: string = `${sudoEnvironment.PATH}${path.delimiter}${podmanPath}`;
@@ -360,7 +361,7 @@ export class ClusterTaskManager extends ShellRunner {
         onSudoGranted,
         'env',
         [
-          `PATH=${podmanBinaryDirectory}${path.delimiter}${process.env.PATH || ''}`,
+          `PATH=${podmanBinaryDirectory}${path.delimiter}${SubprocessEnvironment.currentPath()}`,
           ...configurationArguments,
           'podman',
           'info',
@@ -428,7 +429,7 @@ export class ClusterTaskManager extends ShellRunner {
             title: 'Create Podman machine...',
             task: async (): Promise<void> => {
               const podmanEnvironment: Record<string, string> = {
-                PATH: `${this.podmanInstallationDirectory}${path.delimiter}${process.env.PATH}`,
+                PATH: `${this.podmanInstallationDirectory}${path.delimiter}${SubprocessEnvironment.currentPath()}`,
               };
               await this.podmanDependencyManager.setupConfig();
               const podmanExecutable: string = await this.podmanDependencyManager.getExecutable();
@@ -461,7 +462,7 @@ export class ClusterTaskManager extends ShellRunner {
           {
             title: 'Configure kind to use podman...',
             task: async (): Promise<void> => {
-              process.env.KIND_EXPERIMENTAL_PROVIDER = 'podman';
+              SubprocessEnvironment.setSessionVariable('KIND_EXPERIMENTAL_PROVIDER', constants.PODMAN);
             },
             skip: (): boolean => skipPodmanTasks,
           } as SoloListrTask<AnyObject>,

--- a/src/core/dependency-managers/base-dependency-manager.ts
+++ b/src/core/dependency-managers/base-dependency-manager.ts
@@ -10,6 +10,7 @@ import {PathEx} from '../../business/utils/path-ex.js';
 import {OperatingSystem} from '../../business/utils/operating-system.js';
 import path from 'node:path';
 import {SemanticVersion} from '../../business/utils/semantic-version.js';
+import {SubprocessEnvironment} from '../subprocess-environment.js';
 
 /**
  * Base class for dependency managers that download and manage CLI tools
@@ -122,7 +123,7 @@ export abstract class BaseDependencyManager extends ShellRunner {
       ? [`${this.executableName}.exe`, `${this.executableName}.cmd`, this.executableName]
       : [this.executableName];
 
-    const pathDirectories: string[] = (process.env.PATH ?? '').split(path.delimiter).filter(Boolean);
+    const pathDirectories: string[] = SubprocessEnvironment.currentPath().split(path.delimiter).filter(Boolean);
     this.logger.debug(`Searching PATH for ${this.executableName}: [${pathDirectories.join(', ')}]`);
 
     for (const directory of pathDirectories) {

--- a/src/core/dependency-managers/podman-dependency-manager.ts
+++ b/src/core/dependency-managers/podman-dependency-manager.ts
@@ -16,6 +16,7 @@ import {Zippy} from '../zippy.js';
 import {GitHubRelease, ReleaseInfo, PodmanMode} from '../../types/index.js';
 import {PathEx} from '../../business/utils/path-ex.js';
 import {OperatingSystem} from '../../business/utils/operating-system.js';
+import {SubprocessEnvironment} from '../subprocess-environment.js';
 
 const PODMAN_RELEASES_LIST_URL: string = 'https://api.github.com/repos/containers/podman/releases';
 
@@ -315,7 +316,7 @@ export class PodmanDependencyManager extends BaseDependencyManager {
     let configContent: string = fs.readFileSync(templatePath, 'utf8');
     configContent = configContent.replace('$HELPER_BINARIES_DIR', this.helpersDirectory.replaceAll('\\', '/'));
     fs.writeFileSync(destinationPath, configContent, 'utf8');
-    process.env.CONTAINERS_CONF = destinationPath;
+    SubprocessEnvironment.setSessionVariable('CONTAINERS_CONF', destinationPath);
   }
 
   /**

--- a/src/core/package-managers/brew-package-manager.ts
+++ b/src/core/package-managers/brew-package-manager.ts
@@ -100,22 +100,22 @@ export class BrewPackageManager extends ShellRunner implements PackageManager {
         continue;
       }
       const [, key, rawValue]: string[] = match;
-      const value: string = BrewPackageManager.expandShellValue(rawValue);
       if (key === 'PATH') {
-        BrewPackageManager.registerPathAdditions(value);
+        BrewPackageManager.registerPathAdditions(rawValue);
       } else {
-        SubprocessEnvironment.setSessionVariable(key, value);
+        SubprocessEnvironment.setSessionVariable(key, BrewPackageManager.expandShellValue(rawValue));
       }
     }
   }
 
   /**
-   * Registers the new directories from a shellenv `PATH` value as session path prepends, preserving
-   * order. The brew value is split on the `:` brew hardcodes; this flow only runs on Linux.
+   * Registers the new directories from a raw shellenv `PATH` value as session path prepends, preserving order.
+   * References to the existing PATH are dropped, never expanded and re-split on the `:` brew hardcodes.
    */
-  private static registerPathAdditions(pathValue: string): void {
+  private static registerPathAdditions(rawPathValue: string): void {
+    const literalValue: string = rawPathValue.replaceAll(/\$(\{PATH[^}]*\}|PATH\b)/g, '');
     const currentSegments: Set<string> = new Set<string>(SubprocessEnvironment.currentPath().split(PathEx.delimiter));
-    const newSegments: string[] = pathValue
+    const newSegments: string[] = BrewPackageManager.expandShellValue(literalValue)
       .split(':')
       .filter((segment: string): boolean => Boolean(segment) && !currentSegments.has(segment));
     // prependSessionPath puts each directory in front, so iterate in reverse to preserve order.

--- a/src/core/package-managers/brew-package-manager.ts
+++ b/src/core/package-managers/brew-package-manager.ts
@@ -110,12 +110,11 @@ export class BrewPackageManager extends ShellRunner implements PackageManager {
   }
 
   /**
-   * Registers the new directories from a shellenv `PATH` value (the brew bin/sbin directories it
-   * prepends to the inherited `PATH`) as session path prepends, preserving their order. brew
-   * hardcodes `:` as the separator, and this flow only runs on Linux.
+   * Registers the new directories from a shellenv `PATH` value as session path prepends, preserving
+   * order. The brew value is split on the `:` brew hardcodes; this flow only runs on Linux.
    */
   private static registerPathAdditions(pathValue: string): void {
-    const currentSegments: Set<string> = new Set<string>(SubprocessEnvironment.currentPath().split(':'));
+    const currentSegments: Set<string> = new Set<string>(SubprocessEnvironment.currentPath().split(PathEx.delimiter));
     const newSegments: string[] = pathValue
       .split(':')
       .filter((segment: string): boolean => Boolean(segment) && !currentSegments.has(segment));

--- a/src/core/package-managers/brew-package-manager.ts
+++ b/src/core/package-managers/brew-package-manager.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import {ShellRunner} from '../shell-runner.js';
 import {SubprocessCommandProfile} from '../subprocess-command-profile.js';
+import {SubprocessEnvironment} from '../subprocess-environment.js';
 import {type PackageManager} from './package-manager.js';
 import {PathEx} from '../../business/utils/path-ex.js';
 import {getEnvironmentVariable} from '../constants.js';
@@ -46,7 +47,7 @@ export class BrewPackageManager extends ShellRunner implements PackageManager {
   public async install(): Promise<boolean> {
     await this.runHomebrewScript(BrewPackageManager.INSTALL_SCRIPT_URL);
     await this.applyShellEnvironment();
-    process.env.PATH = `${process.env.PATH}${PathEx.delimiter}${BrewPackageManager.LINUXBREW_BIN}`;
+    SubprocessEnvironment.appendSessionPath(BrewPackageManager.LINUXBREW_BIN);
     return this.isAvailable();
   }
 
@@ -86,6 +87,8 @@ export class BrewPackageManager extends ShellRunner implements PackageManager {
   /**
    * Applies the environment that `brew shellenv` would export, without a shell `eval`. Parses the
    * `export KEY="VALUE";` lines and expands the shell parameter references each value contains.
+   * The values are registered as session environment state for subsequent spawned commands
+   * instead of mutating the global `process.env`.
    */
   private async applyShellEnvironment(): Promise<void> {
     const output: string[] = await this.run(`${BrewPackageManager.LINUXBREW_BIN}/brew`, ['shellenv'], {
@@ -97,8 +100,29 @@ export class BrewPackageManager extends ShellRunner implements PackageManager {
         continue;
       }
       const [, key, rawValue]: string[] = match;
-      // eslint-disable-next-line no-restricted-syntax
-      process.env[key] = BrewPackageManager.expandShellValue(rawValue);
+      const value: string = BrewPackageManager.expandShellValue(rawValue);
+      if (key === 'PATH') {
+        BrewPackageManager.registerPathAdditions(value);
+      } else {
+        SubprocessEnvironment.setSessionVariable(key, value);
+      }
+    }
+  }
+
+  /**
+   * Registers the new directories from a shellenv `PATH` value (the brew bin/sbin directories it
+   * prepends to the inherited `PATH`) as session path prepends, preserving their order. brew
+   * hardcodes `:` as the separator, and this flow only runs on Linux.
+   */
+  private static registerPathAdditions(pathValue: string): void {
+    const currentSegments: Set<string> = new Set<string>(SubprocessEnvironment.currentPath().split(':'));
+    const newSegments: string[] = pathValue
+      .split(':')
+      .filter((segment: string): boolean => Boolean(segment) && !currentSegments.has(segment));
+    // prependSessionPath puts each directory in front, so iterate in reverse to preserve order.
+    newSegments.reverse();
+    for (const segment of newSegments) {
+      SubprocessEnvironment.prependSessionPath(segment);
     }
   }
 

--- a/src/core/package-managers/os-package-manager.ts
+++ b/src/core/package-managers/os-package-manager.ts
@@ -14,6 +14,7 @@ import {PacmanPackageManager} from './pacman-package-manager.js';
 import {ApkPackageManager} from './apk-package-manager.js';
 import {OperatingSystem} from '../../business/utils/operating-system.js';
 import {SoloErrors} from '../errors/solo-errors.js';
+import {SubprocessEnvironment} from '../subprocess-environment.js';
 
 /**
  * Selects the correct {@link PackageManager} for the host operating system and — on Linux — for the
@@ -129,7 +130,7 @@ export class OsPackageManager {
 
   /** Returns true if the given executable is found on the PATH (synchronous, no subprocess). */
   private static isCommandAvailable(command: string): boolean {
-    const pathValue: string = process.env.PATH ?? '';
+    const pathValue: string = SubprocessEnvironment.currentPath();
     return pathValue.split(path.delimiter).some((directory: string): boolean => {
       try {
         fs.accessSync(path.join(directory, command), fs.constants.X_OK);

--- a/src/core/subprocess-environment.ts
+++ b/src/core/subprocess-environment.ts
@@ -3,6 +3,7 @@
 import os from 'node:os';
 import path from 'node:path';
 import {SubprocessCommandProfile} from './subprocess-command-profile.js';
+import {SoloErrors} from './errors/solo-errors.js';
 
 /**
  * Builds a minimal, explicit environment for spawning external commands.
@@ -15,7 +16,7 @@ import {SubprocessCommandProfile} from './subprocess-command-profile.js';
  *
  * Intentionally dependency-free (no dependency-injection, no logging, no heavy imports) so
  * that the standalone `persist-port-forward` script can import it without pulling in the
- * container.
+ * container. The registered error classes are the one exception; they have no runtime dependencies.
  */
 export class SubprocessEnvironment {
   /** Environment variable names inherited by every external command on every platform. */
@@ -156,6 +157,12 @@ export class SubprocessEnvironment {
    * @param value - the value to hand to child processes
    */
   public static setSessionVariable(name: string, value: string): void {
+    if (name.toLowerCase() === 'path') {
+      throw new SoloErrors.validation.illegalArgument(
+        'PATH must be registered with prependSessionPath/appendSessionPath',
+        name,
+      );
+    }
     SubprocessEnvironment.sessionVariables.set(name, value);
   }
 
@@ -205,11 +212,16 @@ export class SubprocessEnvironment {
     return SubprocessEnvironment.withSessionPathAdditions(base);
   }
 
-  /** Clears every session-scoped variable and path addition. Intended for tests. */
-  public static clearSessionState(): void {
+  /** Clears every session variable and path addition. Session state is write-once per invocation; only tests may call this. */
+  public static resetForTesting(): void {
     SubprocessEnvironment.sessionVariables.clear();
     SubprocessEnvironment.sessionPathPrepends.length = 0;
     SubprocessEnvironment.sessionPathAppends.length = 0;
+  }
+
+  /** The environment's `PATH` key, matched case-insensitively (POSIX `PATH`, Windows `Path`); `PATH` when absent. */
+  public static pathKey(environment: Record<string, string>): string {
+    return Object.keys(environment).find((key: string): boolean => key.toLowerCase() === 'path') ?? 'PATH';
   }
 
   private static isSessionPathRegistered(directory: string): boolean {
@@ -258,29 +270,31 @@ export class SubprocessEnvironment {
       (prefix: string): string => normalize(prefix),
     );
 
-    const environment: Record<string, string> = {};
-    // Session variables overlay the parent environment before filtering, so the allowlists apply to both.
-    const sourceEntries: Array<[string, string | undefined]> = [
-      ...Object.entries(process.env),
-      ...SubprocessEnvironment.sessionVariables.entries(),
-    ];
-    for (const [name, value] of sourceEntries) {
-      if (value === undefined) {
-        continue;
-      }
+    const isAllowedName: (name: string) => boolean = (name: string): boolean => {
       const normalized: string = normalize(name);
-      if (
+      return (
         allowedExactNames.has(normalized) ||
         allowedPrefixes.some((prefix: string): boolean => normalized.startsWith(prefix))
-      ) {
+      );
+    };
+
+    const environment: Record<string, string> = {};
+    for (const [name, value] of Object.entries(process.env)) {
+      if (value !== undefined && isAllowedName(name)) {
         // Preserve the original variable name (and its casing) for the child process.
+        environment[name] = value;
+      }
+    }
+    // Separate pass: session state must never be counted or reported as parent-environment inheritance.
+    for (const [name, value] of SubprocessEnvironment.sessionVariables.entries()) {
+      if (isAllowedName(name)) {
         environment[name] = value;
       }
     }
 
     if (SubprocessEnvironment.sessionPathPrepends.length > 0 || SubprocessEnvironment.sessionPathAppends.length > 0) {
-      const pathKey: string =
-        Object.keys(environment).find((key: string): boolean => key.toLowerCase() === 'path') ?? 'PATH';
+      const pathKey: string = SubprocessEnvironment.pathKey(environment);
+      // Deliberate: even with no parent PATH the child gets one, so solo-installed binaries resolve.
       environment[pathKey] = SubprocessEnvironment.withSessionPathAdditions(environment[pathKey] ?? '');
     }
 

--- a/src/core/subprocess-environment.ts
+++ b/src/core/subprocess-environment.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import os from 'node:os';
+import path from 'node:path';
 import {SubprocessCommandProfile} from './subprocess-command-profile.js';
 
 /**
@@ -125,9 +126,105 @@ export class SubprocessEnvironment {
     [SubprocessCommandProfile.BREW]: ['HOMEBREW_'],
   };
 
+  /**
+   * Environment variables established at runtime for the remainder of this solo invocation
+   * (e.g. `KIND_EXPERIMENTAL_PROVIDER` once kind is configured to use podman, or
+   * `CONTAINERS_CONF` once a solo-owned podman configuration is written). They are merged over
+   * the parent environment and pass through the same per-profile allowlists, so they behave
+   * exactly like inherited variables — without mutating the global `process.env`.
+   */
+  private static readonly sessionVariables: Map<string, string> = new Map();
+
+  /** Directories prepended to the `PATH` handed to every child process, highest precedence first. */
+  private static readonly sessionPathPrepends: string[] = [];
+
+  /** Directories appended to the `PATH` handed to every child process, in registration order. */
+  private static readonly sessionPathAppends: string[] = [];
+
   /** Returns true when the current platform is Windows. Isolated for testability. */
   private static isWindowsPlatform(): boolean {
     return os.platform() === 'win32';
+  }
+
+  /**
+   * Registers an environment variable for every subsequently spawned command in this solo
+   * invocation. The variable is still subject to the per-profile allowlists, exactly as if it
+   * were present in the parent environment. `PATH` must not be set this way — use
+   * {@link prependSessionPath} / {@link appendSessionPath} instead.
+   *
+   * @param name - the environment variable name
+   * @param value - the value to hand to child processes
+   */
+  public static setSessionVariable(name: string, value: string): void {
+    SubprocessEnvironment.sessionVariables.set(name, value);
+  }
+
+  /**
+   * The value registered via {@link setSessionVariable} for this solo invocation, or undefined.
+   * Callers that also honor a user-provided variable should fall back to the parent environment
+   * when this returns undefined.
+   *
+   * @param name - the environment variable name
+   */
+  public static sessionVariable(name: string): string | undefined {
+    return SubprocessEnvironment.sessionVariables.get(name);
+  }
+
+  /**
+   * Registers a directory to prepend to the `PATH` of every subsequently spawned command in this
+   * solo invocation. The directory takes precedence over previously registered ones. Duplicate
+   * registrations are ignored.
+   *
+   * @param directory - the directory holding binaries child processes must resolve first
+   */
+  public static prependSessionPath(directory: string): void {
+    if (directory && !SubprocessEnvironment.isSessionPathRegistered(directory)) {
+      SubprocessEnvironment.sessionPathPrepends.unshift(directory);
+    }
+  }
+
+  /**
+   * Registers a directory to append to the `PATH` of every subsequently spawned command in this
+   * solo invocation. Duplicate registrations are ignored.
+   *
+   * @param directory - the directory holding binaries child processes should be able to resolve
+   */
+  public static appendSessionPath(directory: string): void {
+    if (directory && !SubprocessEnvironment.isSessionPathRegistered(directory)) {
+      SubprocessEnvironment.sessionPathAppends.push(directory);
+    }
+  }
+
+  /**
+   * The `PATH` child processes resolve binaries against: the parent `PATH` wrapped with the
+   * session path additions. For callers that construct explicit environment prefixes
+   * (`sudo env PATH=...`) or `PATH` overrides instead of relying on {@link forCommand}.
+   */
+  public static currentPath(): string {
+    const base: string = process.env.PATH ?? process.env.Path ?? '';
+    return SubprocessEnvironment.withSessionPathAdditions(base);
+  }
+
+  /** Clears every session-scoped variable and path addition. Intended for tests. */
+  public static clearSessionState(): void {
+    SubprocessEnvironment.sessionVariables.clear();
+    SubprocessEnvironment.sessionPathPrepends.length = 0;
+    SubprocessEnvironment.sessionPathAppends.length = 0;
+  }
+
+  private static isSessionPathRegistered(directory: string): boolean {
+    return (
+      SubprocessEnvironment.sessionPathPrepends.includes(directory) ||
+      SubprocessEnvironment.sessionPathAppends.includes(directory)
+    );
+  }
+
+  private static withSessionPathAdditions(basePath: string): string {
+    return [
+      ...SubprocessEnvironment.sessionPathPrepends,
+      ...(basePath ? [basePath] : []),
+      ...SubprocessEnvironment.sessionPathAppends,
+    ].join(path.delimiter);
   }
 
   /**
@@ -162,7 +259,12 @@ export class SubprocessEnvironment {
     );
 
     const environment: Record<string, string> = {};
-    for (const [name, value] of Object.entries(process.env)) {
+    // Session variables overlay the parent environment before filtering, so the allowlists apply to both.
+    const sourceEntries: Array<[string, string | undefined]> = [
+      ...Object.entries(process.env),
+      ...SubprocessEnvironment.sessionVariables.entries(),
+    ];
+    for (const [name, value] of sourceEntries) {
       if (value === undefined) {
         continue;
       }
@@ -174,6 +276,12 @@ export class SubprocessEnvironment {
         // Preserve the original variable name (and its casing) for the child process.
         environment[name] = value;
       }
+    }
+
+    if (SubprocessEnvironment.sessionPathPrepends.length > 0 || SubprocessEnvironment.sessionPathAppends.length > 0) {
+      const pathKey: string =
+        Object.keys(environment).find((key: string): boolean => key.toLowerCase() === 'path') ?? 'PATH';
+      environment[pathKey] = SubprocessEnvironment.withSessionPathAdditions(environment[pathKey] ?? '');
     }
 
     return {...environment, ...overrides};

--- a/src/integration/container-engine/docker-client.ts
+++ b/src/integration/container-engine/docker-client.ts
@@ -18,6 +18,7 @@ import {Architecture} from '../../business/utils/architecture.js';
 import {type ContainerEngineCommand} from './container-engine-command.js';
 import {PathEx} from '../../business/utils/path-ex.js';
 import {PodmanClient} from './podman-client.js';
+import {KindProviderResolver} from './kind-provider-resolver.js';
 import {ContainerEngineResourceInspector} from './container-engine-resource-inspector.js';
 import {ClusterNodeResumeOutcome} from './cluster-node-resume-outcome.js';
 import {type ContainerEngineResources} from './container-engine-resources.js';
@@ -184,7 +185,7 @@ export class DockerClient implements ContainerEngineClient {
       return cachedCommand;
     }
 
-    if (PodmanClient.kindProvider() !== constants.PODMAN) {
+    if (KindProviderResolver.current() !== constants.PODMAN) {
       const dockerCommand: ContainerEngineCommand = DockerClient.dockerCommand();
       if (await this.containerExists(dockerCommand, nodeName)) {
         this.kindContainerCommands.set(nodeName, dockerCommand);

--- a/src/integration/container-engine/docker-client.ts
+++ b/src/integration/container-engine/docker-client.ts
@@ -184,7 +184,7 @@ export class DockerClient implements ContainerEngineClient {
       return cachedCommand;
     }
 
-    if (constants.getEnvironmentVariable('KIND_EXPERIMENTAL_PROVIDER') !== constants.PODMAN) {
+    if (PodmanClient.kindProvider() !== constants.PODMAN) {
       const dockerCommand: ContainerEngineCommand = DockerClient.dockerCommand();
       if (await this.containerExists(dockerCommand, nodeName)) {
         this.kindContainerCommands.set(nodeName, dockerCommand);

--- a/src/integration/container-engine/kind-provider-resolver.ts
+++ b/src/integration/container-engine/kind-provider-resolver.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import * as constants from '../../core/constants.js';
+import {SubprocessEnvironment} from '../../core/subprocess-environment.js';
+
+/** Resolves which container engine backs kind; neither engine client owns the question. */
+export class KindProviderResolver {
+  /** The kind provider in effect: the session value, else a user-provided `KIND_EXPERIMENTAL_PROVIDER`. */
+  public static current(): string | undefined {
+    return (
+      SubprocessEnvironment.sessionVariable('KIND_EXPERIMENTAL_PROVIDER') ??
+      constants.getEnvironmentVariable('KIND_EXPERIMENTAL_PROVIDER')
+    );
+  }
+}

--- a/src/integration/container-engine/podman-client.ts
+++ b/src/integration/container-engine/podman-client.ts
@@ -11,6 +11,7 @@ import {PathEx} from '../../business/utils/path-ex.js';
 import {PodmanDependencyManager} from '../../core/dependency-managers/podman-dependency-manager.js';
 import {SubprocessCommandProfile} from '../../core/subprocess-command-profile.js';
 import {SubprocessEnvironment} from '../../core/subprocess-environment.js';
+import {KindProviderResolver} from './kind-provider-resolver.js';
 
 @injectable()
 export class PodmanClient {
@@ -34,18 +35,6 @@ export class PodmanClient {
       .containerConfigEnvironment();
   }
 
-  /**
-   * The kind provider in effect for this solo invocation: the session value set when solo
-   * configures kind to use podman, falling back to a user-provided `KIND_EXPERIMENTAL_PROVIDER`
-   * environment variable.
-   */
-  public static kindProvider(): string | undefined {
-    return (
-      SubprocessEnvironment.sessionVariable('KIND_EXPERIMENTAL_PROVIDER') ??
-      constants.getEnvironmentVariable('KIND_EXPERIMENTAL_PROVIDER')
-    );
-  }
-
   public async getKindContainerCommand(nodeName: string): Promise<ContainerEngineCommand | undefined> {
     const detectedCommand: ContainerEngineCommand | undefined = this.podmanUnavailable
       ? undefined
@@ -55,7 +44,7 @@ export class PodmanClient {
       return detectedCommand;
     }
 
-    if (PodmanClient.kindProvider() === constants.PODMAN) {
+    if (KindProviderResolver.current() === constants.PODMAN) {
       return PodmanClient.podmanCommand();
     }
 

--- a/src/integration/container-engine/podman-client.ts
+++ b/src/integration/container-engine/podman-client.ts
@@ -10,6 +10,7 @@ import * as constants from '../../core/constants.js';
 import {PathEx} from '../../business/utils/path-ex.js';
 import {PodmanDependencyManager} from '../../core/dependency-managers/podman-dependency-manager.js';
 import {SubprocessCommandProfile} from '../../core/subprocess-command-profile.js';
+import {SubprocessEnvironment} from '../../core/subprocess-environment.js';
 
 @injectable()
 export class PodmanClient {
@@ -33,6 +34,18 @@ export class PodmanClient {
       .containerConfigEnvironment();
   }
 
+  /**
+   * The kind provider in effect for this solo invocation: the session value set when solo
+   * configures kind to use podman, falling back to a user-provided `KIND_EXPERIMENTAL_PROVIDER`
+   * environment variable.
+   */
+  public static kindProvider(): string | undefined {
+    return (
+      SubprocessEnvironment.sessionVariable('KIND_EXPERIMENTAL_PROVIDER') ??
+      constants.getEnvironmentVariable('KIND_EXPERIMENTAL_PROVIDER')
+    );
+  }
+
   public async getKindContainerCommand(nodeName: string): Promise<ContainerEngineCommand | undefined> {
     const detectedCommand: ContainerEngineCommand | undefined = this.podmanUnavailable
       ? undefined
@@ -42,7 +55,7 @@ export class PodmanClient {
       return detectedCommand;
     }
 
-    if (constants.getEnvironmentVariable('KIND_EXPERIMENTAL_PROVIDER') === constants.PODMAN) {
+    if (PodmanClient.kindProvider() === constants.PODMAN) {
       return PodmanClient.podmanCommand();
     }
 
@@ -56,7 +69,7 @@ export class PodmanClient {
     engineCommand: ContainerEngineCommand,
   ): Promise<void> {
     const kindArguments: string[] = ['load', 'image-archive', archivePath, '--name', clusterName];
-    const pathEnvironment: string = `${PathEx.dirname(kindExecutable)}${PathEx.delimiter}${process.env.PATH || ''}`;
+    const pathEnvironment: string = `${PathEx.dirname(kindExecutable)}${PathEx.delimiter}${SubprocessEnvironment.currentPath()}`;
     const configEnvironment: Record<string, string> = this.containerConfigEnvironment();
 
     if (PodmanClient.isSudoPodmanCommand(engineCommand)) {
@@ -97,7 +110,7 @@ export class PodmanClient {
       argumentsPrefix: [
         '-n',
         'env',
-        `PATH=${process.env.PATH || ''}`,
+        `PATH=${SubprocessEnvironment.currentPath()}`,
         ...PodmanDependencyManager.toEnvironmentArguments(this.containerConfigEnvironment()),
         constants.PODMAN,
       ],

--- a/src/integration/execution-builder.ts
+++ b/src/integration/execution-builder.ts
@@ -1,15 +1,32 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import path from 'node:path';
+import {SoloErrors} from '../core/errors/solo-errors.js';
+import {SubprocessEnvironment} from '../core/subprocess-environment.js';
 
 export class ExecutionBuilder {
-  public prefixPath(environment: Record<string, string>, prefix: string): void {
-    // find the PATH variable in the environment variables, ignoring case sensitivity, POSIX is PATH, Windows is Path or PATH
-    const pathKey: string = Object.keys(environment).find((key: string): boolean => key.toLowerCase() === 'path');
-    if (pathKey) {
-      environment[pathKey] = `${prefix}${path.delimiter}${environment[pathKey]}`;
-    } else {
-      environment['PATH'] = prefix || '';
+  /** The flags to be passed to the command. */
+  protected readonly _flags: string[] = [];
+
+  /**
+   * Adds a flag to the execution.
+   * @param flag the flag to add; must start with `-`, else the CLI silently treats it as a positional argument
+   * @returns this builder
+   */
+  public flag(flag: string): this {
+    if (!flag) {
+      throw new SoloErrors.validation.illegalArgument('flag must not be null', flag);
     }
+    if (!flag.startsWith('-')) {
+      throw new SoloErrors.validation.illegalArgument('flag must start with "-"', flag);
+    }
+    this._flags.push(flag);
+    return this;
+  }
+
+  public prefixPath(environment: Record<string, string>, prefix: string): void {
+    const pathKey: string = SubprocessEnvironment.pathKey(environment);
+    const existingPath: string | undefined = environment[pathKey];
+    environment[pathKey] = existingPath ? `${prefix}${path.delimiter}${existingPath}` : prefix || '';
   }
 }

--- a/src/integration/helm/execution/helm-execution-builder.ts
+++ b/src/integration/helm/execution/helm-execution-builder.ts
@@ -40,11 +40,6 @@ export class HelmExecutionBuilder extends ExecutionBuilder {
   private readonly _optionsWithMultipleValues: Array<{key: string; value: string[]}> = [];
 
   /**
-   * The flags to be passed to the helm command.
-   */
-  private readonly _flags: string[] = [];
-
-  /**
    * The positional arguments to be passed to the helm command.
    */
   private readonly _positionals: string[] = [];
@@ -166,20 +161,6 @@ export class HelmExecutionBuilder extends ExecutionBuilder {
     }
 
     this._environmentVariables.set(name, value);
-    return this;
-  }
-
-  /**
-   * Adds a flag to the helm execution.
-   * @param flag the flag to be added
-   * @returns this builder
-   */
-  public flag(flag: string): HelmExecutionBuilder {
-    if (!flag) {
-      throw new Error('flag must not be null');
-    }
-
-    this._flags.push(flag);
     return this;
   }
 

--- a/src/integration/helm/impl/default-helm-client.ts
+++ b/src/integration/helm/impl/default-helm-client.ts
@@ -33,6 +33,7 @@ import {HelmDockerAuthStaleException} from '../helm-docker-auth-stale-exception.
 import {RepositoryUpdateRequest} from '../request/repository/repository-update-request.js';
 import path from 'node:path';
 import {SemanticVersion} from '../../../business/utils/semantic-version.js';
+import {SubprocessEnvironment} from '../../../core/subprocess-environment.js';
 import {ChartPullRequest} from '../request/chart/chart-pull-request.js';
 
 type BiFunction<T, U, R> = (t: T, u: U) => R;
@@ -191,7 +192,10 @@ export class DefaultHelmClient implements HelmClient {
       builder.argument(DefaultHelmClient.NAMESPACE_ARG_NAME, namespace);
     }
 
-    builder.environmentVariable('PATH', `${this.installationDirectory}${path.delimiter}${process.env.PATH}`);
+    builder.environmentVariable(
+      'PATH',
+      `${this.installationDirectory}${path.delimiter}${SubprocessEnvironment.currentPath()}`,
+    );
     const execution: HelmExecution = builder.build();
 
     try {

--- a/src/integration/kind/execution/kind-execution-builder.ts
+++ b/src/integration/kind/execution/kind-execution-builder.ts
@@ -7,7 +7,6 @@ import {inject, injectable} from 'tsyringe-neo';
 import {ExecutionBuilder} from '../../execution-builder.js';
 import {SubprocessEnvironment} from '../../../core/subprocess-environment.js';
 import {SubprocessCommandProfile} from '../../../core/subprocess-command-profile.js';
-import {SoloErrors} from '../../../core/errors/solo-errors.js';
 
 /**
  * A builder for creating a kind command execution.
@@ -36,11 +35,6 @@ export class KindExecutionBuilder extends ExecutionBuilder {
    * The list of options and a list of their one or more values.
    */
   private readonly _optionsWithMultipleValues: Array<{key: string; value: string[]}> = [];
-
-  /**
-   * The flags to be passed to the kind command.
-   */
-  private readonly _flags: string[] = [];
 
   /**
    * The positional arguments to be passed to the kind command.
@@ -148,23 +142,6 @@ export class KindExecutionBuilder extends ExecutionBuilder {
       throw new Error(KindExecutionBuilder.VALUE_MUST_NOT_BE_NULL);
     }
     this._environmentVariables.set(name, value);
-    return this;
-  }
-
-  /**
-   * Adds a flag to the kind execution.
-   * @param flag the flag to be added; must start with `-` (e.g. `--retain`), because kind
-   *   silently treats a bare word as a positional argument instead of an option
-   * @returns this builder
-   */
-  public flag(flag: string): KindExecutionBuilder {
-    if (!flag) {
-      throw new Error('flag must not be null');
-    }
-    if (!flag.startsWith('-')) {
-      throw new SoloErrors.validation.illegalArgument('flag must start with "-"', flag);
-    }
-    this._flags.push(flag);
     return this;
   }
 

--- a/src/integration/kind/execution/kind-execution-builder.ts
+++ b/src/integration/kind/execution/kind-execution-builder.ts
@@ -7,6 +7,7 @@ import {inject, injectable} from 'tsyringe-neo';
 import {ExecutionBuilder} from '../../execution-builder.js';
 import {SubprocessEnvironment} from '../../../core/subprocess-environment.js';
 import {SubprocessCommandProfile} from '../../../core/subprocess-command-profile.js';
+import {SoloErrors} from '../../../core/errors/solo-errors.js';
 
 /**
  * A builder for creating a kind command execution.
@@ -152,12 +153,16 @@ export class KindExecutionBuilder extends ExecutionBuilder {
 
   /**
    * Adds a flag to the kind execution.
-   * @param flag the flag to be added
+   * @param flag the flag to be added; must start with `-` (e.g. `--retain`), because kind
+   *   silently treats a bare word as a positional argument instead of an option
    * @returns this builder
    */
   public flag(flag: string): KindExecutionBuilder {
     if (!flag) {
       throw new Error('flag must not be null');
+    }
+    if (!flag.startsWith('-')) {
+      throw new SoloErrors.validation.illegalArgument('flag must start with "-"', flag);
     }
     this._flags.push(flag);
     return this;

--- a/src/integration/kind/impl/default-kind-client.ts
+++ b/src/integration/kind/impl/default-kind-client.ts
@@ -50,6 +50,7 @@ import {InjectTokens} from '../../../core/dependency-injection/inject-tokens.js'
 import {type SoloLogger} from '../../../core/logging/solo-logger.js';
 import {patchInject} from '../../../core/dependency-injection/container-helper.js';
 import path from 'node:path';
+import {SubprocessEnvironment} from '../../../core/subprocess-environment.js';
 import {SemanticVersion} from '../../../business/utils/semantic-version.js';
 
 type BiFunction<T, U, R> = (t: T, u: U) => R;
@@ -164,7 +165,10 @@ export class DefaultKindClient implements KindClient {
   private async executeCall<T extends KindRequest>(request: T): Promise<void> {
     const builder: KindExecutionBuilder = new KindExecutionBuilder();
     builder.executable(this.executable);
-    builder.environmentVariable('PATH', `${this.installationDirectory}${path.delimiter}${process.env.PATH}`);
+    builder.environmentVariable(
+      'PATH',
+      `${this.installationDirectory}${path.delimiter}${SubprocessEnvironment.currentPath()}`,
+    );
     request.apply(builder);
     const execution: KindExecution = builder.build();
     await execution.call();
@@ -216,7 +220,10 @@ export class DefaultKindClient implements KindClient {
 
     const builder: KindExecutionBuilder = new KindExecutionBuilder();
     builder.executable(this.executable);
-    builder.environmentVariable('PATH', `${this.installationDirectory}${path.delimiter}${process.env.PATH}`);
+    builder.environmentVariable(
+      'PATH',
+      `${this.installationDirectory}${path.delimiter}${SubprocessEnvironment.currentPath()}`,
+    );
     request.apply(builder);
     const execution: KindExecution = builder.build();
     return responseFunction(execution, responseClass);

--- a/src/integration/kind/model/create-cluster/cluster-create-options.ts
+++ b/src/integration/kind/model/create-cluster/cluster-create-options.ts
@@ -63,7 +63,7 @@ export class ClusterCreateOptions implements Options {
       builder.argument('name', this._name);
     }
     if (this._retain) {
-      builder.flag('retain');
+      builder.flag('--retain');
     }
     if (this._wait) {
       builder.argument('wait', this._wait);

--- a/src/integration/kind/model/export-kubeconfig/export-kubeconfig-options.ts
+++ b/src/integration/kind/model/export-kubeconfig/export-kubeconfig-options.ts
@@ -41,7 +41,7 @@ export class ExportKubeConfigOptions implements Options {
       builder.argument('name', this._name);
     }
     if (this._internal) {
-      builder.flag('internal');
+      builder.flag('--internal');
     }
     if (this._kubeconfig) {
       builder.argument('kubeconfig', this._kubeconfig);

--- a/src/integration/kube/k8-client/resources/container/k8-client-container.ts
+++ b/src/integration/kube/k8-client/resources/container/k8-client-container.ts
@@ -83,7 +83,7 @@ export class K8ClientContainer implements Container {
         fullArguments,
         {
           env: SubprocessEnvironment.forCommand(SubprocessCommandProfile.KUBECTL, {
-            PATH: `${this.kubectlInstallationDirectory}${path.delimiter}${process.env.PATH}`,
+            PATH: `${this.kubectlInstallationDirectory}${path.delimiter}${SubprocessEnvironment.currentPath()}`,
           }),
           stdio: ['ignore', 'pipe', 'pipe'],
           windowsHide: os.platform() === 'win32',

--- a/src/integration/kube/k8-client/resources/pod/k8-client-pod.ts
+++ b/src/integration/kube/k8-client/resources/pod/k8-client-pod.ts
@@ -32,6 +32,7 @@ import {K8ClientContainerStatus} from './k8-client-container-status.js';
 import {type ContainerStatus} from '../../../resources/pod/container-status.js';
 import {ShellRunner} from '../../../../../core/shell-runner.js';
 import {SubprocessCommandProfile} from '../../../../../core/subprocess-command-profile.js';
+import {SubprocessEnvironment} from '../../../../../core/subprocess-environment.js';
 import chalk from 'chalk';
 import http from 'node:http';
 import os from 'node:os';
@@ -294,7 +295,7 @@ export class K8ClientPod implements Pod {
         detached: true,
         commandProfile: SubprocessCommandProfile.KUBECTL,
         environmentVariablesToAppend: {
-          PATH: `${this.kubectlInstallationDirectory}${path.delimiter}${process.env.PATH}`,
+          PATH: `${this.kubectlInstallationDirectory}${path.delimiter}${SubprocessEnvironment.currentPath()}`,
         },
         useShell: false,
       });

--- a/src/integration/kube/k8-client/resources/pod/persist-port-forward.ts
+++ b/src/integration/kube/k8-client/resources/pod/persist-port-forward.ts
@@ -190,8 +190,9 @@ async function executeKubectl(
     const kubectlCommand: string = KUBECTL_EXECUTABLE || 'kubectl';
 
     const kubectlProcess: ChildProcess = spawn(kubectlCommand, commandArguments, {
+      // The parent baked its session PATH and variables into this worker's environment at spawn.
       env: SubprocessEnvironment.forCommand(SubprocessCommandProfile.KUBECTL, {
-        PATH: `${kubectlInstallationDirectory}${path.delimiter}${process.env.PATH}`,
+        PATH: `${kubectlInstallationDirectory}${path.delimiter}${SubprocessEnvironment.currentPath()}`,
       }),
       stdio: options.captureOutput ? ['ignore', 'pipe', 'pipe'] : 'inherit',
       windowsHide: os.platform() === 'win32',

--- a/test/unit/core/dependency-managers/podman-dependency-manager.test.ts
+++ b/test/unit/core/dependency-managers/podman-dependency-manager.test.ts
@@ -172,7 +172,7 @@ describe('PodmanDependencyManager', (): void => {
     });
 
     afterEach((): void => {
-      SubprocessEnvironment.clearSessionState();
+      SubprocessEnvironment.resetForTesting();
     });
 
     it('should register CONTAINERS_CONF as session state instead of mutating process.env', async (): Promise<void> => {

--- a/test/unit/core/dependency-managers/podman-dependency-manager.test.ts
+++ b/test/unit/core/dependency-managers/podman-dependency-manager.test.ts
@@ -14,6 +14,7 @@ import {PodmanDependencyManager as PodmanDependencyManagerClass} from '../../../
 import {OperatingSystem} from '../../../../src/business/utils/operating-system.js';
 import {PathEx} from '../../../../src/business/utils/path-ex.js';
 import * as constants from '../../../../src/core/constants.js';
+import {SubprocessEnvironment} from '../../../../src/core/subprocess-environment.js';
 
 describe('PodmanDependencyManager', (): void => {
   let podmanDependencyManager: PodmanDependencyManager;
@@ -155,6 +156,34 @@ describe('PodmanDependencyManager', (): void => {
       await expect(podmanDependencyManager.setupConfig()).to.be.rejectedWith(
         'runtimeBinaryDirectory is required to configure rootful podman',
       );
+    });
+  });
+
+  describe('setupConfig in virtual-machine mode', (): void => {
+    beforeEach((): void => {
+      sinon.stub(OperatingSystem, 'isLinux').returns(false);
+
+      const templatesDirectory: string = PathEx.join(cacheDirectory, 'templates', 'podman');
+      fs.mkdirSync(templatesDirectory, {recursive: true});
+      fs.copyFileSync(
+        PathEx.join(constants.RESOURCES_DIR, 'templates', 'podman', 'containers.conf'),
+        PathEx.join(templatesDirectory, 'containers.conf'),
+      );
+    });
+
+    afterEach((): void => {
+      SubprocessEnvironment.clearSessionState();
+    });
+
+    it('should register CONTAINERS_CONF as session state instead of mutating process.env', async (): Promise<void> => {
+      const previousValue: string | undefined = process.env.CONTAINERS_CONF;
+
+      await podmanDependencyManager.setupConfig();
+
+      expect(SubprocessEnvironment.sessionVariable('CONTAINERS_CONF')).to.equal(
+        PathEx.join(configDirectory, 'containers.conf'),
+      );
+      expect(process.env.CONTAINERS_CONF).to.equal(previousValue);
     });
   });
 });

--- a/test/unit/core/helm/execution/helm-execution-builder.test.ts
+++ b/test/unit/core/helm/execution/helm-execution-builder.test.ts
@@ -29,6 +29,23 @@ describe('HelmExecutionBuilder', (): void => {
     }).to.throw(Error);
   });
 
+  describe('flag', (): void => {
+    it('should add a flag', (): void => {
+      const builder: HelmExecutionBuilder = new HelmExecutionBuilder();
+      expect(builder.flag('--atomic')).to.equal(builder);
+    });
+
+    it('should throw error if flag is null', (): void => {
+      const builder: HelmExecutionBuilder = new HelmExecutionBuilder();
+      expect((): HelmExecutionBuilder => builder.flag(null as any)).to.throw('flag must not be null');
+    });
+
+    it('should throw error if flag does not start with a dash', (): void => {
+      const builder: HelmExecutionBuilder = new HelmExecutionBuilder();
+      expect((): HelmExecutionBuilder => builder.flag('atomic')).to.throw('flag must start with "-"');
+    });
+  });
+
   it('builds a minimal helm environment: keeps KUBECONFIG/HELM_*, drops arbitrary secrets', (): void => {
     process.env.KUBECONFIG = '/home/user/.kube/config';
     process.env.HELM_REPOSITORY_CONFIG = '/home/user/.config/helm/repositories.yaml';

--- a/test/unit/core/helm/execution/helm-execution-builder.test.ts
+++ b/test/unit/core/helm/execution/helm-execution-builder.test.ts
@@ -35,9 +35,9 @@ describe('HelmExecutionBuilder', (): void => {
       expect(builder.flag('--atomic')).to.equal(builder);
     });
 
-    it('should throw error if flag is null', (): void => {
+    it('should throw error if flag is empty', (): void => {
       const builder: HelmExecutionBuilder = new HelmExecutionBuilder();
-      expect((): HelmExecutionBuilder => builder.flag(null as any)).to.throw('flag must not be null');
+      expect((): HelmExecutionBuilder => builder.flag('')).to.throw('flag must not be null');
     });
 
     it('should throw error if flag does not start with a dash', (): void => {

--- a/test/unit/core/kind/default-kind-cluster/create-cluster.test.ts
+++ b/test/unit/core/kind/default-kind-cluster/create-cluster.test.ts
@@ -119,7 +119,7 @@ describe('DefaultKindClient - createCluster', (): void => {
     expect(argumentSpy.calledWith('wait', options.wait)).to.be.true;
 
     // Verify flags were set correctly
-    expect(flagSpy.calledWith('retain')).to.be.true;
+    expect(flagSpy.calledWith('--retain')).to.be.true;
   });
 
   it('should handle boolean options correctly', async (): Promise<void> => {
@@ -141,7 +141,7 @@ describe('DefaultKindClient - createCluster', (): void => {
     await client.createCluster(clusterName, options);
 
     // Should include options that are true
-    expect(flagSpy.calledWith('retain')).to.be.true;
+    expect(flagSpy.calledWith('--retain')).to.be.true;
 
     // Should set name as argument
     expect(argumentSpy.calledWith('name', clusterName)).to.be.true;

--- a/test/unit/core/kind/execution/kind-execution-builder.test.ts
+++ b/test/unit/core/kind/execution/kind-execution-builder.test.ts
@@ -60,7 +60,7 @@ describe('KindExecutionBuilder', (): void => {
 
   describe('flag', (): void => {
     it('should add a flag', (): void => {
-      const result: KindExecutionBuilder = builder.flag('quiet');
+      const result: KindExecutionBuilder = builder.flag('--quiet');
       expect(result).to.equal(builder); // Should return this for chaining
     });
 
@@ -72,6 +72,10 @@ describe('KindExecutionBuilder', (): void => {
         expect(error).to.be.instanceOf(Error);
         expect(error.message).to.equal('flag must not be null');
       }
+    });
+
+    it('should throw error if flag does not start with a dash', (): void => {
+      expect((): KindExecutionBuilder => builder.flag('retain')).to.throw('flag must start with "-"');
     });
   });
 
@@ -130,7 +134,7 @@ describe('KindExecutionBuilder', (): void => {
       builder
         .subcommands('create', 'cluster')
         .argument('name', 'test-cluster')
-        .flag('quiet')
+        .flag('--quiet')
         .positional('--config=config.yaml')
         .optionsWithMultipleValues('label', ['app=test', 'env=dev'])
         .environmentVariable('DEBUG', 'true');

--- a/test/unit/core/package-managers/brew-package-manager.test.ts
+++ b/test/unit/core/package-managers/brew-package-manager.test.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import path from 'node:path';
+import {type SinonStub} from 'sinon';
+import sinon from 'sinon';
+import {expect} from 'chai';
+import {describe, it, afterEach} from 'mocha';
+import {BrewPackageManager} from '../../../../src/core/package-managers/brew-package-manager.js';
+import {ShellRunner} from '../../../../src/core/shell-runner.js';
+import {SubprocessEnvironment} from '../../../../src/core/subprocess-environment.js';
+
+describe('BrewPackageManager', (): void => {
+  afterEach((): void => {
+    sinon.restore();
+    SubprocessEnvironment.clearSessionState();
+  });
+
+  it('install registers the brew shellenv variables and PATH directories as session state', async (): Promise<void> => {
+    const previousPath: string = process.env.PATH ?? '';
+    const previousHomebrewPrefix: string | undefined = process.env.HOMEBREW_PREFIX;
+    const runStub: SinonStub = sinon
+      .stub(ShellRunner.prototype, 'run')
+      .callsFake(async (_command: string, arguments_: string[] = []): Promise<string[]> => {
+        if (arguments_[0] === 'shellenv') {
+          return [
+            'export HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew";',
+            'export PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin${PATH+:$PATH}";',
+          ];
+        }
+        return [];
+      });
+
+    const packageManager: BrewPackageManager = new BrewPackageManager();
+    const available: boolean = await packageManager.install();
+
+    expect(available).to.be.true;
+    expect(runStub.called).to.be.true;
+    expect(SubprocessEnvironment.sessionVariable('HOMEBREW_PREFIX')).to.equal('/home/linuxbrew/.linuxbrew');
+    expect(SubprocessEnvironment.currentPath()).to.equal(
+      ['/home/linuxbrew/.linuxbrew/bin', '/home/linuxbrew/.linuxbrew/sbin', previousPath].join(path.delimiter),
+    );
+    // The global process environment must remain untouched.
+    expect(process.env.PATH).to.equal(previousPath);
+    expect(process.env.HOMEBREW_PREFIX).to.equal(previousHomebrewPrefix);
+  });
+});

--- a/test/unit/core/package-managers/brew-package-manager.test.ts
+++ b/test/unit/core/package-managers/brew-package-manager.test.ts
@@ -12,7 +12,7 @@ import {SubprocessEnvironment} from '../../../../src/core/subprocess-environment
 describe('BrewPackageManager', (): void => {
   afterEach((): void => {
     sinon.restore();
-    SubprocessEnvironment.clearSessionState();
+    SubprocessEnvironment.resetForTesting();
   });
 
   it('install registers the brew shellenv variables and PATH directories as session state', async (): Promise<void> => {

--- a/test/unit/core/subprocess-environment.test.ts
+++ b/test/unit/core/subprocess-environment.test.ts
@@ -205,7 +205,7 @@ describe('SubprocessEnvironment', (): void => {
 
   describe('session environment state', (): void => {
     afterEach((): void => {
-      SubprocessEnvironment.clearSessionState();
+      SubprocessEnvironment.resetForTesting();
     });
 
     it('forwards a session variable only to profiles whose allowlist includes it', (): void => {
@@ -227,6 +227,14 @@ describe('SubprocessEnvironment', (): void => {
       expect(SubprocessEnvironment.forCommand(SubprocessCommandProfile.KUBECTL).KUBECONFIG).to.equal(
         '/solo/kubeconfig',
       );
+    });
+
+    it('rejects PATH as a session variable regardless of casing', (): void => {
+      for (const name of ['PATH', 'Path', 'path']) {
+        expect((): void => SubprocessEnvironment.setSessionVariable(name, '/custom/bin'), name).to.throw(
+          'PATH must be registered with prependSessionPath/appendSessionPath',
+        );
+      }
     });
 
     it('exposes session variables through the sessionVariable getter', (): void => {

--- a/test/unit/core/subprocess-environment.test.ts
+++ b/test/unit/core/subprocess-environment.test.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import path from 'node:path';
 import {type SinonStub} from 'sinon';
 import sinon from 'sinon';
 import {expect} from 'chai';
@@ -200,5 +201,84 @@ describe('SubprocessEnvironment', (): void => {
     expect(environment.PATH).to.equal('/custom/bin:/usr/bin');
     // override is present even though KUBECONFIG is not on the generic allowlist
     expect(environment.KUBECONFIG).to.equal('/dev/null');
+  });
+
+  describe('session environment state', (): void => {
+    afterEach((): void => {
+      SubprocessEnvironment.clearSessionState();
+    });
+
+    it('forwards a session variable only to profiles whose allowlist includes it', (): void => {
+      SubprocessEnvironment.setSessionVariable('CONTAINERS_CONF', '/solo/config/containers.conf');
+
+      expect(SubprocessEnvironment.forCommand(SubprocessCommandProfile.CONTAINER_ENGINE).CONTAINERS_CONF).to.equal(
+        '/solo/config/containers.conf',
+      );
+      expect(SubprocessEnvironment.forCommand(SubprocessCommandProfile.KIND).CONTAINERS_CONF).to.equal(
+        '/solo/config/containers.conf',
+      );
+      expect(SubprocessEnvironment.forCommand(SubprocessCommandProfile.HELM)).to.not.have.property('CONTAINERS_CONF');
+    });
+
+    it('lets a session variable override the inherited parent value', (): void => {
+      setTemporaryEnvironmentVariable('KUBECONFIG', '/home/user/.kube/config');
+      SubprocessEnvironment.setSessionVariable('KUBECONFIG', '/solo/kubeconfig');
+
+      expect(SubprocessEnvironment.forCommand(SubprocessCommandProfile.KUBECTL).KUBECONFIG).to.equal(
+        '/solo/kubeconfig',
+      );
+    });
+
+    it('exposes session variables through the sessionVariable getter', (): void => {
+      expect(SubprocessEnvironment.sessionVariable('KIND_EXPERIMENTAL_PROVIDER')).to.equal(undefined);
+
+      SubprocessEnvironment.setSessionVariable('KIND_EXPERIMENTAL_PROVIDER', 'podman');
+
+      expect(SubprocessEnvironment.sessionVariable('KIND_EXPERIMENTAL_PROVIDER')).to.equal('podman');
+    });
+
+    it('wraps the inherited PATH with the session path additions', (): void => {
+      setTemporaryEnvironmentVariable('PATH', '/usr/bin');
+      SubprocessEnvironment.prependSessionPath('/home/linuxbrew/.linuxbrew/bin');
+      SubprocessEnvironment.appendSessionPath('/opt/podman/bin');
+
+      const environment: Record<string, string> = SubprocessEnvironment.forCommand(SubprocessCommandProfile.GENERIC);
+
+      const expectedPath: string = ['/home/linuxbrew/.linuxbrew/bin', '/usr/bin', '/opt/podman/bin'].join(
+        path.delimiter,
+      );
+      expect(environment.PATH).to.equal(expectedPath);
+      expect(SubprocessEnvironment.currentPath()).to.equal(expectedPath);
+    });
+
+    it('gives the most recently prepended directory the highest precedence', (): void => {
+      setTemporaryEnvironmentVariable('PATH', '/usr/bin');
+      SubprocessEnvironment.prependSessionPath('/first');
+      SubprocessEnvironment.prependSessionPath('/second');
+
+      expect(SubprocessEnvironment.currentPath()).to.equal(['/second', '/first', '/usr/bin'].join(path.delimiter));
+    });
+
+    it('ignores duplicate session path registrations', (): void => {
+      setTemporaryEnvironmentVariable('PATH', '/usr/bin');
+      SubprocessEnvironment.prependSessionPath('/solo/bin');
+      SubprocessEnvironment.appendSessionPath('/solo/bin');
+      SubprocessEnvironment.appendSessionPath('/solo/bin');
+
+      expect(SubprocessEnvironment.currentPath()).to.equal(['/solo/bin', '/usr/bin'].join(path.delimiter));
+    });
+
+    it('still applies overrides last, winning over session values', (): void => {
+      SubprocessEnvironment.setSessionVariable('KUBECONFIG', '/solo/kubeconfig');
+      SubprocessEnvironment.appendSessionPath('/solo/bin');
+
+      const environment: Record<string, string> = SubprocessEnvironment.forCommand(SubprocessCommandProfile.KUBECTL, {
+        KUBECONFIG: '/dev/null',
+        PATH: '/custom/bin',
+      });
+
+      expect(environment.KUBECONFIG).to.equal('/dev/null');
+      expect(environment.PATH).to.equal('/custom/bin');
+    });
   });
 });

--- a/test/unit/integration/container-engine/kind-provider-resolver.test.ts
+++ b/test/unit/integration/container-engine/kind-provider-resolver.test.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {expect} from 'chai';
+import {afterEach, beforeEach, describe, it} from 'mocha';
+import {KindProviderResolver} from '../../../../src/integration/container-engine/kind-provider-resolver.js';
+import {SubprocessEnvironment} from '../../../../src/core/subprocess-environment.js';
+
+describe('KindProviderResolver', (): void => {
+  let previousKindProvider: string | undefined;
+
+  beforeEach((): void => {
+    previousKindProvider = process.env.KIND_EXPERIMENTAL_PROVIDER;
+  });
+
+  afterEach((): void => {
+    SubprocessEnvironment.resetForTesting();
+    if (previousKindProvider === undefined) {
+      delete process.env.KIND_EXPERIMENTAL_PROVIDER;
+    } else {
+      process.env.KIND_EXPERIMENTAL_PROVIDER = previousKindProvider;
+    }
+  });
+
+  it('returns undefined when neither session state nor the environment set a provider', (): void => {
+    delete process.env.KIND_EXPERIMENTAL_PROVIDER;
+
+    expect(KindProviderResolver.current()).to.equal(undefined);
+  });
+
+  it('falls back to a user-provided KIND_EXPERIMENTAL_PROVIDER environment variable', (): void => {
+    process.env.KIND_EXPERIMENTAL_PROVIDER = 'podman';
+
+    expect(KindProviderResolver.current()).to.equal('podman');
+  });
+
+  it('prefers the session value over the environment variable', (): void => {
+    process.env.KIND_EXPERIMENTAL_PROVIDER = 'docker';
+    SubprocessEnvironment.setSessionVariable('KIND_EXPERIMENTAL_PROVIDER', 'podman');
+
+    expect(KindProviderResolver.current()).to.equal('podman');
+  });
+});

--- a/test/unit/integration/container-engine/podman-client.test.ts
+++ b/test/unit/integration/container-engine/podman-client.test.ts
@@ -8,6 +8,7 @@ import {type SoloLogger} from '../../../../src/core/logging/solo-logger.js';
 import {PodmanClient} from '../../../../src/integration/container-engine/podman-client.js';
 import {type ContainerEngineCommand} from '../../../../src/integration/container-engine/container-engine-command.js';
 import {PodmanDependencyManager} from '../../../../src/core/dependency-managers/podman-dependency-manager.js';
+import {SubprocessEnvironment} from '../../../../src/core/subprocess-environment.js';
 
 describe('PodmanClient', (): void => {
   let previousKindProvider: string | undefined;
@@ -176,6 +177,31 @@ describe('PodmanClient', (): void => {
       'sudo',
       PodmanClientTestBuilder.sudoKindLoadImageArchiveArguments(kindExecutable, '/tmp/busybox.tar', 'kind'),
     );
+  });
+
+  describe('kindProvider', (): void => {
+    afterEach((): void => {
+      SubprocessEnvironment.clearSessionState();
+    });
+
+    it('returns undefined when neither session state nor the environment set a provider', (): void => {
+      delete process.env.KIND_EXPERIMENTAL_PROVIDER;
+
+      expect(PodmanClient.kindProvider()).to.equal(undefined);
+    });
+
+    it('falls back to a user-provided KIND_EXPERIMENTAL_PROVIDER environment variable', (): void => {
+      process.env.KIND_EXPERIMENTAL_PROVIDER = 'podman';
+
+      expect(PodmanClient.kindProvider()).to.equal('podman');
+    });
+
+    it('prefers the session value over the environment variable', (): void => {
+      process.env.KIND_EXPERIMENTAL_PROVIDER = 'docker';
+      SubprocessEnvironment.setSessionVariable('KIND_EXPERIMENTAL_PROVIDER', 'podman');
+
+      expect(PodmanClient.kindProvider()).to.equal('podman');
+    });
   });
 });
 

--- a/test/unit/integration/container-engine/podman-client.test.ts
+++ b/test/unit/integration/container-engine/podman-client.test.ts
@@ -8,7 +8,6 @@ import {type SoloLogger} from '../../../../src/core/logging/solo-logger.js';
 import {PodmanClient} from '../../../../src/integration/container-engine/podman-client.js';
 import {type ContainerEngineCommand} from '../../../../src/integration/container-engine/container-engine-command.js';
 import {PodmanDependencyManager} from '../../../../src/core/dependency-managers/podman-dependency-manager.js';
-import {SubprocessEnvironment} from '../../../../src/core/subprocess-environment.js';
 
 describe('PodmanClient', (): void => {
   let previousKindProvider: string | undefined;
@@ -177,31 +176,6 @@ describe('PodmanClient', (): void => {
       'sudo',
       PodmanClientTestBuilder.sudoKindLoadImageArchiveArguments(kindExecutable, '/tmp/busybox.tar', 'kind'),
     );
-  });
-
-  describe('kindProvider', (): void => {
-    afterEach((): void => {
-      SubprocessEnvironment.clearSessionState();
-    });
-
-    it('returns undefined when neither session state nor the environment set a provider', (): void => {
-      delete process.env.KIND_EXPERIMENTAL_PROVIDER;
-
-      expect(PodmanClient.kindProvider()).to.equal(undefined);
-    });
-
-    it('falls back to a user-provided KIND_EXPERIMENTAL_PROVIDER environment variable', (): void => {
-      process.env.KIND_EXPERIMENTAL_PROVIDER = 'podman';
-
-      expect(PodmanClient.kindProvider()).to.equal('podman');
-    });
-
-    it('prefers the session value over the environment variable', (): void => {
-      process.env.KIND_EXPERIMENTAL_PROVIDER = 'docker';
-      SubprocessEnvironment.setSessionVariable('KIND_EXPERIMENTAL_PROVIDER', 'podman');
-
-      expect(PodmanClient.kindProvider()).to.equal('podman');
-    });
   });
 });
 


### PR DESCRIPTION
## Description

### Kind flags passed as bare words

`ClusterCreateOptions` passed `retain` and `ExportKubeConfigOptions` passed `internal` without the `--` prefix, so kind treated them as positional arguments and the options did nothing. Both are now passed as `--retain` / `--internal`, and `KindExecutionBuilder.flag()` rejects any value that does not start with `-` (via `SoloErrors.validation.illegalArgument`), so this class of bug fails fast in the future. Neither option is currently set to `true` anywhere in `src/`, so the fix has no behavioral impact on existing flows.

### Global `process.env` mutations

Five places mutated `process.env` to influence later subprocess spawns (`cluster-task-manager.ts`, `brew-package-manager.ts`, `podman-dependency-manager.ts`). These mutations were load-bearing: the values flow to child processes through the `SubprocessEnvironment` per-profile allowlists, and `KIND_EXPERIMENTAL_PROVIDER` is additionally read back in-process by `PodmanClient` / `DockerClient` to decide which container engine backs kind.

Instead of threading overrides through every call path, `SubprocessEnvironment` now owns explicit session-scoped state:

* `setSessionVariable()` / `sessionVariable()` — runtime-established variables, merged over the parent environment **before** allowlist filtering, so they behave exactly like inherited variables without the global mutation.
* `prependSessionPath()` / `appendSessionPath()` / `currentPath()` — PATH additions (brew bin directories, brew-installed podman), applied to the PATH of every spawned command and available to the call sites that build explicit `sudo env PATH=...` prefixes.

All five mutation sites now register session state instead. The in-process reads were consolidated into `PodmanClient.kindProvider()`, which prefers the session value and falls back to a user-provided `KIND_EXPERIMENTAL_PROVIDER` environment variable, preserving existing behavior for users who set it themselves. PATH readers that fed spawned commands (`cluster-task-manager`, `podman-client`, `default-kind-client`) now use `SubprocessEnvironment.currentPath()` so they keep seeing the session additions.

### Testing

* New unit tests for the session state (allowlist filtering, precedence, PATH wrapping, dedupe, override precedence).
* New `BrewPackageManager` unit test covering the `brew shellenv` parsing into session state.
* New `setupConfig` virtual-machine-mode test asserting `CONTAINERS_CONF` lands in session state and `process.env` stays untouched.
* New `PodmanClient.kindProvider()` precedence tests, plus the flag-guard test; existing tests that locked in the bare `retain` flag updated to `--retain`.

### Related Issues

Closes #5872