### PR TITLE
fix: remove SERVER_MAX_MESSAGE_SIZE_BYTES override from block node TSS values

### DIFF
--- a/resources/block-node-tss-values.yaml
+++ b/resources/block-node-tss-values.yaml
@@ -9,11 +9,10 @@ resources:
 blockNode:
   config:
     # TSS bootstrap can include a large genesis WRAPS proof. Keep JVM heap and direct memory
-    # above the configured max block message size so the block node can receive and parse it
-    # without OOM/readiness instability; pod memory remains capped by resources.limits.memory.
+    # above the block node chart's default max block message size so it can receive and parse
+    # the proof without OOM/readiness instability; pod memory remains capped by
+    # resources.limits.memory.
     JAVA_OPTS: '-Xms256m -Xmx512m -XX:MaxDirectMemorySize=128m -XX:MaxMetaspaceSize=128m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="/tmp/dump.hprof"'
-    # 36 MiB: accommodates the ~30 MiB genesis WRAPS proof with ~20% headroom
-    SERVER_MAX_MESSAGE_SIZE_BYTES: "37748736"
   health:
     readiness:
       initialDelaySeconds: 0

--- a/test/unit/commands/block-node-values.test.ts
+++ b/test/unit/commands/block-node-values.test.ts
@@ -60,7 +60,6 @@ interface BlockNodePerformanceValuesConfig {
   blockNode?: {
     config?: {
       JAVA_OPTS?: string;
-      SERVER_MAX_MESSAGE_SIZE_BYTES?: string;
     };
   };
 }
@@ -74,9 +73,7 @@ describe('Block node TSS values', (): void => {
       valuesContent,
     ) as BlockNodePerformanceValuesConfig;
     const javaOptions: string | undefined = parsedValues.blockNode?.config?.JAVA_OPTS;
-    const maxMessageSize: string | undefined = parsedValues.blockNode?.config?.SERVER_MAX_MESSAGE_SIZE_BYTES;
 
-    expect(maxMessageSize, 'TSS max message size should cover the genesis WRAPS proof').to.equal('37748736');
     expect(javaOptions, 'TSS JAVA_OPTS should be defined').to.be.a('string');
     expect(javaOptions, 'TSS heap should have enough headroom for the large bootstrap block').to.include('-Xmx512m');
     expect(javaOptions, 'TSS direct memory should be larger than one max block message').to.include(


### PR DESCRIPTION
## Description

This pull request changes the following:

* Removes the `SERVER_MAX_MESSAGE_SIZE_BYTES: "37748736"` (36 MiB) override from `resources/block-node-tss-values.yaml` so the block node uses the default max message size
* Drops the corresponding assertion from the "Block node TSS values" unit test

### Related Issues

Issue created in another project: https://github.com/hiero-ledger/hiero-block-node/issues/3587

### Pull request (PR) checklist

* [ ] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [x] Any technical debt has been documented as a separate issue and linked to this PR
* [x] Any `package.json` changes have been explained to and approved by a repository manager
* [ ] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [ ] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [x] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* TBD - deploy a TSS-enabled network and confirm the block node accepts the genesis WRAPS proof without a `RESOURCE_EXHAUSTED` / message-size error.

The following was not tested:

* Payloads larger than the genesis WRAPS proof; the chart default is now the only ceiling.
