### PR TITLE
fix: Remove redundant user confirmation in one-shot deploy

### DIFF
--- a/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
+++ b/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
@@ -63,13 +63,7 @@ import {KeysCommandDefinition} from '../../../command-definitions/keys-command-d
 import {type InvokedSoloCommand, invokeSoloCommand} from '../../../command-helpers.js';
 import {Flags as flags} from '../../../flags.js';
 import * as constants from '../../../../core/constants.js';
-import {
-  createDirectoryIfNotExists,
-  entityId,
-  Helpers,
-  remoteConfigsToDeploymentsTable,
-  sleep,
-} from '../../../../core/helpers.js';
+import {createDirectoryIfNotExists, entityId, Helpers, sleep} from '../../../../core/helpers.js';
 import {Duration} from '../../../../core/time/duration.js';
 import {BlockNodeDeployedEvent} from '../../../../core/events/event-types/block-node-deployed-event.js';
 import {MirrorNodeDeployedEvent} from '../../../../core/events/event-types/mirror-node-deployed-event.js';
@@ -93,7 +87,6 @@ import {ExplorerStateSchema} from '../../../../data/schema/model/remote/state/ex
 import {RelayNodeStateSchema} from '../../../../data/schema/model/remote/state/relay-node-state-schema.js';
 import {DeploymentPhase} from '../../../../data/schema/model/remote/deployment-phase.js';
 import {ComponentTypes} from '../../../../core/config/remote/enumerations/component-types.js';
-import {ConfigMap} from '../../../../integration/kube/resources/config-map/config-map.js';
 import {ServiceReference} from '../../../../integration/kube/resources/service/service-reference.js';
 import {ServiceName} from '../../../../integration/kube/resources/service/service-name.js';
 import chalk from 'chalk';
@@ -448,37 +441,6 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
             leaseReference.value = await this.leaseManager.create();
             return ListrLock.newAcquireLockTask(leaseReference.value, task);
           },
-        }),
-      }),
-      new OrchestratorPipelinePhase('Check for other deployments', {
-        asListrTask: (): SoloListrTask<OneShotSingleDeployContext> => ({
-          title: 'Check for other deployments',
-          task: async (
-            _: OneShotSingleDeployContext,
-            task: SoloListrTaskWrapper<OneShotSingleDeployContext>,
-          ): Promise<void> => {
-            const existingRemoteConfigs: ConfigMap[] = await this.k8Factory
-              .default()
-              .configMaps()
-              .listForAllNamespaces(Templates.renderConfigMapRemoteConfigLabels());
-            if (existingRemoteConfigs.length > 0) {
-              const existingDeploymentsTable: string[] = remoteConfigsToDeploymentsTable(existingRemoteConfigs);
-              const promptOptions: {default: boolean; message: string} = {
-                default: false,
-                message:
-                  'Warning: Existing solo deployment detected in cluster.\n\n' +
-                  existingDeploymentsTable.join('\n') +
-                  '\n\nCreating another deployment will require additional' +
-                  ' CPU and memory resources. Do you want to proceed and create another deployment?',
-              };
-              const proceed: boolean = await task.prompt(ListrInquirerPromptAdapter).run(confirmPrompt, promptOptions);
-              if (!proceed) {
-                throw new UserBreak('Aborted by user');
-              }
-            }
-          },
-          skip: (context_: OneShotSingleDeployContext): boolean =>
-            context_.config.force === true || context_.config.quiet === true,
         }),
       }),
       OrchestratorPipelinePhase.composite(


### PR DESCRIPTION
## Description

This PR removes a user confirmation prompt during the `solo one-shot single deploy` command, which was put in place to prevent unintentional creation of additional deployments. Since having more than one `one-shot` deployment is now not possible, the prompt is redundant.

### Related Issues

* Closes #5944
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
