### PR TITLE
ci: bump versions to MN 162 and BN 41 

### DIFF
--- a/.github/workflows/flow-examples-test.yaml
+++ b/.github/workflows/flow-examples-test.yaml
@@ -221,16 +221,18 @@ jobs:
           version: 3.49.1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
-        with:
-          go-version: '1.22.3'
-
       - name: Install grpcurl
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
         run: |
-          go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
+          # Pinned to an exact release and installed as a prebuilt binary. `go install ...@latest`
+          # broke when grpcurl v1.9.4 raised its minimum Go version above the pinned toolchain, and
+          # a floating version can break this job again with no change on our side. The prebuilt
+          # binary also removes the Go toolchain from this job entirely.
+          mkdir -p "${HOME}/.local/bin"
+          curl -sSLf "https://github.com/fullstorydev/grpcurl/releases/download/v1.9.3/grpcurl_1.9.3_linux_x86_64.tar.gz" \
+            | tar -xz -C "${HOME}/.local/bin" grpcurl
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+          "${HOME}/.local/bin/grpcurl" -version
 
       - name: Resolve consensus node version and Java version
         id: resolve-consensus-java

--- a/.github/workflows/flow-nightly-extended-tests.yaml
+++ b/.github/workflows/flow-nightly-extended-tests.yaml
@@ -269,5 +269,5 @@ jobs:
       - generate_matrix
     uses: ./.github/workflows/flow-performance-test.yaml
     with:
-      cn-edge-version: v0.75.1
+      cn-edge-version: v0.77.0-rc.11
     secrets: inherit

--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -22,7 +22,7 @@ on:
         description: "Consensus Node Version:"
         type: string
         required: false
-        default: "v0.75.1"
+        default: "v0.77.0-rc.11"
       skip-unit-and-coverage:
         description: "Skip Unit Tests and Coverage"
         type: boolean

--- a/.github/workflows/script/launch_network.sh
+++ b/.github/workflows/script/launch_network.sh
@@ -727,6 +727,44 @@ SKIP_BLOCK_NODE_UPGRADE_UNTIL_BN_3150_FIXED=false
 #  4. Skip CN upgrade — leave consensus nodes on the source version and continue covering
 #                      Solo/component migration behavior until CN issue #26498 is fixed.
 
+# hiero-consensus-node#26918 replaced the block root hash with a fixed 16-slot merkle tree. The
+# consensus node produces that shape from the v0.77 line and the block node verifies it from 0.41.0.
+# A pre-boundary producer streaming to a post-boundary verifier (or the reverse) is rejected with
+# BAD_BLOCK_PROOF, which saturates the consensus node block buffer and stalls the network. Because
+# blockStream.writerMode is FILE_AND_GRPC here, the consensus node always publishes to the block
+# node, so the two must stay on the same side of the boundary.
+cn_uses_16_slot_block_proof() {
+  local version="${1#v}"
+  local major="${version%%.*}"
+  local minor="${version#*.}"
+  minor="${minor%%.*}"
+
+  (( major > 0 )) || (( minor >= 77 ))
+}
+
+bn_uses_16_slot_block_proof() {
+  local version="${1#v}"
+  local major="${version%%.*}"
+  local minor="${version#*.}"
+  minor="${minor%%.*}"
+
+  (( major > 0 )) || (( minor >= 41 ))
+}
+
+# The consensus node the block node has to interoperate with for the rest of this run.
+if [[ "${SKIP_CONSENSUS_NODE_UPGRADE_UNTIL_CN_26498_FIXED}" == "true" ]]; then
+  EFFECTIVE_CONSENSUS_NODE_VERSION="${FROM_CONSENSUS_NODE_VERSION}"
+else
+  EFFECTIVE_CONSENSUS_NODE_VERSION="${TO_CONSENSUS_NODE_VERSION}"
+fi
+echo "Effective consensus node version for block node compatibility: ${EFFECTIVE_CONSENSUS_NODE_VERSION}"
+
+BLOCK_NODE_UPGRADE_CROSSES_PROOF_BOUNDARY=false
+if bn_uses_16_slot_block_proof "${CURRENT_BLOCK_VERSION}" &&
+  ! cn_uses_16_slot_block_proof "${EFFECTIVE_CONSENSUS_NODE_VERSION}"; then
+  BLOCK_NODE_UPGRADE_CROSSES_PROOF_BOUNDARY=true
+fi
+
 # Step 1: Upgrade BN while CN source version is running, unless the BN bypass is re-enabled.
 ACTIVE_BLOCK_NODE_VERSION="${PREV_BLOCK_VERSION_NO_V}"
 if [[ "${SKIP_BLOCK_NODE_UPGRADE_UNTIL_BN_3150_FIXED}" == "true" ]]; then
@@ -734,6 +772,18 @@ if [[ "${SKIP_BLOCK_NODE_UPGRADE_UNTIL_BN_3150_FIXED}" == "true" ]]; then
   echo "Reason: hiero-block-node#3150 can make mirror importer reject live-stream batches starting with ROUND_HEADER."
   echo "Block node remains on ${PREV_BLOCK_VERSION_NO_V}; continuing component migration coverage."
   dump_bn_log "BN upgrade skipped due to hiero-block-node#3150"
+elif [[ "${BLOCK_NODE_UPGRADE_CROSSES_PROOF_BOUNDARY}" == "true" ]]; then
+  # Skipping keeps the block node on the same side of the boundary as the consensus node that will
+  # actually be running. Once the CN #26498 bypass above is lifted, do not simply re-enable this
+  # branch: move the BN upgrade into the CN stop/start seam below (between `consensus network
+  # upgrade --skip-node-start` and `consensus node start`) so both cross the boundary together
+  # while no consensus node is producing blocks.
+  echo "$(date '+%Y-%m-%d %H:%M:%S') - Skipping BN upgrade to ${CURRENT_BLOCK_VERSION}"
+  echo "Reason: BN ${CURRENT_BLOCK_VERSION} expects the 16-slot block root hash (hiero-consensus-node#26918)"
+  echo "but the consensus node stays on ${EFFECTIVE_CONSENSUS_NODE_VERSION}, which still produces the old shape."
+  echo "Upgrading would make BN reject every block with BAD_BLOCK_PROOF and stall the consensus node."
+  echo "Block node remains on ${PREV_BLOCK_VERSION_NO_V}; continuing component migration coverage."
+  dump_bn_log "BN upgrade skipped due to the 16-slot block proof boundary"
 elif [[ "${PREV_BLOCK_VERSION_NO_V}" != "${CURRENT_BLOCK_VERSION}" ]]; then
   TEMP_BN_UPGRADE_VALUES_FILE="$(mktemp -t bn-upgrade-values-XXXX.yaml)"
   cat > "${TEMP_BN_UPGRADE_VALUES_FILE}" <<'VALS'

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -328,16 +328,18 @@ jobs:
           version: 3.49.1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
