### PR TITLE
fix: remove orphaned ingress resources left by mirror-node and explorer destroy

### DIFF
--- a/src/commands/explorer.ts
+++ b/src/commands/explorer.ts
@@ -1010,6 +1010,13 @@ export class ExplorerCommand extends BaseCommand {
                   .delete(context_.config.ingressReleaseName);
               }
             }
+
+            // Delete the namespace-scoped TLS secret created for the ingress on deploy.
+            // secrets().delete() returns true for NotFound, so no try/catch needed.
+            await this.k8Factory
+              .getK8(context_.config.clusterContext)
+              .secrets()
+              .delete(context_.config.namespace, constants.EXPLORER_INGRESS_TLS_SECRET_NAME);
           },
         },
         this.disableMirrorNodeExplorerComponents(),

--- a/src/commands/mirror-node.ts
+++ b/src/commands/mirror-node.ts
@@ -180,7 +180,6 @@ interface MirrorNodeDestroyConfigClass {
   releaseName: string;
   ingressReleaseName: string;
   isLegacyChartInstalled: boolean;
-  isIngressControllerChartInstalled: boolean;
 }
 
 interface MirrorNodeDestroyContext {
@@ -2117,11 +2116,6 @@ export class MirrorNodeCommand extends BaseCommand {
               releaseName,
               ingressReleaseName,
               isLegacyChartInstalled,
-              isIngressControllerChartInstalled: await this.chartManager.isChartInstalled(
-                namespace,
-                ingressReleaseName,
-                clusterContext,
-              ),
             };
 
             if (!this.oneShotState.isActive()) {
@@ -2184,13 +2178,11 @@ export class MirrorNodeCommand extends BaseCommand {
         this.disableSharedResourceComponents(),
         {
           title: 'Uninstall mirror ingress controller',
-          skip: (context_): boolean => !context_.config.isIngressControllerChartInstalled,
+          // No skip guard: chartManager.uninstall() no-ops when the release is absent, and the
+          // IngressClass / ConfigMap / TLS secret deletions below tolerate missing resources. The
+          // ingress controller must be torn down even when its Helm release name cannot be
+          // re-detected, otherwise the chart, IngressClass, and TLS secret leak after destroy.
           task: async (context_): Promise<void> => {
-            await this.k8Factory
-              .getK8(context_.config.clusterContext)
-              .ingressClasses()
-              .delete(constants.MIRROR_INGRESS_CLASS_NAME);
-
             if (
               await this.k8Factory
                 .getK8(context_.config.clusterContext)
@@ -2221,6 +2213,13 @@ export class MirrorNodeCommand extends BaseCommand {
                   .delete(constants.MIRROR_INGRESS_CLASS_NAME);
               }
             }
+
+            // Delete the namespace-scoped TLS secret created for the ingress on deploy.
+            // secrets().delete() returns true for NotFound, so no try/catch needed.
+            await this.k8Factory
+              .getK8(context_.config.clusterContext)
+              .secrets()
+              .delete(context_.config.namespace, constants.MIRROR_INGRESS_TLS_SECRET_NAME);
           },
         },
         this.disableMirrorNodeComponents(),

--- a/src/commands/mirror-node.ts
+++ b/src/commands/mirror-node.ts
@@ -2179,10 +2179,22 @@ export class MirrorNodeCommand extends BaseCommand {
         {
           title: 'Uninstall mirror ingress controller',
           // No skip guard: chartManager.uninstall() no-ops when the release is absent, and the
-          // IngressClass / ConfigMap / TLS secret deletions below tolerate missing resources. The
-          // ingress controller must be torn down even when its Helm release name cannot be
-          // re-detected, otherwise the chart, IngressClass, and TLS secret leak after destroy.
+          // namespace-scoped ConfigMap / TLS secret deletions below tolerate missing resources, so
+          // they must run even when the ingress controller's Helm release name cannot be re-detected
+          // (otherwise the chart and TLS secret leak after destroy). The cluster-scoped IngressClass
+          // is the exception — see the ingressControllerInstalled gate below.
           task: async (context_): Promise<void> => {
+            // Whether THIS deployment installed an ingress controller. Checked before the uninstall
+            // below (which would make it false afterwards). The IngressClass is cluster-scoped and
+            // shares a fixed name across mirror-node deployments, so it is only deleted when this
+            // deployment actually used ingress — a no-ingress destroy must not remove an IngressClass
+            // still in use by another deployment in the same cluster.
+            const ingressControllerInstalled: boolean = await this.chartManager.isChartInstalled(
+              context_.config.namespace,
+              context_.config.ingressReleaseName,
+              context_.config.clusterContext,
+            );
+
             if (
               await this.k8Factory
                 .getK8(context_.config.clusterContext)
@@ -2200,17 +2212,20 @@ export class MirrorNodeCommand extends BaseCommand {
               context_.config.ingressReleaseName,
               context_.config.clusterContext,
             );
-            // delete ingress class if found one
-            const existingIngressClasses: IngressClass[] = await this.k8Factory
-              .getK8(context_.config.clusterContext)
-              .ingressClasses()
-              .list();
-            for (const ingressClass of existingIngressClasses) {
-              if (ingressClass.name === constants.MIRROR_INGRESS_CLASS_NAME) {
-                await this.k8Factory
-                  .getK8(context_.config.clusterContext)
-                  .ingressClasses()
-                  .delete(constants.MIRROR_INGRESS_CLASS_NAME);
+
+            // delete ingress class if found one — only when this deployment used ingress
+            if (ingressControllerInstalled) {
+              const existingIngressClasses: IngressClass[] = await this.k8Factory
+                .getK8(context_.config.clusterContext)
+                .ingressClasses()
+                .list();
+              for (const ingressClass of existingIngressClasses) {
+                if (ingressClass.name === constants.MIRROR_INGRESS_CLASS_NAME) {
+                  await this.k8Factory
+                    .getK8(context_.config.clusterContext)
+                    .ingressClasses()
+                    .delete(constants.MIRROR_INGRESS_CLASS_NAME);
+                }
               }
             }
 

--- a/test/unit/commands/explorer.test.ts
+++ b/test/unit/commands/explorer.test.ts
@@ -323,6 +323,10 @@ const createHarness: (sandbox: SinonSandbox) => Promise<ExplorerHarness> = async
       };
       return (): Record<string, unknown> => ingressClassesStubs;
     })(),
+    secrets: ((): (() => Record<string, unknown>) => {
+      const secretsStubs: Record<string, unknown> = {delete: sandbox.stub().resolves(true)};
+      return (): Record<string, unknown> => secretsStubs;
+    })(),
     namespaces: (): Record<string, unknown> => ({has: sandbox.stub().resolves(true)}),
   };
 
@@ -668,6 +672,9 @@ describe('ExplorerCommand unit tests', (): void => {
     expect(uninstallStub.getCall(0).args[1]).to.equal(createReleaseName(1));
     expect(uninstallStub.getCall(1).args[1]).to.equal(ingressReleaseName);
     sinon.assert.calledOnceWithMatch(ingressClassesDeleteStub, ingressReleaseName);
+
+    const secretsDeleteStub: SinonStub = (kubernetesClient as any).secrets().delete as SinonStub;
+    sinon.assert.calledOnceWithMatch(secretsDeleteStub, sinon.match.any, constants.EXPLORER_INGRESS_TLS_SECRET_NAME);
 
     const components: Record<string, unknown> = (harness.remoteConfig.configuration as Record<string, unknown>)
       .components as Record<string, unknown>;

--- a/test/unit/commands/explorer.test.ts
+++ b/test/unit/commands/explorer.test.ts
@@ -673,7 +673,8 @@ describe('ExplorerCommand unit tests', (): void => {
     expect(uninstallStub.getCall(1).args[1]).to.equal(ingressReleaseName);
     sinon.assert.calledOnceWithMatch(ingressClassesDeleteStub, ingressReleaseName);
 
-    const secretsDeleteStub: SinonStub = (kubernetesClient as any).secrets().delete as SinonStub;
+    const secretsClient: Record<string, unknown> = (kubernetesClient.secrets as () => Record<string, unknown>)();
+    const secretsDeleteStub: SinonStub = secretsClient.delete as SinonStub;
     sinon.assert.calledOnceWithMatch(secretsDeleteStub, sinon.match.any, constants.EXPLORER_INGRESS_TLS_SECRET_NAME);
 
     const components: Record<string, unknown> = (harness.remoteConfig.configuration as Record<string, unknown>)


### PR DESCRIPTION
### Description

mirror-node deploy (and explorer deploy) create ingress resources that the corresponding destroy flows did not reliably remove, leaving orphaned artifacts behind. This fixes the destroy paths to be symmetric with deploy.

### Related Issues

* Closes #5881
