### PR TITLE
fix: pin grpcurl version to v1.9.3

### DIFF
--- a/.github/workflows/flow-examples-test.yaml
+++ b/.github/workflows/flow-examples-test.yaml
@@ -230,7 +230,7 @@ jobs:
       - name: Install grpcurl
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
         run: |
-          go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
+          go install github.com/fullstorydev/grpcurl/cmd/grpcurl@d00c28104be4b06f4dd887196ccfc57b054aa069 # v1.9.3
 
       - name: Resolve consensus node version and Java version
         id: resolve-consensus-java

--- a/.github/workflows/flow-standard-runner-one-shot-windows.yaml
+++ b/.github/workflows/flow-standard-runner-one-shot-windows.yaml
@@ -127,12 +127,15 @@ jobs:
         # Kind requires Linux containers. GitHub's windows-latest runner has Docker in Windows
         # container mode with no Docker Desktop to switch it. WSL2 + Docker inside it replicates
         # what Docker Desktop does for Windows users, exposing a Linux daemon via TCP.
+        # use-cache is enabled so the distribution installer is cached across runs via
+        # actions/cache instead of re-downloaded every time — this workflow was intermittently
+        # timing out on the fresh download from a shared runner's network.
         uses: Vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7.0.0
         timeout-minutes: 10
         with:
           distribution: Ubuntu-24.04
           wsl-version: 2
-          use-cache: false
+          use-cache: true
           set-as-default: true
           additional-packages: |
             apt-transport-https

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -337,7 +337,7 @@ jobs:
       - name: Install grpcurl
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
         run: |
-          go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
+          go install github.com/fullstorydev/grpcurl/cmd/grpcurl@d00c28104be4b06f4dd887196ccfc57b054aa069 # v1.9.3
 
       - name: Compile Project
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}


### PR DESCRIPTION
## Description

Due to a new version of `grpcurl` all of our E2E tests started failing. This PR pins the version to a stable one.

### Related Issues

* Closes # N/A