-        with:
-          go-version: '1.22.3'
-
       - name: Install grpcurl
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
         run: |
-          go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
+          # Pinned to an exact release and installed as a prebuilt binary. `go install ...@latest`
+          # broke when grpcurl v1.9.4 raised its minimum Go version above the pinned toolchain, and
+          # a floating version can break this job again with no change on our side. The prebuilt
+          # binary also removes the Go toolchain from this job entirely.
+          mkdir -p "${HOME}/.local/bin"
+          curl -sSLf "https://github.com/fullstorydev/grpcurl/releases/download/v1.9.3/grpcurl_1.9.3_linux_x86_64.tar.gz" \
+            | tar -xz -C "${HOME}/.local/bin" grpcurl
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+          "${HOME}/.local/bin/grpcurl" -version
 
       - name: Compile Project
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}

--- a/Taskfile.tests.yml
+++ b/Taskfile.tests.yml
@@ -187,7 +187,7 @@ tasks:
   test-e2e-small-memory-load:
     desc: "Runs E2E Small Memory Load test — CN with NLG v0.14.1 throttle-protected load"
     env:
-      CONSENSUS_NODE_VERSION: v0.75.1
+      CONSENSUS_NODE_VERSION: v0.77.0-rc.11
       NETWORK_LOAD_GENERATOR_CHART_VERSION: "0.14.1"
     cmds:
       - "{{ .test_prefix }}=\"Mocha E2E Small Memory Load Test\"

--- a/examples/local-build-with-custom-config/Taskfile.yml
+++ b/examples/local-build-with-custom-config/Taskfile.yml
@@ -24,7 +24,7 @@ vars:
   CN_LOCAL_BUILD_PATH: "{{.ROOT_DIR}}/../hiero-consensus-node/hedera-node/data"
   LOCAL_BUILD_FLAG: "--local-build-path {{.CN_LOCAL_BUILD_PATH}}"
 
-  CN_VERSION: '{{default "v0.75.1" .CONSENSUS_NODE_VERSION}}'
+  CN_VERSION: '{{default "v0.77.0-rc.11" .CONSENSUS_NODE_VERSION}}'
   RELAY_RELEASE_FLAG: "--relay-release 0.70.1"
   MIRROR_NODE_VERSION_FLAG: "--mirror-node-version v0.149.0"
   EXPLORER_VERSION_FLAG: "--explorer-version 25.0.0"

--- a/examples/node-create-transaction/Taskfile.yml
+++ b/examples/node-create-transaction/Taskfile.yml
@@ -19,7 +19,7 @@ vars:
     sh: git rev-parse --show-toplevel
   CN_LOCAL_BUILD_PATH: "{{.ROOT_DIR}}/../hiero-consensus-node/hedera-node/data"
   LOCAL_BUILD_FLAG: "--local-build-path {{.CN_LOCAL_BUILD_PATH}}"
-  CN_VERSION: '{{default "v0.75.1" .CONSENSUS_NODE_VERSION}}'
+  CN_VERSION: '{{default "v0.77.0-rc.11" .CONSENSUS_NODE_VERSION}}'
   TEMPORARY_DIR: "/tmp/solo-deployment"
   PREPARE_OUTPUT_DIR: "{{ .TEMPORARY_DIR }}/prepare-output"
   APPLICATION_PROPERTIES: "{{ .TEMPORARY_DIR }}/application.properties"

--- a/examples/node-delete-transaction/Taskfile.yml
+++ b/examples/node-delete-transaction/Taskfile.yml
@@ -19,7 +19,7 @@ vars:
     sh: git rev-parse --show-toplevel
   CN_LOCAL_BUILD_PATH: "{{.ROOT_DIR}}/../hiero-consensus-node/hedera-node/data"
   LOCAL_BUILD_FLAG: "--local-build-path {{.CN_LOCAL_BUILD_PATH}}"
-  CN_VERSION: '{{default "v0.75.1" .CONSENSUS_NODE_VERSION}}'
+  CN_VERSION: '{{default "v0.77.0-rc.11" .CONSENSUS_NODE_VERSION}}'
   TEMPORARY_DIR: "/tmp/solo-deployment"
   PREPARE_OUTPUT_DIR: "{{ .TEMPORARY_DIR }}/prepare-output"
   APPLICATION_PROPERTIES: "{{ .TEMPORARY_DIR }}/application.properties"

--- a/examples/node-update-transaction/Taskfile.yml
+++ b/examples/node-update-transaction/Taskfile.yml
@@ -19,7 +19,7 @@ vars:
     sh: git rev-parse --show-toplevel
   CN_LOCAL_BUILD_PATH: "{{.ROOT_DIR}}/../hiero-consensus-node/hedera-node/data"
   LOCAL_BUILD_FLAG: "--local-build-path {{.CN_LOCAL_BUILD_PATH}}"
-  CN_VERSION: '{{default "v0.75.1" .CONSENSUS_NODE_VERSION}}'
+  CN_VERSION: '{{default "v0.77.0-rc.11" .CONSENSUS_NODE_VERSION}}'
   TEMPORARY_DIR: "/tmp/solo-deployment"
   PREPARE_OUTPUT_DIR: "{{ .TEMPORARY_DIR }}/prepare-output"
   APPLICATION_PROPERTIES: "{{ .TEMPORARY_DIR }}/application.properties"

--- a/examples/version-upgrade-test/Taskfile.yml
+++ b/examples/version-upgrade-test/Taskfile.yml
@@ -145,19 +145,27 @@ tasks:
           --pinger
       - cmd: $SOLO_COMMAND ledger account create --deployment {{ .DEPLOYMENT }} --hbar-amount 50
 
