### PR TITLE
fix(ci): clear all high-severity template injection findings

### DIFF
--- a/.github/actions/solo-image-cache/action.yaml
+++ b/.github/actions/solo-image-cache/action.yaml
@@ -47,19 +47,23 @@ runs:
     - name: Build Cache Metadata
       id: cache-metadata
       shell: bash
+      env:
+        OPERATION: ${{ inputs.operation }}
+        KEY_PREFIX: ${{ inputs.key-prefix }}
+        KEY_SUFFIX: ${{ inputs.key-suffix }}
       run: |
         set -euo pipefail
 
-        case "${{ inputs.operation }}" in
+        case "${OPERATION}" in
           restore|save) ;;
-          *) echo "Unsupported operation: ${{ inputs.operation }} (expected 'restore' or 'save')" >&2; exit 1 ;;
+          *) echo "Unsupported operation: ${OPERATION} (expected 'restore' or 'save')" >&2; exit 1 ;;
         esac
 
-        primary_key="${{ inputs.key-prefix }}-${RUNNER_OS}-${RUNNER_ARCH}-${{ inputs.key-suffix }}"
+        primary_key="${KEY_PREFIX}-${RUNNER_OS}-${RUNNER_ARCH}-${KEY_SUFFIX}"
         {
           echo "primary-key=${primary_key}"
           echo "restore-keys<<RESTORE_KEYS"
-          echo "${{ inputs.key-prefix }}-${RUNNER_OS}-${RUNNER_ARCH}-"
+          echo "${KEY_PREFIX}-${RUNNER_OS}-${RUNNER_ARCH}-"
           echo "RESTORE_KEYS"
         } >> "${GITHUB_OUTPUT}"
 
@@ -77,10 +81,12 @@ runs:
       id: inspect
       if: ${{ inputs.operation == 'save' }}
       shell: bash
+      env:
+        CACHE_PATH: ${{ inputs.cache-path }}
       run: |
         set -euo pipefail
 
-        image_cache_dir="${{ inputs.cache-path }}"
+        image_cache_dir="${CACHE_PATH}"
         if [[ -d "${image_cache_dir}" ]] && find "${image_cache_dir}" -type f -name '*.tar' -print -quit | grep -q .; then
           echo "has-files=true" >> "${GITHUB_OUTPUT}"
         else

--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -573,13 +573,13 @@ jobs:
           # Publish those to the channel tag for their line instead, matching the
           # release-<major>.<minor>.x tags already on the registry for earlier lines.
           # The default branch keeps "latest".
-          if [[ "${{ github.ref_name }}" =~ ^release/([0-9]+)\.([0-9]+)$ ]]; then
+          if [[ "${GITHUB_REF_NAME}" =~ ^release/([0-9]+)\.([0-9]+)$ ]]; then
             NPM_DIST_TAG="release-${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.x"
           else
             NPM_DIST_TAG="latest"
           fi
 
-          echo "Publishing from '${{ github.ref_name }}' to dist-tag '${NPM_DIST_TAG}'"
+          echo "Publishing from '${GITHUB_REF_NAME}' to dist-tag '${NPM_DIST_TAG}'"
           echo "npm-dist-tag=${NPM_DIST_TAG}" >> "${GITHUB_OUTPUT}"
 
       - name: Download Hiero-Ledger NPM Package Artifact
@@ -665,16 +665,20 @@ jobs:
 
       - name: Set Inputs
         id: set-inputs
+        env:
+          # github.ref is read below through the GITHUB_REF variable the runner already provides.
+          DRY_RUN_ENABLED_INPUT: ${{ inputs.dry-run-enabled }}
+          RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
         run: |
           set -eo pipefail
-          if [[ "${{ inputs.dry-run-enabled }}" == "true" ]]; then
-            echo "Dry run enabled, setting ref to `github.ref` since tag won't exist."
-            echo "tag_ref=${{ github.ref }}" >> $GITHUB_OUTPUT
-            echo "tag_ref=${{ github.ref }}"
+          if [[ "${DRY_RUN_ENABLED_INPUT}" == "true" ]]; then
+            echo 'Dry run enabled, setting ref to `github.ref` since tag will not exist.'
+            echo "tag_ref=${GITHUB_REF}" >> $GITHUB_OUTPUT
+            echo "tag_ref=${GITHUB_REF}"
           else
