### PR TITLE
fix(ci): repair inert job conditions and hoist injected expressions

### DIFF
--- a/.github/workflows/flow-ledger-reset-warm-start-timing.yaml
+++ b/.github/workflows/flow-ledger-reset-warm-start-timing.yaml
@@ -41,6 +41,10 @@ on:
         type: number
         required: false
         default: 3
+    secrets:
+      SLACK_TEST_WEBHOOK:
+        description: "Webhook used by the Send Slack Notification step to post the timing summary"
+        required: false
 
 defaults:
   run:

--- a/.github/workflows/flow-nightly-extended-tests.yaml
+++ b/.github/workflows/flow-nightly-extended-tests.yaml
@@ -252,14 +252,16 @@ jobs:
     needs:
       - generate_matrix
     uses: ./.github/workflows/flow-one-shot-timing.yaml
-    secrets: inherit
+    secrets:
+      SLACK_TEST_WEBHOOK: ${{ secrets.SLACK_TEST_WEBHOOK }}
 
   ledger-reset-warm-start-timing:
     name: Extended Test (ledger-reset-warm-start-timing)
     needs:
       - generate_matrix
     uses: ./.github/workflows/flow-ledger-reset-warm-start-timing.yaml
-    secrets: inherit
+    secrets:
+      SLACK_TEST_WEBHOOK: ${{ secrets.SLACK_TEST_WEBHOOK }}
 
   flow-performance-test:
     name: Extended Test (flow-performance-test)
@@ -268,7 +270,8 @@ jobs:
       actions: read # flow-performance-test.yaml polls the current workflow run
     needs:
       - generate_matrix
+    # No `secrets:` block: this workflow only uses secrets.GITHUB_TOKEN, which GitHub provides to
+    # called workflows automatically and which cannot be passed explicitly.
     uses: ./.github/workflows/flow-performance-test.yaml
     with:
       cn-edge-version: v0.75.1
-    secrets: inherit

--- a/.github/workflows/flow-one-shot-timing.yaml
+++ b/.github/workflows/flow-one-shot-timing.yaml
@@ -101,6 +101,10 @@ on:
         type: number
         required: false
         default: 3
+    secrets:
+      SLACK_TEST_WEBHOOK:
+        description: "Webhook used by the Send Slack Notification step to post the timing summary"
+        required: false
 
 defaults:
   run:

--- a/.github/workflows/flow-performance-test.yaml
+++ b/.github/workflows/flow-performance-test.yaml
@@ -70,7 +70,7 @@ env:
 jobs:
   performance-test:
     name: Performance Test
-    if: >
+    if: >-
       ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false ||
       startsWith(github.event.pull_request.title, 'trunk-merge') && !cancelled() && !failure() }}
     timeout-minutes: 90

--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -185,7 +185,7 @@ jobs:
     # If it is a workflow dispatch AND we are skipping unit test and coverage, skip Hugo Docs Build job
     # If it is a PR, check if it's a draft PR. If a draft PR, check if it starts with 'trunk-merge', if true then run Docs Automation job
     # If it is regular PR, always run Docs Automation job
-    if: >
+    if: >-
       ${{ (!(github.event_name == 'workflow_dispatch' && github.event.inputs.skip-unit-and-coverage) ||
       (github.event_name == 'pull_request' && (github.event.pull_request.draft == false ||
       startsWith(github.event.pull_request.title, 'trunk-merge')))) && !cancelled() }}

--- a/.github/workflows/zxc-code-style.yaml
+++ b/.github/workflows/zxc-code-style.yaml
@@ -110,6 +110,8 @@ jobs:
 
       - name: Compare warnings with target branch
         if: ${{ github.event_name == 'pull_request' }}
+        env:
+          TARGET_BRANCH: ${{ github.event.pull_request.base.ref }}
         run: |
           get_warnings() {
             file="$1"
@@ -121,7 +123,7 @@ jobs:
             fi
           }
           # Determine the PR target (base) branch
-          target_branch="${{ github.event.pull_request.base.ref }}"
+          target_branch="${TARGET_BRANCH}"
           echo "Target branch: $target_branch"
           # Fetch and check out the target branch from origin
           git fetch origin "$target_branch":"$target_branch"

--- a/.github/workflows/zxc-hugo-build.yaml
+++ b/.github/workflows/zxc-hugo-build.yaml
@@ -65,8 +65,10 @@ jobs:
           egress-policy: audit
 
       - name: Validate docs-build-label input
+        env:
+          DOCS_BUILD_LABEL_INPUT: ${{ inputs.docs-build-label }}
         run: |
-          DOCS_BUILD_LABEL="${{ inputs.docs-build-label }}"
+          DOCS_BUILD_LABEL="${DOCS_BUILD_LABEL_INPUT}"
           echo "Validating docs-build-label: ${DOCS_BUILD_LABEL}"
           if [[ "${DOCS_BUILD_LABEL}" == "main" ]]; then
             echo "Input is 'main', no validation needed."
