### PR TITLE
fix: load local component images into all Kind clusters

### DIFF
--- a/src/commands/base.ts
+++ b/src/commands/base.ts
@@ -311,7 +311,9 @@ export abstract class BaseCommand extends ShellRunner {
 
   protected async kindLoadComponentImage(componentImage: string, clusterContext: string): Promise<void> {
     const targetContexts: Context[] = [...new Set<Context>([...this.remoteConfig.getContexts(), clusterContext])];
-    const nonKindContexts: Context[] = targetContexts.filter((context: Context): boolean => !context.startsWith('kind-'));
+    const nonKindContexts: Context[] = targetContexts.filter(
+      (context: Context): boolean => !context.startsWith('kind-'),
+    );
 
     if (nonKindContexts.length > 0) {
       throw new SoloErrors.validation.illegalArgument(

--- a/src/commands/base.ts
+++ b/src/commands/base.ts
@@ -48,6 +48,7 @@ import {LoadDockerImageOptionsBuilder} from '../integration/kind/model/load-dock
 import {checkDockerImageExists} from '../core/helpers.js';
 import {PathEx} from '../business/utils/path-ex.js';
 import {OperatingSystem} from '../business/utils/operating-system.js';
+import {ImageReference, type ParsedImageReference} from '../business/utils/image-reference.js';
 import {getEnvironmentVariable} from '../core/constants.js';
 
 interface DockerDesktopContainerdCheckResult {
@@ -292,6 +293,19 @@ export abstract class BaseCommand extends ShellRunner {
   }
 
   protected splitImageNameTag(imageReference: string): {name: string; tag: string} {
+    const firstSegment: string = imageReference.split('/', 1)[0];
+    const explicitRegistryReference: boolean =
+      (firstSegment.includes('.') || firstSegment.includes(':') || firstSegment === 'localhost') &&
+      imageReference.includes('/');
+
+    if (explicitRegistryReference || this.isLocalRegistryImageReference(imageReference)) {
+      const parsedReference: ParsedImageReference = ImageReference.parseImageReference(imageReference);
+      return {
+        name: `${parsedReference.registry}/${parsedReference.repository}`,
+        tag: parsedReference.tag,
+      };
+    }
+
     const colonIndex: number = imageReference.lastIndexOf(':');
     if (colonIndex === -1) {
       throw new SoloErrors.validation.illegalArgument(
@@ -310,7 +324,12 @@ export abstract class BaseCommand extends ShellRunner {
   }
 
   protected async kindLoadComponentImage(componentImage: string, clusterContext: string): Promise<void> {
-    const targetContexts: Context[] = [...new Set<Context>([...this.remoteConfig.getContexts(), clusterContext])];
+    const additionalKindContexts: Context[] = this.remoteConfig
+      .getContexts()
+      .filter(
+        (context: Context): boolean => context.startsWith('kind-') && context !== clusterContext,
+      );
+    const targetContexts: Context[] = [...new Set<Context>([clusterContext, ...additionalKindContexts])];
     const nonKindContexts: Context[] = targetContexts.filter(
       (context: Context): boolean => !context.startsWith('kind-'),
     );

--- a/src/commands/base.ts
+++ b/src/commands/base.ts
@@ -276,11 +276,19 @@ export abstract class BaseCommand extends ShellRunner {
   }
 
   protected isLocalImageReference(imageReference: string): boolean {
+    if (this.isLocalRegistryImageReference(imageReference)) {
+      return true;
+    }
+
     const withoutTag: string = imageReference.includes(':')
       ? imageReference.slice(0, imageReference.lastIndexOf(':'))
       : imageReference;
     const firstSegment: string = withoutTag.split('/', 1)[0];
     return !firstSegment.includes('.') && !firstSegment.includes(':') && firstSegment !== 'localhost';
+  }
+
+  protected isLocalRegistryImageReference(imageReference: string): boolean {
+    return /^localhost:\d+\//.test(imageReference);
   }
 
   protected splitImageNameTag(imageReference: string): {name: string; tag: string} {
@@ -302,14 +310,29 @@ export abstract class BaseCommand extends ShellRunner {
   }
 
   protected async kindLoadComponentImage(componentImage: string, clusterContext: string): Promise<void> {
-    const kindClusterName: string = this.kindClusterNameFromContext(clusterContext);
-    this.logger.debug(`Loading '${componentImage}' into Kind cluster '${kindClusterName}'`);
+    const targetContexts: Context[] = [...new Set<Context>([...this.remoteConfig.getContexts(), clusterContext])];
+    const nonKindContexts: Context[] = targetContexts.filter((context: Context): boolean => !context.startsWith('kind-'));
+
+    if (nonKindContexts.length > 0) {
+      throw new SoloErrors.validation.illegalArgument(
+        `Component image '${componentImage}' requires Kind image loading, but target cluster context(s) ` +
+          `'${nonKindContexts.join("', '")}' are not Kind clusters. Push the image to a registry reachable ` +
+          'from every target cluster and pass that registry image reference to --component-image.',
+        componentImage,
+      );
+    }
+
     const kindExecutable: string = await this.depManager.getExecutable(constants.KIND);
     const kindClient: KindClient = await this.kindBuilder.executable(kindExecutable).build();
-    await kindClient.loadDockerImage(
-      componentImage,
-      LoadDockerImageOptionsBuilder.builder().name(kindClusterName).build(),
-    );
+
+    for (const targetContext of targetContexts) {
+      const kindClusterName: string = this.kindClusterNameFromContext(targetContext);
+      this.logger.debug(`Loading '${componentImage}' into Kind cluster '${kindClusterName}'`);
+      await kindClient.loadDockerImage(
+        componentImage,
+        LoadDockerImageOptionsBuilder.builder().name(kindClusterName).build(),
+      );
+    }
   }
 
   protected async throwIfNamespaceIsMissing(context: Context, namespace: NamespaceName): Promise<void> {

--- a/src/commands/base.ts
+++ b/src/commands/base.ts
@@ -293,12 +293,7 @@ export abstract class BaseCommand extends ShellRunner {
   }
 
   protected splitImageNameTag(imageReference: string): {name: string; tag: string} {
-    const firstSegment: string = imageReference.split('/', 1)[0];
-    const explicitRegistryReference: boolean =
-      (firstSegment.includes('.') || firstSegment.includes(':') || firstSegment === 'localhost') &&
-      imageReference.includes('/');
-
-    if (explicitRegistryReference || this.isLocalRegistryImageReference(imageReference)) {
+    if (this.isLocalRegistryImageReference(imageReference)) {
       const parsedReference: ParsedImageReference = ImageReference.parseImageReference(imageReference);
       return {
         name: `${parsedReference.registry}/${parsedReference.repository}`,
@@ -326,9 +321,7 @@ export abstract class BaseCommand extends ShellRunner {
   protected async kindLoadComponentImage(componentImage: string, clusterContext: string): Promise<void> {
     const additionalKindContexts: Context[] = this.remoteConfig
       .getContexts()
-      .filter(
-        (context: Context): boolean => context.startsWith('kind-') && context !== clusterContext,
-      );
+      .filter((context: Context): boolean => context.startsWith('kind-') && context !== clusterContext);
     const targetContexts: Context[] = [...new Set<Context>([clusterContext, ...additionalKindContexts])];
     const nonKindContexts: Context[] = targetContexts.filter(
       (context: Context): boolean => !context.startsWith('kind-'),

--- a/src/commands/block-node.ts
+++ b/src/commands/block-node.ts
@@ -374,26 +374,35 @@ export class BlockNodeCommand extends BaseCommand {
 
     if ('componentImage' in config && config.componentImage) {
       if (this.isLocalImageReference(config.componentImage)) {
-        const {name: localImageName, tag: rawTag} = this.splitImageNameTag(config.componentImage);
-        const localImageTag: string = SemanticVersion.getValidSemanticVersion(rawTag, false, 'Block node image tag');
-        if (this.isLocalImageAvailableInDocker(`${localImageName}:${localImageTag}`)) {
-          // Image found locally — kind-load task will load it; set pullPolicy: Never.
-          if (this.isLocalRegistryImageReference(config.componentImage)) {
-            const parsedReference: ParsedImageReference = ImageReference.parseImageReference(config.componentImage);
+        if (this.isLocalRegistryImageReference(config.componentImage)) {
+          const parsedReference: ParsedImageReference = ImageReference.parseImageReference(config.componentImage);
+          if (this.isLocalImageAvailableInDocker(config.componentImage)) {
+            // Image found locally — kind-load task will load it; set pullPolicy: Never.
             chartValues
               .setLiteral('image.registry', parsedReference.registry)
               .set('image.repository', parsedReference.repository)
-              .set('image.tag', localImageTag)
+              .set('image.tag', parsedReference.tag)
               .set('image.pullPolicy', 'Never');
           } else {
+            // Preserve the explicit registry/repository when a local registry image is pulled remotely.
+            chartValues
+              .setLiteral('image.registry', parsedReference.registry)
+              .set('image.repository', parsedReference.repository)
+              .set('image.tag', parsedReference.tag);
+          }
+        } else {
+          const {name: localImageName, tag: rawTag} = this.splitImageNameTag(config.componentImage);
+          const localImageTag: string = SemanticVersion.getValidSemanticVersion(rawTag, false, 'Block node image tag');
+          if (this.isLocalImageAvailableInDocker(`${localImageName}:${localImageTag}`)) {
+            // Image found locally — kind-load task will load it; set pullPolicy: Never.
             chartValues
               .set('image.repository', localImageName)
               .set('image.tag', localImageTag)
               .set('image.pullPolicy', 'Never');
+          } else {
+            // Not in local Docker — plain tag override so K8s can pull from a registry.
+            chartValues.set('image.tag', localImageTag);
           }
-        } else {
-          // Not in local Docker — plain tag override so K8s can pull from a registry.
-          chartValues.set('image.tag', localImageTag);
         }
       } else {
         const parsedReference: ParsedImageReference = ImageReference.parseImageReference(config.componentImage);
@@ -1713,7 +1722,7 @@ export class BlockNodeCommand extends BaseCommand {
   private getLivenessCheckPortNumber(chartVersion: string, componentImage?: string): number {
     let blockNodeVersion: SemanticVersion<string> = new SemanticVersion<string>(chartVersion);
 
-    if (componentImage && this.isLocalImageReference(componentImage)) {
+    if (componentImage && this.isLocalImageReference(componentImage) && !this.isLocalRegistryImageReference(componentImage)) {
       const tag: string = this.splitImageNameTag(componentImage).tag;
       const imageVersion: SemanticVersion<string> = new SemanticVersion<string>(tag);
       if (blockNodeVersion.lessThan(imageVersion)) {
@@ -1746,7 +1755,11 @@ export class BlockNodeCommand extends BaseCommand {
     }
 
     const deployConfig: BlockNodeDeployConfigClass = config as BlockNodeDeployConfigClass;
-    if (deployConfig.componentImage && this.isLocalImageReference(deployConfig.componentImage)) {
+    if (
+      deployConfig.componentImage &&
+      this.isLocalImageReference(deployConfig.componentImage) &&
+      !this.isLocalRegistryImageReference(deployConfig.componentImage)
+    ) {
       const tag: string = this.splitImageNameTag(deployConfig.componentImage).tag;
       componentImageVersion = new SemanticVersion<string>(tag);
     }

--- a/src/commands/block-node.ts
+++ b/src/commands/block-node.ts
@@ -1722,11 +1722,15 @@ export class BlockNodeCommand extends BaseCommand {
   private getLivenessCheckPortNumber(chartVersion: string, componentImage?: string): number {
     let blockNodeVersion: SemanticVersion<string> = new SemanticVersion<string>(chartVersion);
 
-    if (componentImage && this.isLocalImageReference(componentImage) && !this.isLocalRegistryImageReference(componentImage)) {
+    if (componentImage && this.isLocalImageReference(componentImage)) {
       const tag: string = this.splitImageNameTag(componentImage).tag;
-      const imageVersion: SemanticVersion<string> = new SemanticVersion<string>(tag);
-      if (blockNodeVersion.lessThan(imageVersion)) {
-        blockNodeVersion = imageVersion;
+      try {
+        const imageVersion: SemanticVersion<string> = new SemanticVersion<string>(tag);
+        if (blockNodeVersion.lessThan(imageVersion)) {
+          blockNodeVersion = imageVersion;
+        }
+      } catch {
+        // non-semver tags (e.g. implicit latest on tagless local registry refs) cannot drive the port choice
       }
     }
 
@@ -1755,13 +1759,13 @@ export class BlockNodeCommand extends BaseCommand {
     }
 
     const deployConfig: BlockNodeDeployConfigClass = config as BlockNodeDeployConfigClass;
-    if (
-      deployConfig.componentImage &&
-      this.isLocalImageReference(deployConfig.componentImage) &&
-      !this.isLocalRegistryImageReference(deployConfig.componentImage)
-    ) {
+    if (deployConfig.componentImage && this.isLocalImageReference(deployConfig.componentImage)) {
       const tag: string = this.splitImageNameTag(deployConfig.componentImage).tag;
-      componentImageVersion = new SemanticVersion<string>(tag);
+      try {
+        componentImageVersion = new SemanticVersion<string>(tag);
+      } catch {
+        // non-semver tags (e.g. implicit latest on tagless local registry refs) do not bump the component version
+      }
     }
 
     const finalVersion: SemanticVersion<string> =

--- a/src/commands/block-node.ts
+++ b/src/commands/block-node.ts
@@ -378,10 +378,19 @@ export class BlockNodeCommand extends BaseCommand {
         const localImageTag: string = SemanticVersion.getValidSemanticVersion(rawTag, false, 'Block node image tag');
         if (this.isLocalImageAvailableInDocker(`${localImageName}:${localImageTag}`)) {
           // Image found locally — kind-load task will load it; set pullPolicy: Never.
-          chartValues
-            .set('image.repository', localImageName)
-            .set('image.tag', localImageTag)
-            .set('image.pullPolicy', 'Never');
+          if (this.isLocalRegistryImageReference(config.componentImage)) {
+            const parsedReference: ParsedImageReference = ImageReference.parseImageReference(config.componentImage);
+            chartValues
+              .setLiteral('image.registry', parsedReference.registry)
+              .set('image.repository', parsedReference.repository)
+              .set('image.tag', localImageTag)
+              .set('image.pullPolicy', 'Never');
+          } else {
+            chartValues
+              .set('image.repository', localImageName)
+              .set('image.tag', localImageTag)
+              .set('image.pullPolicy', 'Never');
+          }
         } else {
           // Not in local Docker — plain tag override so K8s can pull from a registry.
           chartValues.set('image.tag', localImageTag);

--- a/src/commands/explorer.ts
+++ b/src/commands/explorer.ts
@@ -436,6 +436,10 @@ export class ExplorerCommand extends BaseCommand {
           }
         }
 
+        if (config.componentImage && this.isLocalImageAvailableInDocker(config.componentImage)) {
+          await this.kindLoadComponentImage(config.componentImage, config.clusterContext);
+        }
+
         await this.chartManager.upgrade(
           config.namespace,
           config.releaseName,

--- a/src/commands/explorer.ts
+++ b/src/commands/explorer.ts
@@ -425,8 +425,16 @@ export class ExplorerCommand extends BaseCommand {
               .set('image.tag', parsedReference.tag)
               .setLiteral('image.pullPolicy', 'Never');
           } else if (this.isLocalImageReference(config.componentImage)) {
-            // Local-looking ref but not in Docker — plain tag override, K8s will pull from registry.
-            explorerChartValues.set('image.tag', parsedReference.tag);
+            // Explicit local registry refs keep their registry/repository metadata even when Docker is missing.
+            if (this.isLocalRegistryImageReference(config.componentImage)) {
+              explorerChartValues
+                .setLiteral('image.registry', parsedReference.registry)
+                .setLiteral('image.repository', parsedReference.repository)
+                .set('image.tag', parsedReference.tag);
+            } else {
+              // Local-looking ref but not in Docker — plain tag override, K8s will pull from registry.
+              explorerChartValues.set('image.tag', parsedReference.tag);
+            }
           } else {
             // Explicit registry reference.
             explorerChartValues

--- a/src/commands/flags.ts
+++ b/src/commands/flags.ts
@@ -538,9 +538,10 @@ export class Flags {
     name: 'component-image',
     definition: {
       describe:
-        'Docker image override. Accepts a registry reference (e.g. ghcr.io/hiero-ledger/block-node-server:0.36.0) ' +
-        'or a local reference (e.g. block-node-server:0.36.0-SNAPSHOT). ' +
-        'Local images found in Docker are automatically loaded into the Kind cluster.',
+        'Docker image override. Supports a published registry reference (e.g. ghcr.io/hiero-ledger/component:1.2.3), ' +
+        'a locally built image (e.g. component:1.2.3), or a Kind-attached local registry ' +
+        '(e.g. localhost:5001/component:1.2.3). Locally available images are loaded into every target Kind ' +
+        'cluster and use pullPolicy: Never. For non-Kind targets, publish the image to a registry reachable by the cluster.',
       defaultValue: '',
       type: 'string',
       alias: 'relay-image',

--- a/test/unit/commands/base.test.ts
+++ b/test/unit/commands/base.test.ts
@@ -286,6 +286,7 @@ describe('BaseCommand', (): void => {
       'hiero-explorer:my-build',
       'hiero-json-rpc-relay:local',
       'myimage:latest',
+      'localhost:5001/block-node-server',
       'localhost:5001/block-node-server:0.38.0',
     ];
 
@@ -342,14 +343,41 @@ describe('BaseCommand', (): void => {
       );
     });
 
+    it('should ignore non-Kind deployment contexts when loading a local image onto a selected Kind context', async (): Promise<void> => {
+      const baseCommandInternal: BaseCommandInternal = baseCmd as unknown as BaseCommandInternal;
+      const loadDockerImageStub: SinonStub = sinon.stub().resolves();
+      const kindClient: KindClient = {loadDockerImage: loadDockerImageStub} as unknown as KindClient;
+
+      baseCommandInternal.remoteConfig = {
+        getContexts: (): Context[] => ['remote-cluster', 'kind-first'],
+      };
+      baseCommandInternal.depManager = {
+        getExecutable: async (dependency: string): Promise<string> => {
+          expect(dependency).to.equal('kind');
+          return 'kind';
+        },
+      };
+      baseCommandInternal.kindBuilder = {
+        executable: (executable: string): {build: () => Promise<KindClient>} => {
+          expect(executable).to.equal('kind');
+          return {build: async (): Promise<KindClient> => kindClient};
+        },
+      };
+
+      await baseCommandInternal.kindLoadComponentImage('block-node-server:0.38.0', 'kind-first');
+
+      expect(loadDockerImageStub).to.have.been.calledOnce;
+      expect(loadDockerImageStub).to.have.been.calledWith('block-node-server:0.38.0', sinon.match.has('name', 'first'));
+    });
+
     it('should explain how to make an image available to a non-Kind target context', async (): Promise<void> => {
       const baseCommandInternal: BaseCommandInternal = baseCmd as unknown as BaseCommandInternal;
       baseCommandInternal.remoteConfig = {
-        getContexts: (): Context[] => ['remote-cluster'],
+        getContexts: (): Context[] => ['kind-first'],
       };
 
       await expect(
-        baseCommandInternal.kindLoadComponentImage('block-node-server:0.38.0', 'kind-first'),
+        baseCommandInternal.kindLoadComponentImage('block-node-server:0.38.0', 'remote-cluster'),
       ).to.be.rejectedWith(
         "Component image 'block-node-server:0.38.0' requires Kind image loading, but target cluster context(s) " +
           "'remote-cluster' are not Kind clusters. Push the image to a registry reachable from every target " +

--- a/test/unit/commands/base.test.ts
+++ b/test/unit/commands/base.test.ts
@@ -27,6 +27,19 @@ import {type CommandFlag} from '../../../src/types/flag-types.js';
 import {type K8Factory} from '../../../src/integration/kube/k8-factory.js';
 import {OperatingSystem} from '../../../src/business/utils/operating-system.js';
 import {PathEx} from '../../../src/business/utils/path-ex.js';
+import {type KindClient} from '../../../src/integration/kind/kind-client.js';
+
+interface BaseCommandInternal {
+  isLocalImageReference: (imageReference: string) => boolean;
+  kindLoadComponentImage: (componentImage: string, clusterContext: string) => Promise<void>;
+  remoteConfig: {getContexts: () => Context[]};
+  depManager: {getExecutable: (dependency: string) => Promise<string>};
+  kindBuilder: {
+    executable: (executable: string) => {
+      build: () => Promise<KindClient>;
+    };
+  };
+}
 
 class TestBaseCommand extends BaseCommand {
   public async close(): Promise<void> {}
@@ -273,12 +286,12 @@ describe('BaseCommand', (): void => {
       'hiero-explorer:my-build',
       'hiero-json-rpc-relay:local',
       'myimage:latest',
+      'localhost:5001/block-node-server:0.38.0',
     ];
 
     const registryCases: string[] = [
       'ghcr.io/hiero-ledger/block-node-server:0.36.0',
       'docker.io/library/redis:7',
-      'localhost:5000/myimage:tag',
       'registry.example.com/org/image:v1',
     ];
 
@@ -295,6 +308,53 @@ describe('BaseCommand', (): void => {
         expect(baseCmd.isLocalImageReference(reference)).to.be.false;
       });
     }
+  });
+
+  describe('kindLoadComponentImage', (): void => {
+    it('should load a local image into every Kind target context', async (): Promise<void> => {
+      const baseCommandInternal: BaseCommandInternal = baseCmd as unknown as BaseCommandInternal;
+      const loadDockerImageStub: SinonStub = sinon.stub().resolves();
+      const kindClient: KindClient = {loadDockerImage: loadDockerImageStub} as unknown as KindClient;
+
+      baseCommandInternal.remoteConfig = {
+        getContexts: (): Context[] => ['kind-first', 'kind-second'],
+      };
+      baseCommandInternal.depManager = {
+        getExecutable: async (dependency: string): Promise<string> => {
+          expect(dependency).to.equal('kind');
+          return 'kind';
+        },
+      };
+      baseCommandInternal.kindBuilder = {
+        executable: (executable: string): {build: () => Promise<KindClient>} => {
+          expect(executable).to.equal('kind');
+          return {build: async (): Promise<KindClient> => kindClient};
+        },
+      };
+
+      await baseCommandInternal.kindLoadComponentImage('block-node-server:0.38.0', 'kind-first');
+
+      expect(loadDockerImageStub).to.have.been.calledTwice;
+      expect(loadDockerImageStub).to.have.been.calledWith('block-node-server:0.38.0', sinon.match.has('name', 'first'));
+      expect(loadDockerImageStub).to.have.been.calledWith(
+        'block-node-server:0.38.0',
+        sinon.match.has('name', 'second'),
+      );
+    });
+
+    it('should explain how to make an image available to a non-Kind target context', async (): Promise<void> => {
+      const baseCommandInternal: BaseCommandInternal = baseCmd as unknown as BaseCommandInternal;
+      baseCommandInternal.remoteConfig = {
+        getContexts: (): Context[] => ['remote-cluster'],
+      };
+
+      await expect(
+        baseCommandInternal.kindLoadComponentImage('block-node-server:0.38.0', 'kind-first'),
+      ).to.be.rejectedWith(
+        "Component image 'block-node-server:0.38.0' requires Kind image loading, but target cluster context(s) " +
+          "'remote-cluster' are not Kind clusters. Push the image to a registry reachable from every target cluster",
+      );
+    });
   });
 
   describe('kindClusterNameFromContext', (): void => {

--- a/test/unit/commands/base.test.ts
+++ b/test/unit/commands/base.test.ts
@@ -352,7 +352,8 @@ describe('BaseCommand', (): void => {
         baseCommandInternal.kindLoadComponentImage('block-node-server:0.38.0', 'kind-first'),
       ).to.be.rejectedWith(
         "Component image 'block-node-server:0.38.0' requires Kind image loading, but target cluster context(s) " +
-          "'remote-cluster' are not Kind clusters. Push the image to a registry reachable from every target cluster",
+          "'remote-cluster' are not Kind clusters. Push the image to a registry reachable from every target " +
+          'cluster and pass that registry image reference to --component-image.',
       );
     });
   });

--- a/test/unit/commands/block-node.test.ts
+++ b/test/unit/commands/block-node.test.ts
@@ -71,6 +71,7 @@ interface BlockNodeCommandInternal {
   ) => Promise<{id: number; releaseName: string; isChartInstalled: boolean; isLegacyChartInstalled: boolean}>;
   prepareValuesArgForBlockNode: (configuration: Record<string, unknown>) => Promise<HelmChartValues>;
   getLivenessCheckPortNumber: (chartVersion: string, componentImage?: string) => number;
+  isLocalImageAvailableInDocker: (componentImage: string) => boolean;
 }
 
 describe('BlockNodeCommand unit tests', (): void => {
@@ -259,6 +260,35 @@ describe('BlockNodeCommand unit tests', (): void => {
     expect(valueArguments).to.not.include(
       'blockNode.config.ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_BASE_URL=http://mirror-2-restjava:80',
     );
+  });
+
+  it('should configure a Kind-attached local registry image with a Never pull policy', async (): Promise<void> => {
+    const blockNodeCommandInternal: BlockNodeCommandInternal = blockNodeCommand as unknown as BlockNodeCommandInternal;
+    blockNodeCommandInternal.remoteConfig = {
+      getConsensusNodes: (): Array<{name: string}> => [],
+      configuration: {
+        clusters: [],
+        state: {
+          tssEnabled: false,
+          blockNodes: [],
+        },
+      },
+    };
+    sinon.stub(blockNodeCommandInternal, 'isLocalImageAvailableInDocker').returns(true);
+
+    const chartValues: HelmChartValues = await blockNodeCommandInternal.prepareValuesArgForBlockNode({
+      blockNodeTssOverlay: false,
+      componentImage: 'localhost:5001/block-node-server:0.38.0',
+      valuesFile: undefined,
+      releaseName: 'block-node-1',
+      namespace: NamespaceName.of('solo-ns'),
+    });
+
+    const valueArguments: string[] = chartValues.toArguments();
+    expect(valueArguments).to.include('image.registry=localhost:5001');
+    expect(valueArguments).to.include('image.repository=block-node-server');
+    expect(valueArguments).to.include('image.tag=0.38.0');
+    expect(valueArguments).to.include('image.pullPolicy=Never');
   });
 
   it('should use the block node release name as the Helm instance label selector', (): void => {

--- a/test/unit/commands/block-node.test.ts
+++ b/test/unit/commands/block-node.test.ts
@@ -135,6 +135,22 @@ describe('BlockNodeCommand unit tests', (): void => {
     expect(blockNodeCommandInternal.getLivenessCheckPortNumber('0.39.0')).to.equal(constants.BLOCK_NODE_HEALTH_PORT);
   });
 
+  it('should use a semver tag on a Kind-attached local registry image to pick the readiness port', (): void => {
+    const blockNodeCommandInternal: BlockNodeCommandInternal = blockNodeCommand as unknown as BlockNodeCommandInternal;
+
+    expect(
+      blockNodeCommandInternal.getLivenessCheckPortNumber('0.38.0', 'localhost:5001/block-node-server:0.40.0'),
+    ).to.equal(constants.BLOCK_NODE_HEALTH_PORT);
+  });
+
+  it('should ignore a tagless local registry ref (implicit latest) when picking the readiness port', (): void => {
+    const blockNodeCommandInternal: BlockNodeCommandInternal = blockNodeCommand as unknown as BlockNodeCommandInternal;
+
+    expect(blockNodeCommandInternal.getLivenessCheckPortNumber('0.38.0', 'localhost:5001/block-node-server')).to.equal(
+      constants.BLOCK_NODE_PORT,
+    );
+  });
+
   it('should configure the RSA mirror bootstrap source for block-stream consensus versions', async (): Promise<void> => {
     const blockNodeCommandInternal: BlockNodeCommandInternal = blockNodeCommand as unknown as BlockNodeCommandInternal;
     blockNodeCommandInternal.remoteConfig = {

--- a/test/unit/commands/block-node.test.ts
+++ b/test/unit/commands/block-node.test.ts
@@ -291,6 +291,35 @@ describe('BlockNodeCommand unit tests', (): void => {
     expect(valueArguments).to.include('image.pullPolicy=Never');
   });
 
+  it('should preserve tagless local registry refs with implicit latest tags', async (): Promise<void> => {
+    const blockNodeCommandInternal: BlockNodeCommandInternal = blockNodeCommand as unknown as BlockNodeCommandInternal;
+    blockNodeCommandInternal.remoteConfig = {
+      getConsensusNodes: (): Array<{name: string}> => [],
+      configuration: {
+        clusters: [],
+        state: {
+          tssEnabled: false,
+          blockNodes: [],
+        },
+      },
+    };
+    sinon.stub(blockNodeCommandInternal, 'isLocalImageAvailableInDocker').returns(true);
+
+    const chartValues: HelmChartValues = await blockNodeCommandInternal.prepareValuesArgForBlockNode({
+      blockNodeTssOverlay: false,
+      componentImage: 'localhost:5001/block-node-server',
+      valuesFile: undefined,
+      releaseName: 'block-node-1',
+      namespace: NamespaceName.of('solo-ns'),
+    });
+
+    const valueArguments: string[] = chartValues.toArguments();
+    expect(valueArguments).to.include('image.registry=localhost:5001');
+    expect(valueArguments).to.include('image.repository=block-node-server');
+    expect(valueArguments).to.include('image.tag=latest');
+    expect(valueArguments).to.include('image.pullPolicy=Never');
+  });
+
   it('should use the block node release name as the Helm instance label selector', (): void => {
     const labels: string[] = Templates.renderBlockNodeLabels(1);
 

--- a/test/unit/commands/explorer.test.ts
+++ b/test/unit/commands/explorer.test.ts
@@ -61,6 +61,8 @@ type ExplorerHarness = {
 
 type ExplorerCommandInternal = {
   prepareHederaExplorerChartValues: (config: Record<string, unknown>) => Promise<HelmChartValues>;
+  isLocalImageAvailableInDocker: (componentImage: string) => boolean;
+  kindLoadComponentImage: (componentImage: string, clusterContext: string) => Promise<void>;
 };
 
 const createNamespace: (namespaceName: string) => NamespaceName = (namespaceName: string): NamespaceName =>
@@ -524,6 +526,29 @@ describe('ExplorerCommand unit tests', (): void => {
 
     expect(stopPortForwardsStub).to.not.have.been.called;
     expect(managePortForwardsStub).to.not.have.been.called;
+  });
+
+  it('loads an available local Explorer image before chart deployment', async (): Promise<void> => {
+    const harness: ExplorerHarness = await createHarness(sandbox);
+    const deployConfig: Record<string, unknown> = {
+      ...createDeployConfig('explorer-local-image'),
+      componentImage: 'localhost:5001/hiero-explorer:1.2.3',
+    };
+    const explorerCommandInternal: ExplorerCommandInternal = harness.command as unknown as ExplorerCommandInternal;
+    const kindLoadComponentImageStub: SinonStub = sandbox
+      .stub(explorerCommandInternal, 'kindLoadComponentImage')
+      .resolves();
+    sandbox.stub(explorerCommandInternal, 'isLocalImageAvailableInDocker').returns(true);
+    const chartUpgradeStub: SinonStub = sandbox.stub(harness.chartManager, 'upgrade').resolves();
+
+    (harness.configManager.getConfig as SinonStub).returns(deployConfig);
+    await harness.command.add({[flags.deployment.name]: 'deployment-1'} as never);
+
+    expect(kindLoadComponentImageStub).to.have.been.calledOnceWithExactly(
+      'localhost:5001/hiero-explorer:1.2.3',
+      'cluster-context-1',
+    );
+    expect(kindLoadComponentImageStub).to.have.been.calledBefore(chartUpgradeStub.getCall(2));
   });
 
   it('upgrade builds the expected task flow and upgrades explorer state without reinstalling cert-manager', async (): Promise<void> => {

--- a/test/unit/commands/relay.test.ts
+++ b/test/unit/commands/relay.test.ts
@@ -144,6 +144,25 @@ describe('RelayCommand unit tests', (): void => {
     expect(valueArguments).to.include('ws.image.tag=7');
   });
 
+  it('should use a Never pull policy for an available Kind-attached local registry image', async (): Promise<void> => {
+    const relayCommandInternal: RelayCommandInternal = relayCommand as unknown as RelayCommandInternal;
+    sinon.restore();
+    sinon.stub(relayCommandInternal, 'isLocalImageAvailableInDocker').returns(true);
+    sinon.stub(relayCommandInternal, 'prepareNetworkJsonString').resolves('{"127.0.0.1:50211":"0.0.3"}');
+
+    const valueArguments: string[] = await prepareRelayValueArguments(
+      relayCommandInternal,
+      createRelayConfig({
+        [flags.componentImage.constName]: 'localhost:5001/hiero-json-rpc-relay:0.61.0',
+      }),
+    );
+
+    expect(valueArguments).to.include('relay.image.registry=localhost:5001');
+    expect(valueArguments).to.include('relay.image.repository=hiero-json-rpc-relay');
+    expect(valueArguments).to.include('relay.image.pullPolicy=Never');
+    expect(valueArguments).to.include('ws.image.pullPolicy=Never');
+  });
+
   it('should set relay and ws service type to LoadBalancer when load balancer is enabled', async (): Promise<void> => {
     const relayCommandInternal: RelayCommandInternal = relayCommand as unknown as RelayCommandInternal;
 


### PR DESCRIPTION
## Description

This pull request changes the following:

* Loads locally available component images into every targeted Kind cluster before deployment.
* Supports images served by a Kind-attached local registry (`localhost:<port>/...`) with `pullPolicy: Never`.
* Ensures Explorer uses the shared image-loading path and fails early with actionable guidance when a target context is not a Kind cluster.
* Documents the supported component-image availability paths in CLI help.

### Related Issues

* Related to #5939 (docs.hedera.com page update tracked separately; not closed by this PR)
* Related to #5940
* Related to #5938

### Pull request (PR) checklist

* [x] This PR added tests (unit, integration, and/or end-to-end)
* [x] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [x] Any technical debt has been documented as a separate issue and linked to this PR
* [x] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the commit message guidelines below have been followed

### Testing

* [x] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [ ] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* Ran the focused unit test suite for flags, BaseCommand, Block Node, Mirror Node, Relay, and Explorer.
* Ran `task format`, `npx tsc --noEmit --pretty false`, and targeted ESLint checks.

The following was not tested:

* Integration/end-to-end testing and deployment to a real multi-cluster Kind environment were not run; the behavior is covered by focused unit tests.

<details>
<summary>
Commit message guidelines
</summary>

We use Conventional Commits to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type. NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix | Description | Semantic Version Update | Captured in Release Notes |
| --- | --- | --- | --- |
| feat: | a new feature | MINOR | Yes |
| fix: | a bug fix | PATCH | Yes |
| perf: | performance | PATCH | Yes |
| refactor: | code change that is not feature or fix | none | No |
| test: | adding missing tests | none | No |
| docs: | changes to documentation | none | Yes |
| build: | changes to build process | none | No |
| ci: | changes to CI configuration | none | No |
| style: | formatting, missing semi-colons, etc | none | No |
| chore: | updating grunt tasks etc; no production code change | none | No |

</details>