-            echo "Dry run not enabled, setting ref to 'refs/tags/v${{ needs.prepare-release.outputs.version }}'."
-            echo "tag_ref=refs/tags/v${{ needs.prepare-release.outputs.version }}" >> $GITHUB_OUTPUT
-            echo "tag_ref=refs/tags/v${{ needs.prepare-release.outputs.version }}"
+            echo "Dry run not enabled, setting ref to 'refs/tags/v${RELEASE_VERSION}'."
+            echo "tag_ref=refs/tags/v${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+            echo "tag_ref=refs/tags/v${RELEASE_VERSION}"
           fi
 
   # Do a Hugo build for the docs site for the release branch

--- a/.github/workflows/flow-examples-test.yaml
+++ b/.github/workflows/flow-examples-test.yaml
@@ -134,13 +134,18 @@ jobs:
       - name: Generate Matrix
         id: set_matrix
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
+        env:
+          # github.event_name and github.ref_name are read through the GITHUB_EVENT_NAME and
+          # GITHUB_REF_NAME variables the runner already provides.
+          EXAMPLE_DIRECTORY_INPUT: ${{ inputs.example-directory }}
+          USE_REDUCED_TEST_MATRIX_INPUT: ${{ inputs.use-reduced-test-matrix }}
         run: |
-          EXAMPLE_DIR="${{ inputs.example-directory }}"
+          EXAMPLE_DIR="${EXAMPLE_DIRECTORY_INPUT}"
           STANDARD_MATRIX_FILE=".github/workflows/support/examples-test-matrix.json"
           REDUCED_MATRIX_FILE=".github/workflows/support/examples-reduced-matrix.json"