@@ -129,14 +131,16 @@ jobs:
         id: hugo-build
         env:
           GH_TOKEN: ${{ secrets.github-token }} # We want this to be null unless we want to pull the existing release artifacts
+          DOCS_BUILD_LABEL_INPUT: ${{ inputs.docs-build-label }}
         run: |
           set -eo pipefail
           cd docs/site
-          DOCS_BUILD_LABEL="${{ inputs.docs-build-label }}"
+          DOCS_BUILD_LABEL="${DOCS_BUILD_LABEL_INPUT}"
+          # GH_TOKEN is inherited from the step environment above.
           if [[ -z ${DOCS_BUILD_LABEL} ]]; then
-            SOLO_CI=true GH_TOKEN=${{ secrets.github-token }} task build 
+            SOLO_CI=true task build
           else
-            SOLO_CI=true GH_TOKEN=${{ secrets.github-token }} HUGO_SOLO_VERSION=${DOCS_BUILD_LABEL} task build
+            SOLO_CI=true HUGO_SOLO_VERSION=${DOCS_BUILD_LABEL} task build
           fi
 
       # Upload the built site to artifacts

--- a/.github/workflows/zxc-hugo-publish.yaml
+++ b/.github/workflows/zxc-hugo-publish.yaml
@@ -107,17 +107,20 @@ jobs:
 
       - name: Attach Docs as Release Artifacts
         if: ${{ inputs.attach-docs-enabled && !inputs.dry-run-enabled && !cancelled() && !failure() }}
