### PR TITLE
fix: finish the shell exec hardening in src

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,6 +48,88 @@ const soloLocalPlugin = {
       },
     },
 
+    // Every direct node:child_process invocation must state its `shell` option explicitly, so the
+    // call site documents that no shell interprets its arguments; exec/execSync always run a shell
+    // and are banned outright. PR #4804 swept the implicit-shell call sites once already and they
+    // drifted back (#5869) — this rule keeps them out.
+    'require-explicit-shell': {
+      meta: {
+        type: 'problem',
+        docs: {
+          description: 'Require an explicit `shell` option on child_process calls and ban exec/execSync.',
+        },
+        schema: [],
+        messages: {
+          missingShell:
+            'Pass an explicit `shell` option (normally `shell: false`) to child_process.{{name}} ' +
+            'so the call site documents that no shell interprets its arguments.',
+          shellOnly: 'child_process.{{name}} always runs a shell — use execFile/spawn with an argument array instead.',
+        },
+      },
+      create(context) {
+        const spawnLikeNames = new Set(['spawn', 'spawnSync', 'execFile', 'execFileSync']);
+        const shellOnlyNames = new Set(['exec', 'execSync']);
+        const namedImportLocals = new Map(); // local identifier name -> imported child_process member name
+        const moduleObjectLocals = new Set(); // locals bound to the whole module (namespace/default import)
+
+        function hasExplicitShellOption(callArguments) {
+          return callArguments.some(
+            argument =>
+              argument.type === 'ObjectExpression' &&
+              argument.properties.some(
+                property =>
+                  property.type === 'Property' &&
+                  !property.computed &&
+                  (property.key.name === 'shell' || property.key.value === 'shell'),
+              ),
+          );
+        }
+
+        function childProcessMemberName(callee) {
+          if (callee.type === 'Identifier') {
+            return namedImportLocals.get(callee.name);
+          }
+          if (
+            callee.type === 'MemberExpression' &&
+            !callee.computed &&
+            callee.object.type === 'Identifier' &&
+            moduleObjectLocals.has(callee.object.name)
+          ) {
+            return callee.property.name;
+          }
+          return undefined;
+        }
+
+        return {
+          ImportDeclaration(node) {
+            if (node.source.value !== 'node:child_process' && node.source.value !== 'child_process') {
+              return;
+            }
+            for (const specifier of node.specifiers) {
+              if (specifier.type === 'ImportSpecifier') {
+                namedImportLocals.set(specifier.local.name, specifier.imported.name);
+              } else {
+                moduleObjectLocals.add(specifier.local.name);
+              }
+            }
+          },
+          CallExpression(node) {
+            const name = childProcessMemberName(node.callee);
+            if (name === undefined) {
+              return;
+            }
+            if (shellOnlyNames.has(name)) {
+              context.report({node, messageId: 'shellOnly', data: {name}});
+              return;
+            }
+            if (spawnLikeNames.has(name) && !hasExplicitShellOption(node.arguments)) {
+              context.report({node, messageId: 'missingShell', data: {name}});
+            }
+          },
+        };
+      },
+    },
+
     // Each exported interface must be in its own file named in kebab-case matching the
     // interface name — §3.5. No off-the-shelf rule covers name-matching; unicorn/filename-case
     // enforces kebab-case style but not that the filename matches the interface name.