-          EVENT_NAME="${{ github.event_name }}"
-          REF_NAME="${{ github.ref_name }}"
-          USE_REDUCED_TEST_MATRIX="${{ inputs.use-reduced-test-matrix }}"
+          EVENT_NAME="${GITHUB_EVENT_NAME}"
+          REF_NAME="${GITHUB_REF_NAME}"
+          USE_REDUCED_TEST_MATRIX="${USE_REDUCED_TEST_MATRIX_INPUT}"
 
           if [[ "${REF_NAME}" == trunk-merge/* || "${EVENT_NAME}" == "push" || "${EVENT_NAME}" == "pull_request" || "${USE_REDUCED_TEST_MATRIX}" == "true" ]]; then
             echo "Using reduced matrix (${EVENT_NAME}:${REF_NAME}, use-reduced-test-matrix=${USE_REDUCED_TEST_MATRIX})."

--- a/.github/workflows/flow-gcs-test.yaml
+++ b/.github/workflows/flow-gcs-test.yaml
@@ -59,8 +59,10 @@ jobs:
       - name: Check if job should be skipped
         id: check
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
+        env:
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
         run: |
-          if [[ "${{ github.actor }}" == "dependabot[bot]" || "${{ github.event.pull_request.head.repo.fork }}" == "true" ]]; then
+          if [[ "${GITHUB_ACTOR}" == "dependabot[bot]" || "${IS_FORK}" == "true" ]]; then
             echo "run=false" >> $GITHUB_OUTPUT
           else
             echo "run=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/flow-hugo-publish.yaml
+++ b/.github/workflows/flow-hugo-publish.yaml
@@ -64,19 +64,25 @@ jobs:
 
       - name: Set Inputs
         id: set-inputs
+        env:
+          # github.ref, github.ref_name and github.event_name are read below through the
+          # GITHUB_REF, GITHUB_REF_NAME and GITHUB_EVENT_NAME variables the runner already
+          # provides, so only the workflow inputs need binding here.
+          DOCS_BUILD_LABEL_INPUT: ${{ inputs.docs-build-label }}
+          DRY_RUN_ENABLED_INPUT: ${{ inputs.dry-run-enabled }}
         run: |
           set -eo pipefail
           echo "::group::Set Inputs"
           echo "Inputs:"
-          echo "docs-build-label=${{ inputs.docs-build-label }}"
-          echo "dry-run-enabled=${{ inputs.dry-run-enabled }}"
-          echo "github.ref=${{ github.ref }}"
-          echo "github.ref_name=${{ github.ref_name }}"
-          echo "github.event_name=${{ github.event_name }}"
+          echo "docs-build-label=${DOCS_BUILD_LABEL_INPUT}"
+          echo "dry-run-enabled=${DRY_RUN_ENABLED_INPUT}"
+          echo "github.ref=${GITHUB_REF}"
+          echo "github.ref_name=${GITHUB_REF_NAME}"
+          echo "github.event_name=${GITHUB_EVENT_NAME}"
           echo "::endgroup::"
-          
+
           echo "::group::Default Output Values"
-          DOCS_BUILD_LABEL="${{ inputs.docs-build-label }}"
+          DOCS_BUILD_LABEL="${DOCS_BUILD_LABEL_INPUT}"
           echo "defaulting: DOCS_BUILD_LABEL=${DOCS_BUILD_LABEL}"
           MAIN_REF="main"
           echo "defaulting: MAIN_REF=${MAIN_REF}"
@@ -92,8 +98,8 @@ jobs:
           fi
          
           # Only download artifacts and attach docs to a release if this is a workflow_dispatch running with a version tag
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            if [[ "${{ github.ref_name }}" != "main" || "${{ inputs.docs-build-label }}" != "main" ]]; then
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            if [[ "${GITHUB_REF_NAME}" != "main" || "${DOCS_BUILD_LABEL_INPUT}" != "main" ]]; then
               echo "Running with a version tag and via workflow_dispatch, this is a versioned release."
               VERSIONED_RELEASE=true
               echo "setting: VERSIONED_RELEASE=${VERSIONED_RELEASE}"
@@ -110,9 +116,9 @@ jobs:
           
           # If the github.ref_name is `main`, then we will checkout github.ref, else checkout `main` for the 
           #  docs-build-label = `main`
-          if [[ "${{ github.ref_name }}" == "main" ]]; then
+          if [[ "${GITHUB_REF_NAME}" == "main" ]]; then
             echo "Running on 'main' branch, setting MAIN_REF to github.ref."
-            MAIN_REF="${{ github.ref }}"
+            MAIN_REF="${GITHUB_REF}"
             echo "setting: MAIN_REF=${MAIN_REF}"
           else
             echo "Running on a branch or tag other than 'main', setting MAIN_REF to 'main'."

--- a/.github/workflows/flow-one-shot-timing.yaml
+++ b/.github/workflows/flow-one-shot-timing.yaml
@@ -183,6 +183,12 @@ jobs:
 
       - name: Resolve Versions
         id: versions
+        env:
+          CN_VERSION_INPUT: ${{ inputs.consensus-node-version }}
+          BN_VERSION_INPUT: ${{ inputs.block-node-version }}
+          MN_VERSION_INPUT: ${{ inputs.mirror-node-version }}
+          RELAY_VERSION_INPUT: ${{ inputs.relay-version }}
+          EXPLORER_VERSION_INPUT: ${{ inputs.explorer-version }}
         run: |
           # Read defaults from version.ts and allow input overrides
           source .github/workflows/script/helper.sh
@@ -192,11 +198,11 @@ jobs:
           DEFAULT_RELAY=$(extract_version HEDERA_JSON_RPC_RELAY_VERSION version.ts)
           DEFAULT_EXPLORER=$(extract_version EXPLORER_VERSION version.ts)
 
-          CN_VERSION="${{ inputs.consensus-node-version }}"
-          BN_VERSION="${{ inputs.block-node-version }}"
-          MN_VERSION="${{ inputs.mirror-node-version }}"
-          RELAY_VERSION="${{ inputs.relay-version }}"
-          EXPLORER_VERSION="${{ inputs.explorer-version }}"
+          CN_VERSION="${CN_VERSION_INPUT}"
+          BN_VERSION="${BN_VERSION_INPUT}"
+          MN_VERSION="${MN_VERSION_INPUT}"
+          RELAY_VERSION="${RELAY_VERSION_INPUT}"
+          EXPLORER_VERSION="${EXPLORER_VERSION_INPUT}"
 
           echo "cn-version=${CN_VERSION:-$DEFAULT_CN}" >> "$GITHUB_OUTPUT"
           echo "bn-version=${BN_VERSION:-$DEFAULT_BN}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/flow-performance-test.yaml
+++ b/.github/workflows/flow-performance-test.yaml
@@ -147,12 +147,15 @@ jobs:
         id: run-e2e-tests
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          # github.event_name is read through the GITHUB_EVENT_NAME variable the runner provides.
+          CN_EDGE_VERSION_INPUT: ${{ inputs.cn-edge-version || '' }}
+          USE_EDGE_INPUT: ${{ inputs.use-edge }}
         run: |
           set -euo pipefail
           export PATH=~/.solo/bin:${PATH}
           echo SOLO_TEST_CLUSTER=solo-e2e > .env
           echo ONE_SHOT_WITH_BLOCK_NODE=true >> .env
-          CN_EDGE_VERSION="${{ inputs.cn-edge-version || '' }}"
+          CN_EDGE_VERSION="${CN_EDGE_VERSION_INPUT}"
           if [[ -n "${CN_EDGE_VERSION}" ]]; then
             echo "Using consensus node edge version: ${CN_EDGE_VERSION}"
             echo CONSENSUS_NODE_EDGE_VERSION="${CN_EDGE_VERSION}" >> .env
@@ -161,7 +164,7 @@ jobs:
             echo "No consensus node edge version specified, using default from version.ts"
           fi
           USE_EDGE="false"
-          if [[ "${{ github.event_name }}" != "pull_request" && "${{ inputs.use-edge }}" == "true" ]]; then
+          if [[ "${GITHUB_EVENT_NAME}" != "pull_request" && "${USE_EDGE_INPUT}" == "true" ]]; then
             USE_EDGE="true"
           fi
           if [[ "${USE_EDGE}" == "true" ]]; then

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -353,14 +353,16 @@ jobs:
         if: ${{ runner.os == 'linux' && inputs.local-java-build && !cancelled() && !failure() }}
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
         shell: bash
+        env:
+          CONSENSUS_NODE_VERSION_INPUT: ${{ inputs.consensus-node-version }}
         run: |
           set -euo pipefail
           source .github/workflows/script/helper.sh
 
-          if [ -z "${{ inputs.consensus-node-version }}" ]; then
+          if [ -z "${CONSENSUS_NODE_VERSION_INPUT}" ]; then
             consensus_node_version="$(extract_version HEDERA_PLATFORM_VERSION version.ts)"
           else
-            consensus_node_version="${{ inputs.consensus-node-version }}"
+            consensus_node_version="${CONSENSUS_NODE_VERSION_INPUT}"
           fi
 
           normalized_version="$(echo "${consensus_node_version}" | sed -E 's/^v//; s/-.*$//')"
@@ -439,27 +441,33 @@ jobs:
         timeout-minutes: ${{ fromJSON(inputs.test-timeout-minutes) }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          CONSENSUS_NODE_VERSION_INPUT: ${{ inputs.consensus-node-version }}
+          LOCAL_JAVA_BUILD_INPUT: ${{ inputs.local-java-build }}
+          TEST_SCRIPT_INPUT: ${{ inputs.test-script }}
+          CLUSTER_NAME_INPUT: ${{ inputs.cluster-name }}
+          DUAL_CLUSTER_NODE_COUNT_INPUT: ${{ inputs.dual-cluster-node-count || 3 }}
+          CUSTOM_JOB_LABEL_INPUT: ${{ inputs.custom-job-label }}
         run: |
           export PATH=~/.solo/bin:${PATH}
           echo "PATH: $PATH"
           source .github/workflows/script/helper.sh
-          if [[ -z "${{ inputs.consensus-node-version }}" ]]; then
-              if [[ "${{ inputs.local-java-build }}" != "true" ]]; then
+          if [[ -z "${CONSENSUS_NODE_VERSION_INPUT}" ]]; then
+              if [[ "${LOCAL_JAVA_BUILD_INPUT}" != "true" ]]; then
                   echo "No consensus node version provided, using default from version-test.ts"
               else
-                  if [[ "${{ inputs.test-script }}" == "test-e2e-block-node" ]]; then
+                  if [[ "${TEST_SCRIPT_INPUT}" == "test-e2e-block-node" ]]; then
                     echo "Use default from version.ts for block node test"
                   else
                     export CONSENSUS_NODE_VERSION=$(extract_version HEDERA_PLATFORM_VERSION version.ts)
                   fi
               fi
           else
-              export CONSENSUS_NODE_VERSION=${{ inputs.consensus-node-version }}
+              export CONSENSUS_NODE_VERSION="${CONSENSUS_NODE_VERSION_INPUT}"
           fi
-          echo SOLO_TEST_CLUSTER=${{ inputs.cluster-name }}-c1 > .env
-          echo SOLO_DUAL_CLUSTER_NODE_COUNT=${{ inputs.dual-cluster-node-count || 3 }} >> .env
+          echo "SOLO_TEST_CLUSTER=${CLUSTER_NAME_INPUT}-c1" > .env
+          echo "SOLO_DUAL_CLUSTER_NODE_COUNT=${DUAL_CLUSTER_NODE_COUNT_INPUT}" >> .env
 
-          if [[ "${{ inputs.custom-job-label }}" != "One Shot Single - using Podman" ]]; then
+          if [[ "${CUSTOM_JOB_LABEL_INPUT}" != "One Shot Single - using Podman" ]]; then
             # Verify cluster connectivity before running tests
             echo "Verifying cluster connectivity..."
             kubectl cluster-info || {
@@ -473,7 +481,7 @@ jobs:
             echo "FORCE_PODMAN=true" >> .env
           fi
 
-          if [[ "${{ inputs.custom-job-label }}" == "One Shot Single" ]]; then
+          if [[ "${CUSTOM_JOB_LABEL_INPUT}" == "One Shot Single" ]]; then
             echo "ENABLE_IMAGE_CACHE=true" >> .env
           fi
 
@@ -509,7 +517,7 @@ jobs:
           }
           trap cleanup SIGTERM SIGINT
 
-          TASK_COMMAND="${{ env.CG_EXEC }} task ${{ inputs.test-script }}"
+          TASK_COMMAND="${CG_EXEC} task ${TEST_SCRIPT_INPUT}"
           if command -v setsid >/dev/null 2>&1; then
             setsid bash -lc "${TASK_COMMAND}" &
           else
@@ -603,8 +611,9 @@ jobs:
         env:
           LOG_FILE: "${{ steps.log-metrics.outputs.solo_log_dir }}/log_file.md"
           JSON_INPUT: "${{ toJSON(fromJSON(steps.log-metrics.outputs.json_log)) }}"
+          CUSTOM_JOB_LABEL_INPUT: ${{ inputs.custom-job-label }}
         run: |
-          echo "## Log Metrics - ${{ inputs.custom-job-label }}" >> $LOG_FILE
+          echo "## Log Metrics - ${CUSTOM_JOB_LABEL_INPUT}" >> $LOG_FILE
           echo "" >> $LOG_FILE
 
           # Add ASCII resource chart if available
@@ -678,6 +687,8 @@ jobs:
       - name: Cleanup Kind Clusters
         if: ${{ always() }}
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
+        env:
+          CLUSTER_NAME_INPUT: ${{ inputs.cluster-name }}
         run: |
           export PATH=~/.solo/bin:${PATH}
 
@@ -696,8 +707,8 @@ jobs:
             } >&2
           }
 
-          for i in $(seq 1 ${{ env.SOLO_CLUSTER_DUALITY }}); do
-            timeout 60 kind delete cluster -n "${{ inputs.cluster-name }}-c${i}" || true
+          for i in $(seq 1 "${SOLO_CLUSTER_DUALITY}"); do
+            timeout 60 kind delete cluster -n "${CLUSTER_NAME_INPUT}-c${i}" || true
           done
           exit_code=0
           timeout 30 docker network rm -f kind || exit_code=$?


### PR DESCRIPTION
## Description

Tier 4 of the stacked zizmor remediation series. **Stacked on #5953** — base is `zizmor-cleanup-tier3`, so this diff shows only the tier 4 change. Merge #5953 first.

zizmor is run **offline** (v1.30.0, `--no-config`); this series adds no scanning job and no ignore/baseline configuration.

**This PR takes High-severity `template-injection` to zero.** After it, the only High-severity findings left in the repository are the three judgment-call rules deliberately deferred throughout this series.

| | before | after |
|---|---|---|
| `template-injection` | 146 | **104** |
| High-severity `template-injection` | 42 | **0** |
| High-severity, all rules | 47 | **9** |
| total findings | 168 | **126** |

The 9 remaining High findings are `cache-poisoning` (6), `dangerous-triggers` (2) and `unpinned-images` (1) — none of which is a mechanical fix. Every High finding that *can* be fixed mechanically is now fixed.

### What the risk is

GitHub substitutes `${{ … }}` into a `run:` block **as text**, before the shell ever sees it. A value containing quotes or shell metacharacters can terminate the surrounding quoting and execute arbitrary commands with the job's privileges. Routing the value through the step environment instead means the shell receives it as data.

### Approach

Where the expression is a `github.*` context the runner already publishes, the existing variable is used rather than inventing a new binding — `GITHUB_REF`, `GITHUB_REF_NAME`, `GITHUB_EVENT_NAME`, `GITHUB_ACTOR`. Workflow-level `env:` values (`CG_EXEC`, `SOLO_CLUSTER_DUALITY`) are likewise already shell variables. Only `inputs.*` and event-payload fields needed new `env:` entries. Comments record that split where a step mixes both, so the asymmetry does not read as an oversight.

Blocks were hoisted whole rather than line-by-line. That also cleared the Informational and Low findings sharing those blocks, which is why `template-injection` drops by 42 rather than by the 20 High findings alone.

### Files

* **`.github/actions/solo-image-cache/action.yaml`** (6, all High) — a composite action used by ~10 workflows, so the highest-leverage file here. Four inputs were interpolated into two `run:` blocks, including a `case` statement and the cache-key assignment. `${RUNNER_OS}`/`${RUNNER_ARCH}` were already shell references and are untouched, so **the computed cache key is byte-identical and existing caches still hit**.
* **`.github/workflows/flow-hugo-publish.yaml`** (8, all High) — all in the `Set Inputs` step.
* **`.github/workflows/zxc-e2e-test.yaml`** (11 High) — spread across four `run:` blocks, including the task-invocation line and the kind-cluster cleanup loop.
* **`.github/workflows/flow-one-shot-timing.yaml`** (5 High) — the five version-override inputs in `Resolve Versions`.
* **`.github/workflows/flow-deploy-release-artifact.yaml`** (4 High) — the npm dist-tag branch and the dry-run `Set Inputs` step.
* **`.github/workflows/flow-performance-test.yaml`** (1 High), **`flow-examples-test.yaml`** (2 High), **`flow-gcs-test.yaml`** (1 High) — the last stragglers, included so the High class reaches zero rather than one.

### Latent bug fixed along the way

`flow-deploy-release-artifact.yaml` had this in its dry-run branch:

```bash
echo "Dry run enabled, setting ref to `github.ref` since tag won't exist."
```

The backticks are inside a **double-quoted** string, so the shell treated them as command substitution and tried to execute `github.ref` as a command. The line is now single-quoted. Unrelated to the audit, but it was inside a line this PR was already rewriting.

### Equivalence

The rewrite is behaviour-preserving by construction: `GITHUB_REF`, `GITHUB_REF_NAME`, `GITHUB_EVENT_NAME` and `GITHUB_ACTOR` hold exactly the values of the contexts they replace, and every other substitution moves a value from one expansion point to another without changing it. Two previously unquoted expansions (`export CONSENSUS_NODE_VERSION=…`, the `.env` writes in `zxc-e2e-test.yaml`) are now quoted, which is strictly safer for values containing spaces.

### Remaining after this PR

126 findings: `template-injection` 104 (**0 High** — 97 Informational, 7 Low), `adhoc-packages` 13, `cache-poisoning` 6, `dangerous-triggers` 2, `unpinned-images` 1.

The character of the remaining work changes completely after this PR. What is left is either low-risk noise (`${{ inputs.* }}` / `${{ env.* }}` from trusted sources) or the three rules that need an owner decision rather than a cleanup commit:

* `dangerous-triggers` — `pull_request_target` and `workflow_run`; remediation means redesigning how those workflows obtain privileges, or consciously accepting the risk.
* `cache-poisoning` — Low confidence; needs per-workflow judgement about whether caching belongs in a publishing path.
* `unpinned-images` — `archlinux:latest`, where an inline comment already documents why a rolling distro is not pinned. Repo policy in `CLAUDE.md` forbids floating tags, so this needs an explicit ruling.

### Related Issues

* Related to #5931
* Stacked on #5953

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[x] This PR added no TODOs or commented out code
* \[x] This PR has no breaking changes
* \[x] Any technical debt has been documented as a separate issue and linked to this PR
* \[x] Any `package.json` changes have been explained to and approved by a repository manager
* \[x] All related issues have been linked to this PR
* \[x] All changes in this PR are included in the description
* \[x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

Two boxes are left unchecked. **No tests were added:** these are CI workflow definitions, which the repository's unit and E2E suites do not exercise; verification was static and is described below. **No documentation update:** the change relocates expression expansion within existing steps and has no user-facing surface.

### Testing

* \[x] These changes required manual testing that is documented below
* \[x] Anything not tested is documented

`task build` and `task format` were both run before pushing: **exit 0**, with `0 errors` from ESLint. The 645 warnings reported are pre-existing `no-explicit-any` noise in `test/`, untouched by this YAML-only change.

With zizmor 1.30.0:

* Scanned before and after with `zizmor --no-config .github/workflows .github/actions` and diffed by rule: `template-injection` **146 → 104**, total **168 → 126**. `cache-poisoning`, `adhoc-packages`, `unpinned-images` and `dangerous-triggers` are all unchanged, so the edits fixed exactly the intended class and introduced nothing new.
* Confirmed the headline claim directly: **0** findings remain with `ident == template-injection && severity == High`, and the 9 High findings left repo-wide belong only to `cache-poisoning`, `dangerous-triggers` and `unpinned-images`.
* Confirmed the two files from this PR's original scope report **0 remaining findings** of any severity.
* Parsed all 34 workflow and composite-action files with `js-yaml` — all valid.
* Re-grepped the composite action for `${{` and confirmed every remaining occurrence sits in a safe position (`env:`, `if:`, `with:`, output `value:`), none inside a `run:` block.

The following was not tested:

* No workflow was executed. `zxc-e2e-test.yaml` and `flow-performance-test.yaml` run on pull requests and so should get real coverage from this PR's own CI; `flow-examples-test.yaml` and `flow-gcs-test.yaml` partly so.
* `flow-hugo-publish.yaml`, `flow-deploy-release-artifact.yaml` and `flow-one-shot-timing.yaml` are release, publish and scheduled paths that this PR does not trigger. They will first run on merge to `main` or on a real release. The `Set Inputs` steps in the first two compute `versioned_release`, `main_ref` and `tag_ref`, which feed the rest of the publish flow and are worth a glance on the first `main` build.
* The `solo-image-cache` cache key is unchanged by construction; a cache **miss** on the first run would be the visible symptom if that reasoning were wrong.