+        env:
+          DOCS_BUILD_LABEL_INPUT: ${{ inputs.docs-build-label }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eo pipefail
-          RELEASE_VERSION="${{ inputs.docs-build-label }}"
+          RELEASE_VERSION="${DOCS_BUILD_LABEL_INPUT}"
           # Ensure the release version is set
           if [[ -z "${RELEASE_VERSION}" ]]; then
             echo "Error: docs-build-label input is required for attaching release artifacts." >&2
             exit 1
           fi
           cd docs/site
-          # Create the release artifact tarballs
-          GH_TOKEN=${{ secrets.GITHUB_TOKEN }} HUGO_SOLO_VERSION="${RELEASE_VERSION}" task github:upload:release:assets
+          # Create the release artifact tarballs; GH_TOKEN is inherited from the step environment.
+          HUGO_SOLO_VERSION="${RELEASE_VERSION}" task github:upload:release:assets
 
       # Upload / stage the built site to GitHub Pages
       - name: Upload Pages Artifact


### PR DESCRIPTION
## Description

First of a series of stacked PRs remediating pre-existing zizmor findings. zizmor is run **offline** (v1.30.0, `--no-config`) — this series fixes the underlying issues, and adds no scanning job and no ignore/baseline configuration.

This PR fixes **9 findings across 8 workflows**, chosen because each is High confidence and has a mechanical fix that needs no design decision.

### `unsound-condition` (2 findings) — job guards were completely inert

`flow-performance-test.yaml` and `flow-pull-request-checks.yaml` declared their job guards with the folded block scalar `if: >`, which **retains a trailing newline**. The value is therefore not a pure expression but the string `"${{ ... }}\n"`. GitHub treats a non-empty string as truthy, so both guards always evaluated to true and their jobs ran unconditionally — the draft-PR and `skip-unit-and-coverage` filters never took effect.

Switching to `if: >-` strips the trailing newline and restores the intended evaluation. The remaining 5 folded conditions in the repository already use `>-`; these two were the only outliers.

**This changes behaviour, which is the point:** `performance-test` and `docs-automation` will now actually skip when their conditions say they should. Confirmed after the change that the parsed `if` value ends in `}}` with no trailing newline.

Note for a follow-up, not changed here: in `flow-performance-test.yaml` the guard mixes `||` and `&&` without parentheses, so `!cancelled() && !failure()` binds only to the `startsWith(...)` branch rather than to the whole condition. That is likely not what was intended, but it is a semantic decision for the workflow owner rather than part of this finding. `flow-pull-request-checks.yaml` is correctly parenthesised and needs no such follow-up.

### `template-injection` (4 findings) — expressions expanded into shell

`zxc-code-style.yaml`, `zxc-hugo-build.yaml` (×2) and `zxc-hugo-publish.yaml` expanded `${{ ... }}` directly into `run:` blocks, where a crafted value can terminate the surrounding shell quoting and execute arbitrary code. The most exposed of these is `zxc-code-style.yaml`, which interpolated `github.event.pull_request.base.ref`.

Each value now travels through the step's `env:` and is referenced as a shell variable, so it is never substituted into the script text.

In `zxc-hugo-build.yaml` and `zxc-hugo-publish.yaml` the GitHub token was additionally re-interpolated inline (`GH_TOKEN=${{ secrets.… }} task build`) when it was already present in — or could be moved to — the step environment. Those run blocks now inherit it, which is equivalent and removes the interpolation.

### `secrets-inherit` (3 findings) — every repository secret forwarded to called workflows

`flow-nightly-extended-tests.yaml` called three reusable workflows with `secrets: inherit`, which forwards *every* repository secret to the callee regardless of what it actually needs. The three calls split into two cases:

* `flow-one-shot-timing.yaml` and `flow-ledger-reset-warm-start-timing.yaml` genuinely need `secrets.SLACK_TEST_WEBHOOK` for their Slack notification step, but never declared it — they were receiving it *only* because of `inherit`. Both now declare it under `workflow_call.secrets`, and the caller passes that one secret explicitly.
* `flow-performance-test.yaml` uses only `secrets.GITHUB_TOKEN`, which GitHub provides to called workflows automatically and which cannot be passed explicitly. Its `secrets: inherit` is therefore dropped with no replacement, and a comment records why the job has no `secrets:` block.

`SLACK_TEST_WEBHOOK` is declared `required: false`, so both workflows can still be run directly via `workflow_dispatch`, where the repository secret resolves without being passed by a caller.

### Deliberately excluded

* `dangerous-triggers` (2, High/**Medium**) — `pull_request_target` in `flow-pull-request-formatting.yaml` and `workflow_run` in `flow-trigger-solo-docs-update.yaml`. These are architectural: remediating them means redesigning how the workflow obtains its privileges, or consciously accepting the risk. Needs a decision from the workflow owners, not a cleanup commit.
* `cache-poisoning` (6, High/**Low**) — requires per-workflow judgement about whether caching is actually needed in a publishing path.
* `unpinned-images` (1) — `flow-install-validation.yaml` uses `archlinux:latest`, but an inline comment already documents *why*: Arch is a rolling release, so pinning a tag would desynchronise the pinned base from the freshly refreshed package index the bootstrap relies on. Pinning it would change what the matrix actually validates, so it needs an explicit call rather than a silent change.

### Remaining after this PR

238 findings: `template-injection` 146, `self-repository` 43, `artipacked` 27, `adhoc-packages` 13, `cache-poisoning` 6, `dangerous-triggers` 2, `unpinned-images` 1. The `secrets-inherit` and `unsound-condition` rules are now fully cleared. These will follow as further stacked PRs, scoped per workflow to keep diffs small and avoid merge conflicts.

### Related Issues

* Related to #5931

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[x] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[x] Any technical debt has been documented as a separate issue and linked to this PR
* \[x] Any `package.json` changes have been explained to and approved by a repository manager
* \[x] All related issues have been linked to this PR
* \[x] All changes in this PR are included in the description
* \[x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

Two boxes are deliberately left unchecked. **No tests were added:** these are CI workflow definitions, which the repository's unit and E2E suites do not exercise; verification was done by static analysis and YAML parsing, described below. **Not free of behaviour changes:** the two `if:` corrections intentionally make previously-inert job guards effective, as described above. No *user-facing* or API behaviour changes.

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[x] These changes required manual testing that is documented below
* \[x] Anything not tested is documented

The following manual testing was done, with the same zizmor release the project standardised on (1.30.0):

* Scanned before and after with `zizmor --no-config .github/workflows .github/actions` and diffed the results by rule: `unsound-condition` **2 → 0**, `template-injection` **150 → 146**, `secrets-inherit` **3 → 0**, total **247 → 238**. Every other rule count is unchanged, confirming the edits fixed the intended findings and introduced no new ones.
* Verified the rewired secrets by parsing the documents: the two callers now pass exactly `{SLACK_TEST_WEBHOOK}`, the `flow-performance-test` call passes nothing, and both callees declare `SLACK_TEST_WEBHOOK` with `required: false`. Confirmed no `secrets: inherit` remains anywhere under `.github/workflows`.
* Parsed all eight modified workflows with `js-yaml` to confirm they are still valid YAML.
* Asserted on the parsed document that `flow-performance-test.yaml`'s `if` value now terminates in `}}` rather than a newline — the actual mechanism of the `unsound-condition` fix.
* Grepped the whole workflow directory to confirm `if: >` no longer appears and that the 5 pre-existing `if: >-` conditions were untouched.

The following was not tested:

* The workflows were not executed end-to-end. The two `if:` changes alter which jobs run, so the first real PR and dispatch runs are worth watching to confirm `performance-test` and `docs-automation` gate as intended.
* The nightly extended-test run was not executed, so the rewired `SLACK_TEST_WEBHOOK` hand-off has not been observed end to end. Note that the Slack step is guarded only by `if: ${{ !cancelled() }}` and not on the webhook being present, so if a future caller omits the secret that step will fail rather than skip — unchanged from the previous behaviour, but worth knowing.
* `zxc-hugo-build` and `zxc-hugo-publish` are release/publishing paths that this PR does not trigger. The token handling there changes only *where* `GH_TOKEN` is bound (step `env:` instead of an inline command prefix), with the same value, so it is equivalent by inspection but has not been observed in a live release run.