-      # Upgrade network to main with local build path
+      # Stage the network upgrade to main with local build path, but leave the consensus nodes
+      # stopped. Consensus node and block node must cross the fixed 16-slot block root hash
+      # boundary (hiero-consensus-node#26918) together: an upgraded consensus node streaming to a
+      # pre-0.41.0 block node is rejected with BAD_BLOCK_PROOF, which saturates the consensus node
+      # block buffer and stalls the network. Upgrading both while no consensus node is producing
+      # removes that window entirely, so no version comparison is needed here.
       - cmd: |
           export CONSENSUS_NODE_VERSION=$(awk -v RS=';' '/export const HEDERA_PLATFORM_VERSION[[:space:]]*:[[:space:]]*string[[:space:]]*=/ { s=$0; v=""; while (match(s, /'\''[^'\'']*'\''/)) { v=substr(s, RSTART+1, RLENGTH-2); s=substr(s, RSTART+RLENGTH) } if (v!="") { print v; exit } }' ../../version.ts)
           echo "Upgrading consensus network to version: ${CONSENSUS_NODE_VERSION}"
           SOLO_LOG_LEVEL=debug $SOLO_COMMAND consensus network upgrade --node-aliases {{ .NODE_IDENTIFIERS }} \
           --upgrade-version ${CONSENSUS_NODE_VERSION} \
-          --deployment {{ .DEPLOYMENT }}
+          --deployment {{ .DEPLOYMENT }} \
+          --skip-node-start
 
-      # Upgrade block node
+      # Upgrade block node while the consensus nodes are still stopped
       - cmd: |
           $SOLO_COMMAND block node upgrade --deployment {{ .DEPLOYMENT }}
-      - cmd: $SOLO_COMMAND ledger account create --deployment {{ .DEPLOYMENT }} --hbar-amount 50
 
+      # Start the upgraded consensus nodes now that the block node also speaks the new format
+      - cmd: |
+          $SOLO_COMMAND consensus node start --deployment {{ .DEPLOYMENT }} --node-aliases {{ .NODE_IDENTIFIERS }}
 
       - cmd: $SOLO_COMMAND ledger account create --deployment {{ .DEPLOYMENT }} --hbar-amount 50
 
@@ -213,19 +221,39 @@ tasks:
 
       - echo "All functionality verification completed successfully!"
 
-      # Test Block Node functionality
+      # Test Block Node functionality.
+      # get-block.sh always requests the latest block, so a single SUCCESS response only proves the
+      # block node still serves what it persisted before the upgrade. Sample twice and require the
+      # block number to advance, otherwise a block node that stopped verifying the upgraded
+      # consensus node's proofs (see the 16-slot boundary note in upgrade-components) reports
+      # SUCCESS forever on a stale block and this check false-passes.
       - cmd: |
           kubectl port-forward --namespace {{ .NAMESPACE }} svc/block-node-1 40840:40840 >/tmp/solo-block-node-port-forward.log 2>&1 &
           cd ../../test/data
-          
-          OUTPUT=$(./get-block.sh 1)
-          echo "$OUTPUT"
-          if echo "$OUTPUT" | grep -q '"status": "SUCCESS"'; then
-            echo "✓ Block node test passed - status is SUCCESS"
-          else
-            echo "✗ Block node test failed - status is not SUCCESS"
+
+          latest_block_number() {
+            ./get-block.sh 2>/dev/null | jq -rs 'if any(.[]; .status == "SUCCESS") then [.. | .number? | select(. != null)] | first // empty else empty end'
+          }
+
+          FIRST=$(latest_block_number)
+          if [[ -z "${FIRST}" ]]; then
+            echo "✗ Block node test failed - could not read a SUCCESS block response"
+            ./get-block.sh || true
             exit 1
           fi
+          echo "Block node latest block: ${FIRST}"
+
+          for _ in $(seq 1 12); do
+            sleep 5
+            SECOND=$(latest_block_number)
+            if [[ -n "${SECOND}" ]] && (( SECOND > FIRST )); then
+              echo "✓ Block node test passed - advanced from block ${FIRST} to ${SECOND}"
+              exit 0
+            fi
+          done
+
+          echo "✗ Block node test failed - stuck at block ${FIRST} (last read: ${SECOND:-none})"
+          exit 1
 
   destroy:
     desc: Destroy the Solo network and cleanup

