### PR TITLE
chore(ci): record accepted zizmor risks inline

### DIFF
--- a/.github/workflows/flow-examples-test.yaml
+++ b/.github/workflows/flow-examples-test.yaml
@@ -194,6 +194,8 @@ jobs:
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
 
       - name: Setup Node
+        # zizmor: ignore[cache-poisoning]
+        # Accepted: this workflow does not publish release artifacts; retaining the cache avoids significant CI overhead.
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
         with:
@@ -221,6 +223,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Go
+        # zizmor: ignore[cache-poisoning]
+        # Accepted: this workflow does not publish release artifacts; retaining the cache avoids significant CI overhead.
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
         with:
@@ -260,6 +264,8 @@ jobs:
 
       - name: Setup Gradle
         if: ${{ runner.os == 'linux' && matrix.example.local-java-build && !cancelled() && !failure() }}
+        # zizmor: ignore[cache-poisoning]
+        # Accepted: this workflow does not publish release artifacts; retaining the cache avoids significant CI overhead.
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
         with:
@@ -304,6 +310,8 @@ jobs:
         # subsequent run sharing the same version.ts hash. Docker Hub is contacted at most
         # once per version bump — preventing anonymous rate-limit 429s.
         if: ${{ matrix.example.local-java-build }}
+        # zizmor: ignore[cache-poisoning]
+        # Accepted: this workflow does not publish release artifacts; retaining the cache avoids significant CI overhead.
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.solo/helm-chart-cache

--- a/.github/workflows/flow-install-validation.yaml
+++ b/.github/workflows/flow-install-validation.yaml
@@ -86,6 +86,8 @@ jobs:
           # Arch is rolling, so the tag cannot be pinned to a release; -Syu keeps the freshly
           # refreshed package index and the installed system from drifting apart.
           - distro: arch
+            # zizmor: ignore[unpinned-images]
+            # Accepted: archlinux:latest is an intentional exception to pinning policy because Arch is rolling release and we explicitly want to test the current rolling environment.
             image: archlinux:latest
             bootstrap: 'pacman -Syu --noconfirm --needed git curl sudo ca-certificates'
             use_setup_node: true

--- a/.github/workflows/flow-performance-test.yaml
+++ b/.github/workflows/flow-performance-test.yaml
@@ -96,6 +96,8 @@ jobs:
           sudo apt-get update && sudo apt-get install -y jq
 
       - name: Setup Node
+        # zizmor: ignore[cache-poisoning]
+        # Accepted: this workflow does not publish release artifacts; retaining the cache avoids significant CI overhead.
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
         with:

--- a/.github/workflows/flow-pull-request-formatting.yaml
+++ b/.github/workflows/flow-pull-request-formatting.yaml
@@ -17,6 +17,8 @@
 name: "PR Formatting"
 on:
   workflow_dispatch:
+  # zizmor: ignore[dangerous-triggers]
+  # Accepted: this workflow does not checkout or execute untrusted PR code, it only reads the PR title. pull_request_target is needed for statuses: write.
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/flow-trigger-solo-docs-update.yaml
+++ b/.github/workflows/flow-trigger-solo-docs-update.yaml
@@ -17,6 +17,8 @@
 name: "Solo Docs Update Trigger"
 
 on:
+  # zizmor: ignore[dangerous-triggers]
+  # Accepted: this workflow does not checkout PR code or download untrusted artifacts. It invokes gh workflow run against a trusted repo. Warning: do not add checkout/download here, GH_ACCESS_TOKEN would make it dangerous.
   workflow_run:
     workflows:
       - "Deploy Release Artifact"


### PR DESCRIPTION
#5957 

## Summary

This PR documents the remaining accepted `zizmor` security findings identified in #5957.

After reviewing the affected workflows, these findings were determined to be intentional and acceptable for the current repository setup. Instead of changing the workflow behavior, I added inline `# zizmor: ignore[...]` comments next to the affected configurations, along with short explanations for why each risk is acceptable.

### Changes

* Documented the 2 `dangerous-triggers` findings.
* Documented the 5 currently verifiable `cache-poisoning` findings.
* Documented the `unpinned-images` finding for `archlinux:latest`.
* Kept all existing triggers, caches, permissions, and workflow behavior unchanged.
* Kept `archlinux:latest` intentionally, since this workflow is meant to test the rolling Arch Linux environment.

### Note about CodeQL

The original issue references a CodeQL cache-poisoning finding in `flow-codeql-analysis.yaml`. However, that workflow does not exist in the current repository, and a search through the available Git history did not find it either.

Because there is no corresponding workflow or finding to document, no CodeQL ignore comment was added rather than introducing a change that does not apply to the current repository state.

### Validation

* Ran `git diff --check`.
* Reviewed the complete diff to ensure only the intended workflow comments were added.
* Confirmed that no workflow behavior, triggers, caches, permissions, or dependencies were changed.
* `zizmor` was not run locally because it is not installed in the current environment.

Overall, this PR keeps the CI behavior unchanged while making the accepted security decisions explicit and visible to future contributors.