@@ -314,11 +396,13 @@ export default [
   {
     // No exported functions in source code — see §10.3.1.
     // One exported interface per file, filename matches interface name in kebab-case — see §3.5.
+    // Explicit `shell` option on every child_process call — see #5869.
     files: ['src/**/*.ts'],
     plugins: {solo: soloLocalPlugin},
     rules: {
       'solo/no-exported-function': 'error',
       'solo/exported-interface-in-own-file': 'error',
+      'solo/require-explicit-shell': 'error',
     },
   },
   {

--- a/src/business/utils/file-permissions.ts
+++ b/src/business/utils/file-permissions.ts
@@ -93,6 +93,7 @@ export class FilePermissions {
       // `/inheritance:r` drops all inherited ACEs (removing the broad BUILTIN\Users access that is the
       // Windows analogue of group/other), and `/grant:r` replaces any existing grant for the user.
       execFileSync('icacls', [targetPath, '/inheritance:r', '/grant:r', `${principal}:${permissions}`], {
+        shell: false,
         stdio: 'ignore',
         env: SubprocessEnvironment.forCommand(SubprocessCommandProfile.GENERIC),
       });

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -3162,6 +3162,7 @@ export class NodeCommandTasks {
                   'helm',
                   ['get', 'values', release.name, '-n', release.namespace, '--kube-context', context, '--all'],
                   {
+                    shell: false,
                     encoding: 'utf8',
                     cwd: process.cwd(),
                     maxBuffer: 1024 * 1024 * 10, // 10MB buffer

--- a/src/commands/util/diagnostics-reporter.ts
+++ b/src/commands/util/diagnostics-reporter.ts
@@ -284,6 +284,7 @@ export class DiagnosticsReporter {
    */
   public static executeGhCommand(arguments_: string[]): SpawnSyncReturns<string> {
     return spawnSync('gh', arguments_, {
+      shell: false,
       encoding: 'utf8',
       env: SubprocessEnvironment.forCommand(SubprocessCommandProfile.GITHUB_CLI),
     });
@@ -309,9 +310,9 @@ export class DiagnosticsReporter {
     zipFilePath?: string,
   ): Promise<string> {
     // Write body to a temp file to avoid any shell interpretation of the markdown content.
-    // We use spawnSync without shell:true so the title and all other args are passed
-    // verbatim — ShellRunner uses shell:true which splits space-containing args into separate
-    // tokens, breaking both multi-word titles and multi-line bodies.
+    // spawnSync without a shell passes the title and all other args verbatim and returns the
+    // exit status synchronously — ShellRunner (also shell-less since #4804) is async and
+    // throws on a non-zero exit, which this flow inspects instead.
     const bodyFilePath: string = PathEx.join(os.tmpdir(), `solo-gh-issue-body-${Date.now()}.md`);
     fs.writeFileSync(bodyFilePath, body, 'utf8');
     try {

--- a/src/core/helpers.ts
+++ b/src/core/helpers.ts
@@ -751,6 +751,7 @@ export class Helpers {
     const fullImageName: string = `${imageName}:${imageTag}`;
     try {
       const output: string = execFileSync('docker', ['images', '--format', '{{.Repository}}:{{.Tag}}'], {
+        shell: false,
         encoding: 'utf8',
         stdio: 'pipe',
         env: SubprocessEnvironment.forCommand(SubprocessCommandProfile.CONTAINER_ENGINE),

--- a/src/core/lock/lock-holder.ts
+++ b/src/core/lock/lock-holder.ts
@@ -157,6 +157,7 @@ export class LockHolder {
         // `ps -o stat= -p <pid>` prints the process state with no header; the first character is
         // 'T' for a stopped process. We do not pass a shell — args are array-passed to execFile.
         const stat: string = execFileSync('ps', ['-o', 'stat=', '-p', String(this._processId)], {
+          shell: false,
           encoding: 'utf8',
           stdio: ['ignore', 'pipe', 'ignore'],
           env: SubprocessEnvironment.forCommand(SubprocessCommandProfile.GENERIC),

--- a/src/integration/kube/k8-client/resources/container/k8-client-container.ts
+++ b/src/integration/kube/k8-client/resources/container/k8-client-container.ts
@@ -82,6 +82,7 @@ export class K8ClientContainer implements Container {
         constants.KUBECTL,
         fullArguments,
         {
+          shell: false,
           env: SubprocessEnvironment.forCommand(SubprocessCommandProfile.KUBECTL, {
             PATH: `${this.kubectlInstallationDirectory}${path.delimiter}${process.env.PATH}`,
           }),

--- a/src/integration/kube/k8-client/resources/pod/persist-port-forward.ts
+++ b/src/integration/kube/k8-client/resources/pod/persist-port-forward.ts
@@ -190,6 +190,7 @@ async function executeKubectl(
     const kubectlCommand: string = KUBECTL_EXECUTABLE || 'kubectl';
 
     const kubectlProcess: ChildProcess = spawn(kubectlCommand, commandArguments, {
+      shell: false,
       env: SubprocessEnvironment.forCommand(SubprocessCommandProfile.KUBECTL, {
         PATH: `${kubectlInstallationDirectory}${path.delimiter}${process.env.PATH}`,
       }),


### PR DESCRIPTION
## Description

### Explicit `shell: false` on the remaining child process calls

Seven direct `node:child_process` invocations had no `shell` option. All are `spawn`/`spawnSync`/`execFileSync`, whose default is already `shell: false`, so these additions are explicit hardening documentation with zero behavior change:

* `src/integration/kube/k8-client/resources/pod/persist-port-forward.ts`
* `src/integration/kube/k8-client/resources/container/k8-client-container.ts`
* `src/commands/util/diagnostics-reporter.ts`
* `src/core/helpers.ts`
* `src/core/lock/lock-holder.ts`
* `src/business/utils/file-permissions.ts`
* `src/commands/node/tasks.ts`

(Two of the issue's paths drifted since it was filed: the reporter now lives at `src/commands/util/diagnostics-reporter.ts`, and the `node/tasks.ts` call moved to the helm-values collection block.)

### Lint rule so it does not drift again

PR #4804 swept the implicit-shell call sites in June and they came back. A new local rule `solo/require-explicit-shell` (error for `src/**`) now enforces it: every call to `spawn`/`spawnSync`/`execFile`/`execFileSync` imported from `node:child_process` (named, aliased, namespace, or default import) must carry an explicit `shell` property in its options, and `exec`/`execSync` — which always run a shell — are banned outright in favor of `execFile`/`spawn` with an argument array. The rule is import-aware, so unrelated calls such as `RegExp.exec()` are not flagged. Verified both ways: reverting one fix produces exactly one `solo/require-explicit-shell` error, and the fixed tree lints with zero errors — the already-explicit sites (`shell-runner.ts`, `kind-execution.ts`, `helm-execution.ts`) pass as-is.

### The rest of the issue

* `npm-client.ts` keeps `useShell: true` through `ShellRunner` — it already carries the explanatory comment (Windows `npm.cmd`, CVE-2024-27980, static arguments) and is outside the rule's scope since it is not a direct `child_process` call.
* The stale comment in `diagnostics-reporter.ts` claiming "ShellRunner uses shell:true" (wrong since #4804) is rewritten to state the actual reason for using `spawnSync` there: synchronous execution with direct exit-status inspection.

### Testing

* `task build` clean (0 errors, warning count unchanged from baseline).
* All 34 unit tests covering the touched modules pass (`lock-holder`, `k8-client-container`, `file-permissions`, `diagnostics-reporter`).

### Related Issues

Closes #5869