--- a/src/commands/block-node.ts
+++ b/src/commands/block-node.ts
@@ -436,14 +436,40 @@ export class BlockNodeCommand extends BaseCommand {
 
   /**
    * Rejects a block node version that sits on the opposite side of the fixed 16-slot block root hash
-   * boundary (hiero-consensus-node#26918) from the deployed consensus node. The consensus node streams
-   * every block to the block node for verification, so a mismatched pair is rejected with
+   * boundary (hiero-consensus-node#26918) from the consensus node it will serve. The consensus node
+   * streams every block to the block node for verification, so a mismatched pair is rejected with
    * BAD_BLOCK_PROOF until the consensus node block buffer saturates and the network stalls.
+   *
+   * `consensusNodeVersion` must be the version that will actually be running alongside this block
+   * node. See {@link resolveConsensusNodeVersionForCompatibility} for how add picks it.
    */
-  private assertBlockProofCompatibility(blockNodeVersion: string, force: boolean): void {
-    const consensusNodeVersion: string =
-      this.remoteConfig.configuration.versions?.consensusNode?.toString() ?? versions.HEDERA_PLATFORM_VERSION;
+  /**
+   * Picks the consensus node version that a block node being added will actually serve.
+   *
+   * An explicitly requested version wins, because a block node is often added before the consensus
+   * network exists — remote config then still holds solo's default rather than the version about to
+   * be deployed. With no explicit request, remote config is the ground truth for an already deployed
+   * network. Falls back to solo's default when neither is available.
+   *
+   * `--consensus-node-version` defaults to an empty string, which yargs drops, so its presence in
+   * argv means the caller supplied it. The deprecated `--release-tag` always carries solo's default
+   * into argv, so it only counts as explicit when it differs from that default.
+   */
+  private resolveConsensusNodeVersionForCompatibility(argv: ArgvStruct): string {
+    const requestedConsensusNodeVersion: string = argv[flags.consensusNodeVersion.name] as string;
+    if (requestedConsensusNodeVersion) {
+      return requestedConsensusNodeVersion;
+    }
 
+    const requestedReleaseTag: string = argv[flags.releaseTag.name] as string;
+    if (requestedReleaseTag && requestedReleaseTag !== versions.HEDERA_PLATFORM_VERSION) {
+      return requestedReleaseTag;
+    }
+
+    return this.remoteConfig.configuration.versions?.consensusNode?.toString() ?? versions.HEDERA_PLATFORM_VERSION;
+  }
+
+  private assertBlockProofCompatibility(blockNodeVersion: string, consensusNodeVersion: string, force: boolean): void {
     const blockNodeUsesFixedSlots: boolean = new SemanticVersion<string>(blockNodeVersion).greaterThanOrEqual(
       versions.MINIMUM_BLOCK_NODE_VERSION_FOR_16_SLOT_BLOCK_PROOF,
     );
@@ -919,7 +945,11 @@ export class BlockNodeCommand extends BaseCommand {
               config.componentImage = `${constants.BLOCK_NODE_IMAGE_NAME}:${config.imageTag}`;
             }
 
-            this.assertBlockProofCompatibility(config.chartVersion, config.force);
+            this.assertBlockProofCompatibility(
+              config.chartVersion,
+              this.resolveConsensusNodeVersionForCompatibility(argv),
+              config.force,
+            );
 
             config.livenessCheckPort = this.getLivenessCheckPortNumber(config.chartVersion, config.componentImage);
 
@@ -1386,7 +1416,12 @@ export class BlockNodeCommand extends BaseCommand {
               optionFromFlag(flags.upgradeVersion),
             );
 
-            this.assertBlockProofCompatibility(config.upgradeVersion, config.force);
+            // On upgrade the consensus network is already deployed, so remote config is ground truth.
+            this.assertBlockProofCompatibility(
+              config.upgradeVersion,
+              this.remoteConfig.configuration.versions?.consensusNode?.toString() ?? versions.HEDERA_PLATFORM_VERSION,
+              config.force,
+            );
 
             if (!this.oneShotState.isActive()) {
               return ListrLock.newAcquireLockTask(lease, task);

--- a/src/commands/block-node.ts
+++ b/src/commands/block-node.ts
@@ -78,6 +78,7 @@ interface BlockNodeDeployConfigClass {
   domainName: Optional<string>;
   enableIngress: boolean;
   quiet: boolean;
+  force: boolean;
   valuesFile: Optional<string>;
   releaseTag: string;
   imageTag: Optional<string>;
@@ -125,6 +126,7 @@ interface BlockNodeUpgradeConfigClass {
   deployment: DeploymentName;
   debugMode: boolean;
   quiet: boolean;
+  force: boolean;
   valuesFile: Optional<string>;
   namespace: NamespaceName;
   context: string;
@@ -243,6 +245,7 @@ export class BlockNodeCommand extends BaseCommand {
       flags.debugMode,
       flags.domainName,
       flags.enableIngress,
+      flags.force,
       flags.quiet,
       flags.valuesFile,
       // Keep deprecated legacy flag accepted for backward compatibility.
@@ -429,6 +432,42 @@ export class BlockNodeCommand extends BaseCommand {
       this.remoteConfig.configuration.versions?.consensusNode?.toString() ?? versions.HEDERA_PLATFORM_VERSION;
     const blockStreamMode: string = constants.getEnvironmentVariable('BLOCK_STREAM_STREAM_MODE') ?? 'BLOCKS';
     return Helpers.requiresRsaBootstrap(consensusNodeVersion, blockStreamMode);
+  }
+
+  /**
+   * Rejects a block node version that sits on the opposite side of the fixed 16-slot block root hash
+   * boundary (hiero-consensus-node#26918) from the deployed consensus node. The consensus node streams
+   * every block to the block node for verification, so a mismatched pair is rejected with
+   * BAD_BLOCK_PROOF until the consensus node block buffer saturates and the network stalls.
+   */
+  private assertBlockProofCompatibility(blockNodeVersion: string, force: boolean): void {
+    const consensusNodeVersion: string =
+      this.remoteConfig.configuration.versions?.consensusNode?.toString() ?? versions.HEDERA_PLATFORM_VERSION;
+
+    const blockNodeUsesFixedSlots: boolean = new SemanticVersion<string>(blockNodeVersion).greaterThanOrEqual(
+      versions.MINIMUM_BLOCK_NODE_VERSION_FOR_16_SLOT_BLOCK_PROOF,
+    );
+    const consensusNodeUsesFixedSlots: boolean = new SemanticVersion<string>(consensusNodeVersion).greaterThanOrEqual(
+      versions.MINIMUM_CN_VERSION_FOR_16_SLOT_BLOCK_PROOF,
+    );
+
+    if (blockNodeUsesFixedSlots === consensusNodeUsesFixedSlots) {
+      return;
+    }
+
+    if (force) {
+      this.logger.warn(
+        `Force flag enabled, bypassing the block root hash compatibility check between block node ${blockNodeVersion} and consensus node ${consensusNodeVersion}`,
+      );
+      return;
+    }
+
+    throw new SoloErrors.validation.blockNodeBlockProofIncompatible(
+      blockNodeVersion,
+      consensusNodeVersion,
+      versions.MINIMUM_BLOCK_NODE_VERSION_FOR_16_SLOT_BLOCK_PROOF,
+      versions.MINIMUM_CN_VERSION_FOR_16_SLOT_BLOCK_PROOF,
+    );
   }
 
   private resolveMirrorNodeReleaseName(): string {
@@ -879,6 +918,8 @@ export class BlockNodeCommand extends BaseCommand {
             if (!config.componentImage && config.imageTag) {
               config.componentImage = `${constants.BLOCK_NODE_IMAGE_NAME}:${config.imageTag}`;
             }
+
+            this.assertBlockProofCompatibility(config.chartVersion, config.force);
 
             config.livenessCheckPort = this.getLivenessCheckPortNumber(config.chartVersion, config.componentImage);
 
@@ -1344,6 +1385,8 @@ export class BlockNodeCommand extends BaseCommand {
               this.remoteConfig.getComponentVersion(ComponentTypes.BlockNode),
               optionFromFlag(flags.upgradeVersion),
             );
+
+            this.assertBlockProofCompatibility(config.upgradeVersion, config.force);
 
             if (!this.oneShotState.isActive()) {
               return ListrLock.newAcquireLockTask(lease, task);

--- a/src/core/errors/classes/validation/block-node-block-proof-incompatible-solo-error.ts
+++ b/src/core/errors/classes/validation/block-node-block-proof-incompatible-solo-error.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {SoloError} from '../../solo-error.js';
+import {ErrorOwnership} from '../../error-ownership.js';
+import {ErrorCodeRegistry} from '../../error-code-registry.js';
+
+/**
+ * @description Thrown when the selected block node version and the deployed consensus node version sit on opposite
+ * sides of the fixed 16-slot block root hash boundary (hiero-consensus-node#26918); the message names both versions.
+ * The consensus node streams every block to the block node for verification, so a mismatched pair is rejected with
+ * BAD_BLOCK_PROOF and the consensus node block buffer saturates until the network stalls.
+ */
+export class BlockNodeBlockProofIncompatibleSoloError extends SoloError {
+  protected override readonly retryable: boolean = false;
+  protected override readonly ownership: ErrorOwnership = ErrorOwnership.User;
+
+  public constructor(
+    blockNodeVersion: string,
+    consensusNodeVersion: string,
+    minimumBlockNodeVersion: string,
+    minimumConsensusNodeVersion: string,
+  ) {
+    super({
+      message:
+        `Block node ${blockNodeVersion} and consensus node ${consensusNodeVersion} use incompatible block root hashes: ` +
+        `the fixed 16-slot merkle tree requires block node >= ${minimumBlockNodeVersion} together with ` +
+        `consensus node >= ${minimumConsensusNodeVersion}`,
+      code: ErrorCodeRegistry.BLOCK_NODE_BLOCK_PROOF_INCOMPATIBLE,
+      troubleshootingSteps:
+        `Upgrade the consensus node to ${minimumConsensusNodeVersion} or newer: solo consensus network upgrade --upgrade-version ${minimumConsensusNodeVersion}\n` +
+        `Or pin a block node below ${minimumBlockNodeVersion}: solo block node add --block-node-version <version>\n` +
+        'Upgrade both together by staging the consensus node upgrade with --skip-node-start, upgrading the block node, then running solo consensus node start\n' +
+        'Or bypass this check with --force if you accept the block verification failures',
+    });
+  }
+}

--- a/src/core/errors/error-code-registry.ts
+++ b/src/core/errors/error-code-registry.ts
@@ -221,6 +221,7 @@ export const ErrorCodeRegistry: Record<string, string> = {
   VALUES_FILE_PARSE_FAILED: 'SOLO-4079',
   BACKUP_DATABASE_DUMP_NOT_FOUND: 'SOLO-4080',
   INVALID_FLAG_VALUE: 'SOLO-4081',
+  BLOCK_NODE_BLOCK_PROOF_INCOMPATIBLE: 'SOLO-4082',
 
   // 5xxx - System / Environment: kubectl, DNS, permissions, timeouts
   RESOURCE_NOT_FOUND: 'SOLO-5001',

--- a/src/core/errors/solo-errors.ts
+++ b/src/core/errors/solo-errors.ts
@@ -250,6 +250,7 @@ import {ConfirmationRequiredSoloError} from './classes/validation/confirmation-r
 import {ValuesFileNotFoundSoloError} from './classes/validation/values-file-not-found-solo-error.js';
 import {ValuesFileParseFailedSoloError} from './classes/validation/values-file-parse-failed-solo-error.js';
 import {InvalidFlagValueSoloError} from './classes/validation/invalid-flag-value-solo-error.js';
+import {BlockNodeBlockProofIncompatibleSoloError} from './classes/validation/block-node-block-proof-incompatible-solo-error.js';
 import {HelmRepoSetupFailedSoloError} from './classes/system/helm-repo-setup-failed-solo-error.js';
 import {HelmRepoCheckFailedSoloError} from './classes/system/helm-repo-check-failed-solo-error.js';
 import {HelmChartListFailedSoloError} from './classes/system/helm-chart-list-failed-solo-error.js';
@@ -666,6 +667,7 @@ export class SoloErrors {
     readonly valuesFileNotFound: typeof ValuesFileNotFoundSoloError;
     readonly valuesFileParseFailed: typeof ValuesFileParseFailedSoloError;
     readonly invalidFlagValue: typeof InvalidFlagValueSoloError;
+    readonly blockNodeBlockProofIncompatible: typeof BlockNodeBlockProofIncompatibleSoloError;
   } = Object.freeze({
     blockNodeLocalImageNotFound: BlockNodeLocalImageNotFoundSoloError,
     blockNodeInvalidComponentId: BlockNodeInvalidComponentIdSoloError,
@@ -744,6 +746,7 @@ export class SoloErrors {
     valuesFileNotFound: ValuesFileNotFoundSoloError,
     valuesFileParseFailed: ValuesFileParseFailedSoloError,
     invalidFlagValue: InvalidFlagValueSoloError,
+    blockNodeBlockProofIncompatible: BlockNodeBlockProofIncompatibleSoloError,
   });
 
   // 5xxx — System / Environment: kubectl, DNS, permissions, timeouts

--- a/test/unit/commands/block-node.test.ts
+++ b/test/unit/commands/block-node.test.ts
@@ -18,6 +18,7 @@ import {resetForTest} from '../../test-container.js';
 import fs from 'node:fs';
 import os from 'node:os';
 import {PathEx} from '../../../src/business/utils/path-ex.js';
+import * as versions from '../../../version.js';
 
 interface BlockNodeK8Stub {
   services: () => BlockNodeServicesStub;
@@ -477,5 +478,77 @@ describe('BlockNodeCommand unit tests', (): void => {
       isLegacyChartInstalled: false,
     });
     expect(blockNodeCommandInternal.chartManager.isChartInstalled.firstCall.args[1]).to.equal('block-node-1');
+  });
+
+  describe('block proof compatibility', (): void => {
+    interface CompatibilityInternal {
+      remoteConfig: {configuration: {versions: {consensusNode: string}}};
+      resolveConsensusNodeVersionForCompatibility: (argv: Record<string, unknown>) => string;
+      assertBlockProofCompatibility: (blockNodeVersion: string, consensusNodeVersion: string, force: boolean) => void;
+    }
+
+    const internal: (deployedConsensusNodeVersion: string) => CompatibilityInternal = (
+      deployedConsensusNodeVersion: string,
+    ): CompatibilityInternal => {
+      const compatibilityInternal: CompatibilityInternal = blockNodeCommand as unknown as CompatibilityInternal;
+      compatibilityInternal.remoteConfig = {
+        configuration: {versions: {consensusNode: deployedConsensusNodeVersion}},
+      };
+      return compatibilityInternal;
+    };
+
+    // Regression: the version-upgrade example adds a v0.40.0 block node for a v0.74.0 consensus node
+    // that is not deployed yet, so remote config still holds solo's default. Trusting remote config
+    // there rejected a correctly matched pair.
+    it('prefers an explicitly requested consensus node version over remote config', (): void => {
+      const compatibilityInternal: CompatibilityInternal = internal('0.77.0-rc.11');
+
+      expect(
+        compatibilityInternal.resolveConsensusNodeVersionForCompatibility({'consensus-node-version': 'v0.74.0'}),
+      ).to.equal('v0.74.0');
+    });
+
+    it('treats a deprecated release tag that differs from the default as explicit', (): void => {
+      const compatibilityInternal: CompatibilityInternal = internal('0.77.0-rc.11');
+
+      expect(compatibilityInternal.resolveConsensusNodeVersionForCompatibility({'release-tag': 'v0.74.0'})).to.equal(
+        'v0.74.0',
+      );
+    });
+
+    // Regression: the migration test adds a block node without any consensus node flag, so yargs fills
+    // in solo's default. Remote config is the only source that knows the deployed version there.
+    it('falls back to remote config when the release tag only carries solo default', (): void => {
+      const compatibilityInternal: CompatibilityInternal = internal('0.74.0');
+
+      expect(
+        compatibilityInternal.resolveConsensusNodeVersionForCompatibility({
+          'release-tag': versions.HEDERA_PLATFORM_VERSION,
+        }),
+      ).to.equal('0.74.0');
+    });
+
+    it('accepts a block node and consensus node on the same side of the boundary', (): void => {
+      const compatibilityInternal: CompatibilityInternal = internal('0.74.0');
+
+      expect((): void => compatibilityInternal.assertBlockProofCompatibility('0.40.0', '0.74.0', false)).to.not.throw();
+      expect((): void =>
+        compatibilityInternal.assertBlockProofCompatibility('0.41.0', 'v0.77.0-rc.11', false),
+      ).to.not.throw();
+    });
+
+    it('rejects a block node and consensus node on opposite sides of the boundary', (): void => {
+      const compatibilityInternal: CompatibilityInternal = internal('0.75.1');
+
+      expect((): void => compatibilityInternal.assertBlockProofCompatibility('0.41.0', '0.75.1', false)).to.throw(
+        /incompatible block root hashes/,
+      );
+    });
+
+    it('allows a mismatched pair through when force is set', (): void => {
+      const compatibilityInternal: CompatibilityInternal = internal('0.75.1');
+
+      expect((): void => compatibilityInternal.assertBlockProofCompatibility('0.41.0', '0.75.1', true)).to.not.throw();
+    });
   });
 });

--- a/test/unit/version/block-proof-boundary.test.ts
+++ b/test/unit/version/block-proof-boundary.test.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {expect} from 'chai';
+import {describe, it} from 'mocha';
+
+import {SemanticVersion} from '../../../src/business/utils/semantic-version.js';
+import * as versions from '../../../version.js';
+
+const usesFixedSlotBlockProof: (blockNodeVersion: string, consensusNodeVersion: string) => [boolean, boolean] = (
+  blockNodeVersion: string,
+  consensusNodeVersion: string,
+): [boolean, boolean] => [
+  new SemanticVersion<string>(blockNodeVersion).greaterThanOrEqual(
+    versions.MINIMUM_BLOCK_NODE_VERSION_FOR_16_SLOT_BLOCK_PROOF,
+  ),
+  new SemanticVersion<string>(consensusNodeVersion).greaterThanOrEqual(
+    versions.MINIMUM_CN_VERSION_FOR_16_SLOT_BLOCK_PROOF,
+  ),
+];
+
+/**
+ * hiero-consensus-node#26918 replaced the block root hash with a fixed 16-slot merkle tree. The
+ * consensus node and the block node must sit on the same side of that boundary, otherwise every
+ * block is rejected with BAD_BLOCK_PROOF. These cases pin the boundary constants so a future
+ * component bump cannot silently reintroduce a mismatched default pairing.
+ */
+describe('16-slot block proof boundary', (): void => {
+  const cases: Array<[string, string, boolean]> = [
+    // Matched pairs on either side of the boundary are allowed.
+    ['0.41.0', 'v0.77.0-rc.11', true],
+    ['0.40.1', 'v0.75.1', true],
+    ['0.42.0', 'v0.78.0', true],
+    // New-format block node against an old-format consensus node.
+    ['0.41.0', 'v0.76.1', false],
+    ['0.41.0', 'v0.75.1', false],
+    ['0.41.0', 'v0.74.0', false],
+    // Old-format block node against a new-format consensus node.
+    ['0.40.0', 'v0.77.0-rc.11', false],
+  ];
+
+  for (const [blockNodeVersion, consensusNodeVersion, compatible] of cases) {
+    it(`block node ${blockNodeVersion} with consensus node ${consensusNodeVersion} is ${compatible ? 'compatible' : 'incompatible'}`, (): void => {
+      const [blockNodeUsesFixedSlots, consensusNodeUsesFixedSlots]: [boolean, boolean] = usesFixedSlotBlockProof(
+        blockNodeVersion,
+        consensusNodeVersion,
+      );
+
+      expect(blockNodeUsesFixedSlots === consensusNodeUsesFixedSlots).to.equal(compatible);
+    });
+  }
+
+  it('ships a default consensus node and block node version on the same side of the boundary', (): void => {
+    const [blockNodeUsesFixedSlots, consensusNodeUsesFixedSlots]: [boolean, boolean] = usesFixedSlotBlockProof(
+      versions.BLOCK_NODE_VERSION,
+      versions.HEDERA_PLATFORM_VERSION,
+    );
+
+    expect(blockNodeUsesFixedSlots).to.equal(consensusNodeUsesFixedSlots);
+  });
+});

--- a/version-test.ts
+++ b/version-test.ts
@@ -5,7 +5,7 @@ export const TEST_UPGRADE_FROM_VERSION: string = 'v0.74.0';
 export const TEST_UPGRADE_TO_VERSION: string = 'v0.75.1';
 
 // Do not delete, used by test script or Taskfile
-export const PREV_BLOCK_NODE_VERSION: string = 'v0.39.0';
-export const PREV_MIRROR_NODE_VERSION: string = 'v0.160.0';
+export const PREV_BLOCK_NODE_VERSION: string = 'v0.40.0';
+export const PREV_MIRROR_NODE_VERSION: string = 'v0.161.0';
 export const PREV_EXPLORER_VERSION: string = '26.0.0';
 export const PREV_RELAY_VERSION: string = '0.77.0';

--- a/version-test.ts
+++ b/version-test.ts
@@ -2,7 +2,7 @@
 // using a different version than the one in version.ts to test backwards compatibility
 
 export const TEST_UPGRADE_FROM_VERSION: string = 'v0.74.0';
-export const TEST_UPGRADE_TO_VERSION: string = 'v0.75.1';
+export const TEST_UPGRADE_TO_VERSION: string = 'v0.77.0-rc.11';
 
 // Do not delete, used by test script or Taskfile
 export const PREV_BLOCK_NODE_VERSION: string = 'v0.40.0';

--- a/version.ts
+++ b/version.ts
@@ -25,7 +25,8 @@ export const KUBECTL_VERSION: string = 'v1.32.2';
 export const CRANE_VERSION: string = 'v0.21.4';
 
 export const SOLO_CHART_VERSION: string = constants.getEnvironmentVariable('SOLO_CHART_VERSION') || '0.66.0';
-export const HEDERA_PLATFORM_VERSION: string = constants.getEnvironmentVariable('CONSENSUS_NODE_VERSION') || 'v0.75.1';
+export const HEDERA_PLATFORM_VERSION: string =
+  constants.getEnvironmentVariable('CONSENSUS_NODE_VERSION') || 'v0.77.0-rc.11';
 export const MIRROR_NODE_VERSION: string = constants.getEnvironmentVariable('MIRROR_NODE_VERSION') || 'v0.162.0';
 export const EXPLORER_VERSION: string = constants.getEnvironmentVariable('EXPLORER_VERSION') || '26.2.0';
 export const HEDERA_JSON_RPC_RELAY_VERSION: string = constants.getEnvironmentVariable('RELAY_VERSION') || '0.78.1';
@@ -88,6 +89,14 @@ export const MINIMUM_SOLO_CHART_VERSION: string = '0.64.0';
 // Block node >= v0.39.0 serves health endpoints from a dedicated port (BLOCK_NODE_HEALTH_PORT)
 // rather than the gRPC port. The '-0' suffix makes pre-releases (e.g. v0.39.0-rc1) satisfy the check.
 export const MINIMUM_HIERO_BLOCK_NODE_VERSION_FOR_DEDICATED_HEALTH_PORT: string = 'v0.39.0-0';
+
+// hiero-consensus-node#26918 replaced the block root hash with a fixed 16-slot merkle tree. The
+// consensus node produces that shape from the v0.77 line and the block node verifies it from 0.41.0,
+// so a deployment must keep both on the same side of the boundary: a mismatch is rejected with
+// BAD_BLOCK_PROOF, which saturates the consensus node block buffer and stalls the network. The '-0'
+// suffix makes pre-releases (e.g. v0.77.0-rc.11) satisfy the check.
+export const MINIMUM_CN_VERSION_FOR_16_SLOT_BLOCK_PROOF: string = 'v0.77.0-0';
+export const MINIMUM_BLOCK_NODE_VERSION_FOR_16_SLOT_BLOCK_PROOF: string = 'v0.41.0-0';
 
 export function getSoloVersion(): Version {
   const __filename: string = fileURLToPath(import.meta.url);

--- a/version.ts
+++ b/version.ts
@@ -26,14 +26,14 @@ export const CRANE_VERSION: string = 'v0.21.4';
 
 export const SOLO_CHART_VERSION: string = constants.getEnvironmentVariable('SOLO_CHART_VERSION') || '0.66.0';
 export const HEDERA_PLATFORM_VERSION: string = constants.getEnvironmentVariable('CONSENSUS_NODE_VERSION') || 'v0.75.1';
-export const MIRROR_NODE_VERSION: string = constants.getEnvironmentVariable('MIRROR_NODE_VERSION') || 'v0.161.0';
+export const MIRROR_NODE_VERSION: string = constants.getEnvironmentVariable('MIRROR_NODE_VERSION') || 'v0.162.0';
 export const EXPLORER_VERSION: string = constants.getEnvironmentVariable('EXPLORER_VERSION') || '26.2.0';
 export const HEDERA_JSON_RPC_RELAY_VERSION: string = constants.getEnvironmentVariable('RELAY_VERSION') || '0.78.1';
 export const INGRESS_CONTROLLER_VERSION: string =
   constants.getEnvironmentVariable('INGRESS_CONTROLLER_VERSION') || '0.14.5';
 // If this version changes, regenerate test/data/proto.zip (see test/data/get-block.sh for steps) —
 // a stale vendored schema causes intermittent grpcurl unmarshal failures (see issue #5848).
-export const BLOCK_NODE_VERSION: string = constants.getEnvironmentVariable('BLOCK_NODE_VERSION') || '0.40.1';
+export const BLOCK_NODE_VERSION: string = constants.getEnvironmentVariable('BLOCK_NODE_VERSION') || '0.41.0';
 
 export const METALLB_CHART_VERSION: string = constants.getEnvironmentVariable('METALLB_CHART_VERSION') || '0.15.3';
 export const MINIO_OPERATOR_VERSION: string = constants.getEnvironmentVariable('MINIO_OPERATOR_VERSION') || '7.1.1';


### PR DESCRIPTION
## Description

This pull request changes the following:

* Bump mirror node to `v0.162.0` and block node to `0.41.0`.
* Bump consensus node to `v0.77.0-rc.11`, because the mirror node and block node bumps above cannot land without it (see below).
* Replace every remaining functional `v0.75.1` consensus node pin with `v0.77.0-rc.11`: the `consensus-node-version` workflow input default, the nightly `cn-edge-version`, the `test-e2e-small-memory-load` env pin, `TEST_UPGRADE_TO_VERSION`, and the `CN_VERSION` default in four example Taskfiles.
* Add a validation gate so a mismatched consensus node / block node pairing fails immediately instead of silently stalling the network.
* Remove a reachable version-mismatch window in the version-upgrade example, and stop its block node check from false-passing.

### Why the consensus node bump is required

[hiero-consensus-node#26918](https://github.com/hiero-ledger/hiero-consensus-node/pull/26918) replaced the block root hash with a **fixed 16-slot merkle tree**, first tagged in `v0.77.0-rc.9`. Both bumps in this PR pick up the matching change:

| Component | Old block-proof format | New 16-slot format from | Change |
| --- | --- | --- | --- |
| Consensus node | through `v0.76.x` | `v0.77.0-rc.9` | [#26918](https://github.com/hiero-ledger/hiero-consensus-node/pull/26918) |
| Block node | through `0.40.1` | `0.41.0` | [#3378](https://github.com/hiero-ledger/hiero-block-node/pull/3378) |
| Mirror node | through `v0.161.0` | `v0.162.0` | [#14078](https://github.com/hiero-ledger/hiero-mirror-node/pull/14078) |

In mirror node `v0.162.0`, `BlockRootHashDigest.SLOT_COUNT` is `16` unconditionally — there is no feature flag or version gate. The mirror node PR author noted this directly: *"CI workflows depending on blockstream will start to fail until we get new compatible CN / BN release candidates."*

Against the previously pinned consensus node `v0.75.1`, which still emits the old shape, the block node rejected every block with `BAD_BLOCK_PROOF`, the consensus node block buffer saturated, nodes fell out of `ACTIVE`, and **ten checks failed** — E2E Block Node, E2E External database new, both GCS Storage tests, Performance Test, four Test Examples, and Docs Automation Command Output. The Docs failure was downstream: with no mirror data the relay never bound its port, so kubelet `SIGKILL`ed it (`exitCode: 137`).

Consensus node `v0.77.0-rc.11` is a release candidate because there is no GA `v0.77.0` yet (latest GA is `v0.76.1`). Its `build-v0.77.0-rc.11.zip` and `.sha384` are published on `builds.hedera.com`, and solo has pinned `-rc.N` consensus node versions before (`v0.74.0-rc.1`, `v0.73.0-rc.4`).

### Boundary gate

Three layers, so a future bump of any one component cannot silently reintroduce the stall:

* `version.ts` — new `MINIMUM_CN_VERSION_FOR_16_SLOT_BLOCK_PROOF` and `MINIMUM_BLOCK_NODE_VERSION_FOR_16_SLOT_BLOCK_PROOF` constants.
* `block node add` / `block node upgrade` — `assertBlockProofCompatibility()` rejects a block node version whose block-proof format disagrees with the deployed consensus node, via a new registered `BlockNodeBlockProofIncompatibleSoloError` (`SOLO-4082`). `--force` bypasses with a warning; `flags.force` was added to `ADD_FLAGS_LIST` for this.
* `.github/workflows/script/launch_network.sh` — the block node upgrade is skipped when it would cross the boundary while the consensus node stays behind. This is currently reachable: `SKIP_CONSENSUS_NODE_UPGRADE_UNTIL_CN_26498_FIXED=true` pins the consensus node to the source version for the whole run, so upgrading the block node to `0.41.0` alone left a **sustained** mismatch, not a brief window. A comment records that when that bypass is lifted the block node upgrade must move into the stop/start seam rather than simply being re-enabled.

### Version-upgrade example

`upgrade-components` previously ran `consensus network upgrade` and then `block node upgrade`, leaving the upgraded consensus node streaming to a pre-`0.41.0` block node for the duration of a helm upgrade plus a StatefulSet roll. Reordering alone does not help — a new-format block node cannot verify old-format proofs either — so the consensus node upgrade is now staged with `--skip-node-start`, the block node is upgraded while nothing is producing, then `consensus node start` runs.

Its block node assertion also called `./get-block.sh 1`, but `get-block.sh` ignores its argument and always requests `retrieveLatest`, so a block node that had stopped ingesting returned `SUCCESS` forever on a stale block. It now samples twice and requires the block number to advance.

### Behavior change to note during review

The new gate turns a previously-silent stall into a hard failure. Any deployment pairing a pre-`v0.77` consensus node with a `0.41.0`+ block node (or the reverse) will now be rejected by `block node add`/`upgrade` unless `--force` is passed. This is intentional, but it is a new error on a path that previously appeared to succeed.

Separately, and **not** caused by this PR: `--edge` is broken until consensus node `0.77.0` reaches GA, because `EdgeVersionFetcher.resolveEdgeVersions` selects each component's latest *stable* GitHub release, which yields old-format consensus node `v0.76.1` alongside new-format block node `0.41.0` and mirror node `v0.162.0`. No CI job enables edge today (`use-edge` defaults to `false` and is forced off for `pull_request`), so this is user-facing only.

### Related Issues

* Closes #
* Related to #

Two follow-ups are described above but do **not** yet have tracking issues — the unticked technical-debt and related-issues boxes below reflect that:

1. The migration test cannot fail on block node ingestion problems, because every progress assertion is fed from the record stream.
2. `--edge` pairs an old-format consensus node with new-format block/mirror nodes until consensus node `0.77.0` reaches GA.

### Pull request (PR) checklist

* \[x] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[x] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[x] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[x] All changes in this PR are included in the description
* \[x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[x] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[x] These changes required manual testing that is documented below
* \[x] Anything not tested is documented

The following manual testing was done:

* Confirmed the consensus node artifact exists before pinning it: `build-v0.77.0-rc.11.zip` and `build-v0.77.0-rc.11.sha384` both return HTTP 200 from `https://builds.hedera.com/node/software/v0.77/`. This matters because the release tag is interpolated into that URL verbatim rather than used as an image tag.
* Confirmed `0.77.0-rc.11` is published in `gcr.io/hedera-registry/consensus-node`.
* Diffed the block protos between consensus node `v0.76.1` (what block node `0.41.0` and mirror node `v0.162.0` build against) and `v0.77.0-rc.11`: comment-only differences, so all three agree at the wire level.
* Verified `-rc.N` handling end to end: `TEST_UPGRADE_TO_VERSION` has previously been `v0.75.0-rc.8` and `v0.74.0-rc.1`, so the `VERSION=` assertion in `consensus-node-test.ts` already handles the suffix, and the `MINIMUM_*` gates use the `-0` sentinel so prereleases compare correctly.
* Exercised the two bash version predicates added to `launch_network.sh` against 12 version strings: `0.74`/`0.75`/`0.76` resolve to the old format, `0.77.x` (rc and GA) to the new; block node `0.40.x` old, `0.41.0`+ new. `bash -n` clean.
* Full unit suite: 1950 passing. New `test/unit/version/block-proof-boundary.test.ts` adds 8 cases covering each mismatch pairing plus a guard that the shipped `BLOCK_NODE_VERSION` and `HEDERA_PLATFORM_VERSION` defaults stay on the same side of the boundary — that last case is what would have caught this PR before CI.
* `task build` and `task format` both pass with 0 errors, and the changed files contribute 0 new lint warnings.

The following was not tested:

* A local end-to-end deploy on consensus node `v0.77.0-rc.11`; this relies on the PR's E2E and example suites.
* The `--force` bypass on the new gate was not exercised against a live cluster, only the version comparison logic it guards.
* No new end-to-end test was added for the boundary itself. The existing block-node-attached suites (E2E Block Node, Dual Cluster Full, External Database) cover the matched-version path, and the mismatch path is now covered by unit tests plus the `launch_network.sh` skip.
* The migration test still does not assert block node health — its progress checks are fed from the record stream, so a block node that stops ingesting cannot fail it. Left as-is here; called out above as follow-up.

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>