### PR TITLE
ci: cache verified Ubuntu WSL installer

### DIFF
--- a/.github/workflows/flow-standard-runner-one-shot-windows.yaml
+++ b/.github/workflows/flow-standard-runner-one-shot-windows.yaml
@@ -231,11 +231,12 @@ jobs:
           $available = '${{ steps.validate_ubuntu_wsl_installer.outputs.valid }}' -eq 'true' -or '${{ steps.seed_ubuntu_wsl_installer.outputs.valid }}' -eq 'true'
           Add-Content -Path $env:GITHUB_OUTPUT -Value "available=$($available.ToString().ToLowerInvariant())"
           if (-not $available) {
-            @"
-            ## Windows WSL integration skipped
-
-            The verified Ubuntu installer cache was unavailable or invalid. This PR did not attempt online Ubuntu acquisition. A `main` run will seed a missing cache; an invalid cache is deleted and replaced on `main`.
-            "@ | Add-Content -Path $env:GITHUB_STEP_SUMMARY
+            $summary = @(
+              '## Windows WSL integration skipped'
+              ''
+              'The verified Ubuntu installer cache was unavailable or invalid. This PR did not attempt online Ubuntu acquisition. A main run will seed a missing cache; an invalid cache is deleted and replaced on main.'
+            ) -join [Environment]::NewLine
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $summary
             Write-Warning 'Skipping WSL-dependent integration steps because the verified Ubuntu installer cache is unavailable.'
           }
 

--- a/.github/workflows/flow-standard-runner-one-shot-windows.yaml
+++ b/.github/workflows/flow-standard-runner-one-shot-windows.yaml
@@ -309,7 +309,6 @@ jobs:
         # Bypass both setup-wsl's downloader and WSL's online downloader when the validated
         # repository cache is available. Retry Setup WSL2 still runs afterwards to configure
         # the distribution's packages and the wsl-bash shell wrapper.
-        continue-on-error: true
         timeout-minutes: 3
         shell: pwsh
         run: |
@@ -341,9 +340,11 @@ jobs:
 
       - name: Retry Setup WSL2
         id: retry_setup_wsl2
-        if: ${{ !cancelled() && steps.setup_wsl2.outcome == 'failure' }}
-        # Run after the cached fallback even if it failed. Without !cancelled(), GitHub's
-        # implicit success() check skips this retry after the fallback fails.
+        if: ${{ !cancelled() && steps.setup_wsl2.outcome == 'failure' && steps.install_cached_ubuntu_wsl.outcome == 'success' }}
+        # Only retry after the cached fallback installed the distribution. This explicit
+        # condition bypasses GitHub's implicit success() check after the first setup failure.
+        # A failed cached fallback stops the job rather than allowing this action to download
+        # Ubuntu online again.
         uses: Vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7.0.0
         timeout-minutes: 5
         with:

--- a/.github/workflows/flow-standard-runner-one-shot-windows.yaml
+++ b/.github/workflows/flow-standard-runner-one-shot-windows.yaml
@@ -204,7 +204,7 @@ jobs:
           Write-Host "Seeded verified Ubuntu WSL installer cache: $installerPath"
 
       - name: Save seeded Ubuntu WSL installer cache
-        if: ${{ success() && steps.seed_ubuntu_wsl_installer.outputs.valid == 'true' }}
+        if: ${{ success() && github.ref == 'refs/heads/main' && steps.seed_ubuntu_wsl_installer.outputs.valid == 'true' }}
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ runner.tool_cache }}\Ubuntu\${{ env.WSL_UBUNTU_VERSION }}\x64

--- a/.github/workflows/flow-standard-runner-one-shot-windows.yaml
+++ b/.github/workflows/flow-standard-runner-one-shot-windows.yaml
@@ -45,6 +45,9 @@ env:
   DOCKER_HOST: tcp://localhost:2375
   ACTIONS_STEP_DEBUG: 'true'
   ACTIONS_RUNNER_DEBUG: 'true'
+  WSL_UBUNTU_VERSION: '24.4.4'
+  WSL_UBUNTU_INSTALLER_FILE: 'ubuntu-24.04.4-wsl-amd64.wsl'
+  WSL_UBUNTU_INSTALLER_SHA256: '9b2f7730dc68227dd04a9f3e5eab86ad85caf556b8606ad94f1f29ff5c4fd3f5'
 
 jobs:
   standard-runner-one-shot-windows:
@@ -101,7 +104,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
 
-      - name: Setup Node.js 22
+      - name: Setup Node.js 24
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
         with:
@@ -120,36 +123,63 @@ jobs:
         run: |
           task build:compile
 
-      - name: Validate Ubuntu WSL cache
+      - name: Restore verified Ubuntu WSL installer cache
+        id: restore_ubuntu_wsl_installer
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ runner.tool_cache }}\Ubuntu\${{ env.WSL_UBUNTU_VERSION }}\x64
+          key: solo-wsl-installer-${{ runner.os }}-${{ runner.arch }}-${{ env.WSL_UBUNTU_VERSION }}-${{ env.WSL_UBUNTU_INSTALLER_SHA256 }}
+
+      - name: Validate restored Ubuntu WSL installer cache
+        id: validate_ubuntu_wsl_installer
         shell: pwsh
         timeout-minutes: 1
         run: |
-          $cacheDirectory = Join-Path $env:RUNNER_TOOL_CACHE 'Ubuntu\24.4.4\x64'
-          $installerPath = Join-Path $cacheDirectory 'ubuntu-24.04.4-wsl-amd64.wsl'
+          $cacheDirectory = Join-Path $env:RUNNER_TOOL_CACHE "Ubuntu\$env:WSL_UBUNTU_VERSION\x64"
+          $installerPath = Join-Path $cacheDirectory $env:WSL_UBUNTU_INSTALLER_FILE
           $completeMarker = Join-Path $cacheDirectory '.complete'
-          $valid = (
-            (Test-Path -LiteralPath $installerPath) -and
-            (Test-Path -LiteralPath $completeMarker) -and
-            ((Get-Item -LiteralPath $installerPath).Length -gt 100MB)
-          )
+          $cacheHit = '${{ steps.restore_ubuntu_wsl_installer.outputs.cache-hit }}'
+          $valid = $false
+          $validationResult = 'cache miss'
 
-          if ($valid) {
-            Write-Host "Ubuntu WSL cache is valid: $installerPath"
+          if ((Test-Path -LiteralPath $installerPath) -and (Test-Path -LiteralPath $completeMarker)) {
+            $actualHash = (Get-FileHash -LiteralPath $installerPath -Algorithm SHA256).Hash.ToLowerInvariant()
+            if ($actualHash -eq $env:WSL_UBUNTU_INSTALLER_SHA256) {
+              $valid = $true
+              $validationResult = 'valid SHA-256'
+              Write-Host "Verified Ubuntu WSL installer cache: $installerPath"
+            } else {
+              $validationResult = "invalid SHA-256: $actualHash"
+            }
           } elseif (Test-Path -LiteralPath $cacheDirectory) {
-            Write-Warning "Removing incomplete Ubuntu WSL cache: $cacheDirectory"
-            Remove-Item -LiteralPath $cacheDirectory -Recurse -Force
-          } else {
-            Write-Host "Ubuntu WSL cache is not present; setup-wsl will download it."
+            $validationResult = 'installer or completion marker is missing'
           }
+
+          if (-not $valid -and (Test-Path -LiteralPath $cacheDirectory)) {
+            Write-Warning "Discarding invalid Ubuntu WSL installer cache: $validationResult"
+            Remove-Item -LiteralPath $cacheDirectory -Recurse -Force
+          }
+
+          if (-not $valid -and $cacheHit -eq 'true') {
+            throw "Restored Ubuntu WSL installer cache failed validation: $validationResult"
+          }
+
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "valid=$($valid.ToString().ToLowerInvariant())"
+          @"
+          ## Ubuntu WSL installer cache
+
+          - GitHub Actions cache hit: $cacheHit
+          - Validation: $validationResult
+          "@ | Add-Content -Path $env:GITHUB_STEP_SUMMARY
 
       - name: Setup WSL2
         id: setup_wsl2
         # Kind requires Linux containers. GitHub's windows-latest runner has Docker in Windows
         # container mode with no Docker Desktop to switch it. WSL2 + Docker inside it replicates
         # what Docker Desktop does for Windows users, exposing a Linux daemon via TCP.
-        # use-cache is enabled so the distribution installer is cached across runs via
-        # actions/cache instead of re-downloaded every time — this workflow was intermittently
-        # timing out on the fresh download from a shared runner's network.
+        # The action cache restores the installer across fresh GitHub-hosted runner VMs.
+        # The verified repository cache above restores the same installer before this action
+        # touches its own tool-cache lookup, avoiding an Ubuntu download on the common path.
         uses: Vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7.0.0
         continue-on-error: true
         # A healthy setup completes in about one minute. Bound a stalled action so the
@@ -158,8 +188,7 @@ jobs:
         with:
           distribution: Ubuntu-24.04
           wsl-version: 2
-          # The setup-wsl cache has hung on hosted runners while resolving this distribution.
-          use-cache: false
+          use-cache: true
           set-as-default: true
           additional-packages: |
             apt-transport-https
@@ -257,9 +286,51 @@ jobs:
           }
           exit 0
 
-      - name: Install Ubuntu WSL distribution fallback
-        if: ${{ steps.setup_wsl2.outcome == 'failure' }}
-        # Bypass setup-wsl's downloadTool path when the hosted tool cache is incomplete.
+      - name: Install cached Ubuntu WSL distribution fallback
+        id: install_cached_ubuntu_wsl
+        if: ${{ !cancelled() && steps.setup_wsl2.outcome == 'failure' }}
+        # Bypass both setup-wsl's downloader and WSL's online downloader when the validated
+        # repository cache is available. Retry Setup WSL2 still runs afterwards to configure
+        # the distribution's packages and the wsl-bash shell wrapper.
+        continue-on-error: true
+        timeout-minutes: 3
+        shell: pwsh
+        run: |
+          $distributionName = 'Ubuntu-24.04'
+          $cacheDirectory = Join-Path $env:RUNNER_TOOL_CACHE "Ubuntu\$env:WSL_UBUNTU_VERSION\x64"
+          $installerPath = Join-Path $cacheDirectory $env:WSL_UBUNTU_INSTALLER_FILE
+          $completeMarker = Join-Path $cacheDirectory '.complete'
+
+          if (-not (Test-Path -LiteralPath $installerPath) -or -not (Test-Path -LiteralPath $completeMarker)) {
+            Write-Host 'Validated Ubuntu WSL installer is unavailable; continuing to web fallback.'
+            Add-Content -Path $env:GITHUB_OUTPUT -Value 'installed=false'
+            exit 0
+          }
+
+          $actualHash = (Get-FileHash -LiteralPath $installerPath -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actualHash -ne $env:WSL_UBUNTU_INSTALLER_SHA256) {
+            throw "Cached Ubuntu WSL installer SHA-256 mismatch: $actualHash"
+          }
+
+          $installedDistributions = @(wsl.exe --list --quiet 2>$null)
+          if ($installedDistributions -match [regex]::Escape($distributionName)) {
+            Write-Host "WSL distribution already installed from the validated cache: $distributionName"
+          } else {
+            Write-Host "Installing $distributionName from the validated repository cache"
+            & "$env:SystemRoot\System32\wsl.exe" --install --from-file $installerPath --no-launch --name $distributionName
+            if ($LASTEXITCODE -ne 0) {
+              throw "wsl.exe failed to install $distributionName from the validated cache with exit code $LASTEXITCODE"
+            }
+          }
+
+          Add-Content -Path $env:GITHUB_OUTPUT -Value 'installed=true'
+
+      - name: Install Ubuntu WSL distribution web fallback
+        id: install_web_ubuntu_wsl
+        if: ${{ !cancelled() && steps.setup_wsl2.outcome == 'failure' && steps.install_cached_ubuntu_wsl.outputs.installed != 'true' }}
+        # A last-resort path for a cache miss. Marking it continue-on-error lets the bounded
+        # retry below decide the job outcome instead of suppressing the retry after this fails.
+        continue-on-error: true
         timeout-minutes: 5
         shell: pwsh
         run: |
@@ -277,8 +348,10 @@ jobs:
           }
 
       - name: Retry Setup WSL2
-        if: ${{ steps.setup_wsl2.outcome == 'failure' }}
-        # Retry once after removing the process and distribution left by the timed-out setup action.
+        id: retry_setup_wsl2
+        if: ${{ !cancelled() && steps.setup_wsl2.outcome == 'failure' }}
+        # Run after either fallback even if it failed. Without !cancelled(), GitHub's implicit
+        # success() check skips this retry after a failed web-download fallback.
         uses: Vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7.0.0
         timeout-minutes: 5
         with:
@@ -291,6 +364,35 @@ jobs:
             ca-certificates
             curl
             software-properties-common
+
+      - name: Verify Ubuntu WSL installer before caching
+        id: verify_ubuntu_wsl_installer
+        if: ${{ !cancelled() && (steps.setup_wsl2.outcome == 'success' || steps.retry_setup_wsl2.outcome == 'success') }}
+        shell: pwsh
+        timeout-minutes: 1
+        run: |
+          $cacheDirectory = Join-Path $env:RUNNER_TOOL_CACHE "Ubuntu\$env:WSL_UBUNTU_VERSION\x64"
+          $installerPath = Join-Path $cacheDirectory $env:WSL_UBUNTU_INSTALLER_FILE
+          $completeMarker = Join-Path $cacheDirectory '.complete'
+
+          if (-not (Test-Path -LiteralPath $installerPath) -or -not (Test-Path -LiteralPath $completeMarker)) {
+            throw "Ubuntu WSL installer is missing after setup: $installerPath"
+          }
+
+          $actualHash = (Get-FileHash -LiteralPath $installerPath -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actualHash -ne $env:WSL_UBUNTU_INSTALLER_SHA256) {
+            throw "Ubuntu WSL installer SHA-256 mismatch after setup: $actualHash"
+          }
+
+          Write-Host "Verified Ubuntu WSL installer for repository cache: $installerPath"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value 'valid=true'
+
+      - name: Save verified Ubuntu WSL installer cache
+        if: ${{ !cancelled() && github.ref == 'refs/heads/main' && steps.restore_ubuntu_wsl_installer.outputs.cache-hit != 'true' && steps.verify_ubuntu_wsl_installer.outputs.valid == 'true' }}
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ runner.tool_cache }}\Ubuntu\${{ env.WSL_UBUNTU_VERSION }}\x64
+          key: solo-wsl-installer-${{ runner.os }}-${{ runner.arch }}-${{ env.WSL_UBUNTU_VERSION }}-${{ env.WSL_UBUNTU_INSTALLER_SHA256 }}
 
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1

--- a/.github/workflows/flow-standard-runner-one-shot-windows.yaml
+++ b/.github/workflows/flow-standard-runner-one-shot-windows.yaml
@@ -34,6 +34,7 @@ on:
       - ready_for_review
 
 permissions:
+  actions: write
   contents: read
 
 concurrency:
@@ -47,8 +48,9 @@ env:
   ACTIONS_RUNNER_DEBUG: 'true'
   WSL_UBUNTU_VERSION: '24.4.4'
   WSL_UBUNTU_INSTALLER_FILE: 'ubuntu-24.04.4-wsl-amd64.wsl'
+  WSL_UBUNTU_INSTALLER_URL: 'https://releases.ubuntu.com/24.04.4/ubuntu-24.04.4-wsl-amd64.wsl'
   WSL_UBUNTU_INSTALLER_SHA256: '9b2f7730dc68227dd04a9f3e5eab86ad85caf556b8606ad94f1f29ff5c4fd3f5'
-  # Cache key used by the pinned Vampire/setup-wsl action for Ubuntu 24.04.4.
+  # Cache key and tool-cache path used by setup-wsl for Ubuntu 24.04.4.
   WSL_UBUNTU_CACHE_KEY: '2:distributionDirectory_Ubuntu_24.4.4'
 
 jobs:
@@ -163,8 +165,14 @@ jobs:
             Remove-Item -LiteralPath $cacheDirectory -Recurse -Force
           }
 
-          if (-not $valid -and $cacheHit -eq 'true') {
-            throw "Restored Ubuntu WSL installer cache failed validation: $validationResult"
+          $completeMarkerPath = "$cacheDirectory.complete"
+          if ($valid) {
+            # setup-wsl's tool-cache.find() requires this sibling marker. Create
+            # it only after the installer hash has been verified so setup-wsl
+            # uses these bytes instead of removing them and restoring again.
+            New-Item -ItemType File -Path $completeMarkerPath -Force | Out-Null
+          } elseif (Test-Path -LiteralPath $completeMarkerPath) {
+            Remove-Item -LiteralPath $completeMarkerPath -Force
           }
 
           Add-Content -Path $env:GITHUB_OUTPUT -Value "valid=$($valid.ToString().ToLowerInvariant())"
@@ -175,20 +183,70 @@ jobs:
           - Validation: $validationResult
           "@ | Add-Content -Path $env:GITHUB_STEP_SUMMARY
 
-      - name: Fail early when verified Ubuntu WSL installer cache is unavailable
-        if: ${{ success() && github.ref != 'refs/heads/main' && steps.validate_ubuntu_wsl_installer.outputs.valid != 'true' }}
+      - name: Delete invalid Ubuntu WSL installer cache from main
+        if: ${{ success() && github.ref == 'refs/heads/main' && steps.restore_ubuntu_wsl_installer.outputs.cache-hit == 'true' && steps.validate_ubuntu_wsl_installer.outputs.valid != 'true' }}
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $cacheKey = [uri]::EscapeDataString($env:WSL_UBUNTU_CACHE_KEY)
+          $cacheRef = [uri]::EscapeDataString($env:GITHUB_REF)
+          gh api --method DELETE "repos/$env:GITHUB_REPOSITORY/actions/caches?key=$cacheKey&ref=$cacheRef"
+
+      - name: Seed verified Ubuntu WSL installer cache from main
+        id: seed_ubuntu_wsl_installer
+        if: ${{ success() && github.ref == 'refs/heads/main' && steps.validate_ubuntu_wsl_installer.outputs.valid != 'true' }}
+        shell: pwsh
+        timeout-minutes: 10
+        run: |
+          $cacheDirectory = Join-Path $env:RUNNER_TOOL_CACHE "Ubuntu\$env:WSL_UBUNTU_VERSION\x64"
+          $installerPath = Join-Path $cacheDirectory $env:WSL_UBUNTU_INSTALLER_FILE
+          $completeMarkerPath = "$cacheDirectory.complete"
+          New-Item -ItemType Directory -Path $cacheDirectory -Force | Out-Null
+          Remove-Item -LiteralPath $installerPath,$completeMarkerPath -Force -ErrorAction SilentlyContinue
+
+          Invoke-WebRequest -Uri $env:WSL_UBUNTU_INSTALLER_URL -OutFile $installerPath
+          $actualHash = (Get-FileHash -LiteralPath $installerPath -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actualHash -ne $env:WSL_UBUNTU_INSTALLER_SHA256) {
+            Remove-Item -LiteralPath $installerPath -Force -ErrorAction SilentlyContinue
+            throw "Seeded Ubuntu WSL installer failed SHA-256 validation: $actualHash"
+          }
+
+          New-Item -ItemType File -Path $completeMarkerPath -Force | Out-Null
+          Add-Content -Path $env:GITHUB_OUTPUT -Value 'valid=true'
+          Write-Host "Seeded verified Ubuntu WSL installer cache: $installerPath"
+
+      - name: Save seeded Ubuntu WSL installer cache
+        if: ${{ success() && steps.seed_ubuntu_wsl_installer.outputs.valid == 'true' }}
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ runner.tool_cache }}\Ubuntu\${{ env.WSL_UBUNTU_VERSION }}\x64
+          key: ${{ env.WSL_UBUNTU_CACHE_KEY }}
+
+      - name: Report Ubuntu WSL installer cache availability
+        id: ubuntu_wsl_installer
+        if: ${{ success() }}
         shell: pwsh
         run: |
-          throw 'Verified Ubuntu WSL installer cache is unavailable. Online Ubuntu acquisition is disabled on non-main runs; rerun after a main workflow seeds the setup-wsl cache.'
+          $available = '${{ steps.validate_ubuntu_wsl_installer.outputs.valid }}' -eq 'true' -or '${{ steps.seed_ubuntu_wsl_installer.outputs.valid }}' -eq 'true'
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "available=$($available.ToString().ToLowerInvariant())"
+          if (-not $available) {
+            @"
+            ## Windows WSL integration skipped
+
+            The verified Ubuntu installer cache was unavailable or invalid. This PR did not attempt online Ubuntu acquisition. A `main` run will seed a missing cache; an invalid cache is deleted and replaced on `main`.
+            "@ | Add-Content -Path $env:GITHUB_STEP_SUMMARY
+            Write-Warning 'Skipping WSL-dependent integration steps because the verified Ubuntu installer cache is unavailable.'
+          }
 
       - name: Setup WSL2
         id: setup_wsl2
+        if: ${{ success() && steps.ubuntu_wsl_installer.outputs.available == 'true' }}
         # Kind requires Linux containers. GitHub's windows-latest runner has Docker in Windows
         # container mode with no Docker Desktop to switch it. WSL2 + Docker inside it replicates
         # what Docker Desktop does for Windows users, exposing a Linux daemon via TCP.
-        # The action cache restores the installer across fresh GitHub-hosted runner VMs.
-        # The verified restore above uses the pinned action's cache key so this action finds
-        # the installer in its tool cache before it considers an Ubuntu download.
+        # The verified restore above creates setup-wsl's .complete marker so find()
+        # returns the installer before the action reaches its cache or download path.
         uses: Vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7.0.0
         # A healthy setup completes in about one minute. Bound a stalled action so a
         # distribution problem is reported promptly instead of consuming ten minutes.
@@ -196,7 +254,7 @@ jobs:
         with:
           distribution: Ubuntu-24.04
           wsl-version: 2
-          use-cache: true
+          use-cache: false
           set-as-default: true
           additional-packages: |
             apt-transport-https
@@ -278,10 +336,12 @@ jobs:
           egress-policy: audit
 
       - name: Restart WSL
+        if: ${{ success() && steps.ubuntu_wsl_installer.outputs.available == 'true' }}
         run: wsl --shutdown
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
 
       - name: Install Docker in WSL2
+        if: ${{ success() && steps.ubuntu_wsl_installer.outputs.available == 'true' }}
         shell: wsl-bash {0}
         timeout-minutes: 10
         run: |
@@ -327,6 +387,7 @@ jobs:
           ss -tlnp | grep 2375
 
       - name: Forward Docker TCP Port from WSL2 to Windows
+        if: ${{ success() && steps.ubuntu_wsl_installer.outputs.available == 'true' }}
         shell: pwsh
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
         run: |
@@ -340,6 +401,7 @@ jobs:
           docker info
 
       - name: Render Kind Config for WSL Docker Daemon
+        if: ${{ success() && steps.ubuntu_wsl_installer.outputs.available == 'true' }}
         shell: pwsh
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
         run: |
@@ -375,6 +437,7 @@ jobs:
           "SOLO_KIND_CLUSTER_CONFIG_FILE=$renderedConfig" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: One-Shot Single Deploy
+        if: ${{ success() && steps.ubuntu_wsl_installer.outputs.available == 'true' }}
         shell: pwsh
         timeout-minutes: 70
         env:
@@ -384,6 +447,7 @@ jobs:
           npm run solo -- one-shot single deploy --dev
 
       - name: Check Port Forwarding Still Works After Deploy
+        if: ${{ success() && steps.ubuntu_wsl_installer.outputs.available == 'true' }}
         shell: pwsh
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
         run: |
@@ -391,7 +455,7 @@ jobs:
           npm run solo -- deployment diagnostics connections -d one-shot --check
 
       - name: Collect Diagnostics on Failure
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.ubuntu_wsl_installer.outputs.available == 'true' }}
         shell: pwsh
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
         run: |
@@ -399,7 +463,7 @@ jobs:
           npm run solo -- deployment diagnostics logs -q --dev; $true
 
       - name: One-Shot Single Destroy
-        if: always()
+        if: ${{ always() && steps.ubuntu_wsl_installer.outputs.available == 'true' }}
         shell: pwsh
         timeout-minutes: 15
         run: |

--- a/.github/workflows/flow-standard-runner-one-shot-windows.yaml
+++ b/.github/workflows/flow-standard-runner-one-shot-windows.yaml
@@ -48,6 +48,8 @@ env:
   WSL_UBUNTU_VERSION: '24.4.4'
   WSL_UBUNTU_INSTALLER_FILE: 'ubuntu-24.04.4-wsl-amd64.wsl'
   WSL_UBUNTU_INSTALLER_SHA256: '9b2f7730dc68227dd04a9f3e5eab86ad85caf556b8606ad94f1f29ff5c4fd3f5'
+  # Cache key used by the pinned Vampire/setup-wsl action for Ubuntu 24.04.4.
+  WSL_UBUNTU_CACHE_KEY: '2:distributionDirectory_Ubuntu_24.4.4'
 
 jobs:
   standard-runner-one-shot-windows:
@@ -128,7 +130,7 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ runner.tool_cache }}\Ubuntu\${{ env.WSL_UBUNTU_VERSION }}\x64
-          key: solo-wsl-installer-${{ runner.os }}-${{ runner.arch }}-${{ env.WSL_UBUNTU_VERSION }}-${{ env.WSL_UBUNTU_INSTALLER_SHA256 }}
+          key: ${{ env.WSL_UBUNTU_CACHE_KEY }}
 
       - name: Validate restored Ubuntu WSL installer cache
         id: validate_ubuntu_wsl_installer
@@ -178,8 +180,8 @@ jobs:
         # container mode with no Docker Desktop to switch it. WSL2 + Docker inside it replicates
         # what Docker Desktop does for Windows users, exposing a Linux daemon via TCP.
         # The action cache restores the installer across fresh GitHub-hosted runner VMs.
-        # The verified repository cache above restores the same installer before this action
-        # touches its own tool-cache lookup, avoiding an Ubuntu download on the common path.
+        # The verified restore above uses the pinned action's cache key so this action finds
+        # the installer in its tool cache before it considers an Ubuntu download.
         uses: Vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7.0.0
         continue-on-error: true
         # A healthy setup completes in about one minute. Bound a stalled action so the
@@ -286,9 +288,55 @@ jobs:
           }
           exit 0
 
+      - name: Rehydrate verified Ubuntu WSL installer cache after setup failure
+        id: restore_ubuntu_wsl_installer_after_failure
+        if: ${{ !cancelled() && steps.setup_wsl2.outcome == 'failure' }}
+        # setup-wsl or wsl.exe can consume the local installer before failing. Restore the
+        # action's repository cache again so the direct fallback below still has an input file.
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ runner.tool_cache }}\Ubuntu\${{ env.WSL_UBUNTU_VERSION }}\x64
+          key: ${{ env.WSL_UBUNTU_CACHE_KEY }}
+
+      - name: Validate Ubuntu WSL installer cache for fallback
+        id: validate_ubuntu_wsl_installer_after_failure
+        if: ${{ !cancelled() && steps.setup_wsl2.outcome == 'failure' }}
+        shell: pwsh
+        timeout-minutes: 1
+        run: |
+          $cacheDirectory = Join-Path $env:RUNNER_TOOL_CACHE "Ubuntu\$env:WSL_UBUNTU_VERSION\x64"
+          $installerPath = Join-Path $cacheDirectory $env:WSL_UBUNTU_INSTALLER_FILE
+          $completeMarker = Join-Path $cacheDirectory '.complete'
+          $cacheHit = '${{ steps.restore_ubuntu_wsl_installer_after_failure.outputs.cache-hit }}'
+          $valid = $false
+          $validationResult = 'cache miss'
+
+          if ((Test-Path -LiteralPath $installerPath) -and (Test-Path -LiteralPath $completeMarker)) {
+            $actualHash = (Get-FileHash -LiteralPath $installerPath -Algorithm SHA256).Hash.ToLowerInvariant()
+            if ($actualHash -eq $env:WSL_UBUNTU_INSTALLER_SHA256) {
+              $valid = $true
+              $validationResult = 'valid SHA-256'
+            } else {
+              $validationResult = "invalid SHA-256: $actualHash"
+            }
+          } elseif (Test-Path -LiteralPath $cacheDirectory) {
+            $validationResult = 'installer or completion marker is missing'
+          }
+
+          if (-not $valid -and (Test-Path -LiteralPath $cacheDirectory)) {
+            Write-Warning "Discarding invalid Ubuntu WSL installer cache: $validationResult"
+            Remove-Item -LiteralPath $cacheDirectory -Recurse -Force
+          }
+
+          if (-not $valid -and $cacheHit -eq 'true') {
+            throw "Restored Ubuntu WSL installer cache failed validation: $validationResult"
+          }
+
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "valid=$($valid.ToString().ToLowerInvariant())"
+
       - name: Install cached Ubuntu WSL distribution fallback
         id: install_cached_ubuntu_wsl
-        if: ${{ !cancelled() && steps.setup_wsl2.outcome == 'failure' }}
+        if: ${{ !cancelled() && steps.setup_wsl2.outcome == 'failure' && steps.validate_ubuntu_wsl_installer_after_failure.outputs.valid == 'true' }}
         # Bypass both setup-wsl's downloader and WSL's online downloader when the validated
         # repository cache is available. Retry Setup WSL2 still runs afterwards to configure
         # the distribution's packages and the wsl-bash shell wrapper.
@@ -364,35 +412,6 @@ jobs:
             ca-certificates
             curl
             software-properties-common
-
-      - name: Verify Ubuntu WSL installer before caching
-        id: verify_ubuntu_wsl_installer
-        if: ${{ !cancelled() && (steps.setup_wsl2.outcome == 'success' || steps.retry_setup_wsl2.outcome == 'success') }}
-        shell: pwsh
-        timeout-minutes: 1
-        run: |
-          $cacheDirectory = Join-Path $env:RUNNER_TOOL_CACHE "Ubuntu\$env:WSL_UBUNTU_VERSION\x64"
-          $installerPath = Join-Path $cacheDirectory $env:WSL_UBUNTU_INSTALLER_FILE
-          $completeMarker = Join-Path $cacheDirectory '.complete'
-
-          if (-not (Test-Path -LiteralPath $installerPath) -or -not (Test-Path -LiteralPath $completeMarker)) {
-            throw "Ubuntu WSL installer is missing after setup: $installerPath"
-          }
-
-          $actualHash = (Get-FileHash -LiteralPath $installerPath -Algorithm SHA256).Hash.ToLowerInvariant()
-          if ($actualHash -ne $env:WSL_UBUNTU_INSTALLER_SHA256) {
-            throw "Ubuntu WSL installer SHA-256 mismatch after setup: $actualHash"
-          }
-
-          Write-Host "Verified Ubuntu WSL installer for repository cache: $installerPath"
-          Add-Content -Path $env:GITHUB_OUTPUT -Value 'valid=true'
-
-      - name: Save verified Ubuntu WSL installer cache
-        if: ${{ !cancelled() && github.ref == 'refs/heads/main' && steps.restore_ubuntu_wsl_installer.outputs.cache-hit != 'true' && steps.verify_ubuntu_wsl_installer.outputs.valid == 'true' }}
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ${{ runner.tool_cache }}\Ubuntu\${{ env.WSL_UBUNTU_VERSION }}\x64
-          key: solo-wsl-installer-${{ runner.os }}-${{ runner.arch }}-${{ env.WSL_UBUNTU_VERSION }}-${{ env.WSL_UBUNTU_INSTALLER_SHA256 }}
 
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1

--- a/.github/workflows/flow-standard-runner-one-shot-windows.yaml
+++ b/.github/workflows/flow-standard-runner-one-shot-windows.yaml
@@ -121,7 +121,9 @@ jobs:
 
       - name: Build Project
         shell: pwsh
-        timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
+        # npm ci can consume most of the normal five-minute step limit on a
+        # slow hosted runner, leaving no time for compilation.
+        timeout-minutes: 10
         run: |
           task build:compile
 
@@ -174,7 +176,7 @@ jobs:
           "@ | Add-Content -Path $env:GITHUB_STEP_SUMMARY
 
       - name: Fail early when verified Ubuntu WSL installer cache is unavailable
-        if: ${{ !cancelled() && github.ref != 'refs/heads/main' && steps.validate_ubuntu_wsl_installer.outputs.valid != 'true' }}
+        if: ${{ success() && github.ref != 'refs/heads/main' && steps.validate_ubuntu_wsl_installer.outputs.valid != 'true' }}
         shell: pwsh
         run: |
           throw 'Verified Ubuntu WSL installer cache is unavailable. Online Ubuntu acquisition is disabled on non-main runs; rerun after a main workflow seeds the setup-wsl cache.'

--- a/.github/workflows/flow-standard-runner-one-shot-windows.yaml
+++ b/.github/workflows/flow-standard-runner-one-shot-windows.yaml
@@ -173,6 +173,12 @@ jobs:
           - Validation: $validationResult
           "@ | Add-Content -Path $env:GITHUB_STEP_SUMMARY
 
+      - name: Fail early when verified Ubuntu WSL installer cache is unavailable
+        if: ${{ !cancelled() && github.ref != 'refs/heads/main' && steps.validate_ubuntu_wsl_installer.outputs.valid != 'true' }}
+        shell: pwsh
+        run: |
+          throw 'Verified Ubuntu WSL installer cache is unavailable. Online Ubuntu acquisition is disabled on non-main runs; rerun after a main workflow seeds the setup-wsl cache.'
+
       - name: Setup WSL2
         id: setup_wsl2
         # Kind requires Linux containers. GitHub's windows-latest runner has Docker in Windows
@@ -297,44 +303,9 @@ jobs:
           path: ${{ runner.tool_cache }}\Ubuntu\${{ env.WSL_UBUNTU_VERSION }}\x64
           key: ${{ env.WSL_UBUNTU_CACHE_KEY }}
 
-      - name: Validate Ubuntu WSL installer cache for fallback
-        id: validate_ubuntu_wsl_installer_after_failure
-        if: ${{ !cancelled() && steps.setup_wsl2.outcome == 'failure' }}
-        shell: pwsh
-        timeout-minutes: 1
-        run: |
-          $cacheDirectory = Join-Path $env:RUNNER_TOOL_CACHE "Ubuntu\$env:WSL_UBUNTU_VERSION\x64"
-          $installerPath = Join-Path $cacheDirectory $env:WSL_UBUNTU_INSTALLER_FILE
-          $cacheHit = '${{ steps.restore_ubuntu_wsl_installer_after_failure.outputs.cache-hit }}'
-          $valid = $false
-          $validationResult = 'cache miss'
-
-          if (Test-Path -LiteralPath $installerPath) {
-            $actualHash = (Get-FileHash -LiteralPath $installerPath -Algorithm SHA256).Hash.ToLowerInvariant()
-            if ($actualHash -eq $env:WSL_UBUNTU_INSTALLER_SHA256) {
-              $valid = $true
-              $validationResult = 'valid SHA-256'
-            } else {
-              $validationResult = "invalid SHA-256: $actualHash"
-            }
-          } elseif (Test-Path -LiteralPath $cacheDirectory) {
-            $validationResult = 'installer is missing'
-          }
-
-          if (-not $valid -and (Test-Path -LiteralPath $cacheDirectory)) {
-            Write-Warning "Discarding invalid Ubuntu WSL installer cache: $validationResult"
-            Remove-Item -LiteralPath $cacheDirectory -Recurse -Force
-          }
-
-          if (-not $valid -and $cacheHit -eq 'true') {
-            throw "Restored Ubuntu WSL installer cache failed validation: $validationResult"
-          }
-
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "valid=$($valid.ToString().ToLowerInvariant())"
-
       - name: Install cached Ubuntu WSL distribution fallback
         id: install_cached_ubuntu_wsl
-        if: ${{ !cancelled() && steps.setup_wsl2.outcome == 'failure' && steps.validate_ubuntu_wsl_installer_after_failure.outputs.valid == 'true' }}
+        if: ${{ !cancelled() && steps.setup_wsl2.outcome == 'failure' }}
         # Bypass both setup-wsl's downloader and WSL's online downloader when the validated
         # repository cache is available. Retry Setup WSL2 still runs afterwards to configure
         # the distribution's packages and the wsl-bash shell wrapper.
@@ -347,9 +318,7 @@ jobs:
           $installerPath = Join-Path $cacheDirectory $env:WSL_UBUNTU_INSTALLER_FILE
 
           if (-not (Test-Path -LiteralPath $installerPath)) {
-            Write-Host 'Validated Ubuntu WSL installer is unavailable; continuing to web fallback.'
-            Add-Content -Path $env:GITHUB_OUTPUT -Value 'installed=false'
-            exit 0
+            throw "Verified Ubuntu WSL installer is unavailable after setup failure: $installerPath"
           }
 
           $actualHash = (Get-FileHash -LiteralPath $installerPath -Algorithm SHA256).Hash.ToLowerInvariant()
@@ -370,33 +339,11 @@ jobs:
 
           Add-Content -Path $env:GITHUB_OUTPUT -Value 'installed=true'
 
-      - name: Install Ubuntu WSL distribution web fallback
-        id: install_web_ubuntu_wsl
-        if: ${{ !cancelled() && steps.setup_wsl2.outcome == 'failure' && steps.install_cached_ubuntu_wsl.outputs.installed != 'true' }}
-        # A last-resort path for a cache miss. Marking it continue-on-error lets the bounded
-        # retry below decide the job outcome instead of suppressing the retry after this fails.
-        continue-on-error: true
-        timeout-minutes: 5
-        shell: pwsh
-        run: |
-          $distributionName = 'Ubuntu-24.04'
-          $installedDistributions = @(wsl.exe --list --quiet 2>$null)
-          if ($installedDistributions -match [regex]::Escape($distributionName)) {
-            Write-Host "WSL distribution already installed: $distributionName"
-            exit 0
-          }
-
-          Write-Host "Installing $distributionName through WSL web download"
-          & "$env:SystemRoot\System32\wsl.exe" --install --web-download --distribution $distributionName --no-launch
-          if ($LASTEXITCODE -ne 0) {
-            throw "wsl.exe failed to install $distributionName with exit code $LASTEXITCODE"
-          }
-
       - name: Retry Setup WSL2
         id: retry_setup_wsl2
         if: ${{ !cancelled() && steps.setup_wsl2.outcome == 'failure' }}
-        # Run after either fallback even if it failed. Without !cancelled(), GitHub's implicit
-        # success() check skips this retry after a failed web-download fallback.
+        # Run after the cached fallback even if it failed. Without !cancelled(), GitHub's
+        # implicit success() check skips this retry after the fallback fails.
         uses: Vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7.0.0
         timeout-minutes: 5
         with:

--- a/.github/workflows/flow-standard-runner-one-shot-windows.yaml
+++ b/.github/workflows/flow-standard-runner-one-shot-windows.yaml
@@ -34,7 +34,6 @@ on:
       - ready_for_review
 
 permissions:
-  actions: write
   contents: read
 
 concurrency:
@@ -50,8 +49,6 @@ env:
   WSL_UBUNTU_INSTALLER_FILE: 'ubuntu-24.04.4-wsl-amd64.wsl'
   WSL_UBUNTU_INSTALLER_URL: 'https://releases.ubuntu.com/24.04.4/ubuntu-24.04.4-wsl-amd64.wsl'
   WSL_UBUNTU_INSTALLER_SHA256: '9b2f7730dc68227dd04a9f3e5eab86ad85caf556b8606ad94f1f29ff5c4fd3f5'
-  # Cache key and tool-cache path used by setup-wsl for Ubuntu 24.04.4.
-  WSL_UBUNTU_CACHE_KEY: '2:distributionDirectory_Ubuntu_24.4.4'
 
 jobs:
   standard-runner-one-shot-windows:
@@ -134,7 +131,7 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ runner.tool_cache }}\Ubuntu\${{ env.WSL_UBUNTU_VERSION }}\x64
-          key: ${{ env.WSL_UBUNTU_CACHE_KEY }}
+          key: ubuntu-wsl-installer-v1-${{ env.WSL_UBUNTU_VERSION }}-${{ env.WSL_UBUNTU_INSTALLER_SHA256 }}
 
       - name: Validate restored Ubuntu WSL installer cache
         id: validate_ubuntu_wsl_installer
@@ -183,19 +180,9 @@ jobs:
           - Validation: $validationResult
           "@ | Add-Content -Path $env:GITHUB_STEP_SUMMARY
 
-      - name: Delete invalid Ubuntu WSL installer cache from main
-        if: ${{ success() && github.ref == 'refs/heads/main' && steps.restore_ubuntu_wsl_installer.outputs.cache-hit == 'true' && steps.validate_ubuntu_wsl_installer.outputs.valid != 'true' }}
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          $cacheKey = [uri]::EscapeDataString($env:WSL_UBUNTU_CACHE_KEY)
-          $cacheRef = [uri]::EscapeDataString($env:GITHUB_REF)
-          gh api --method DELETE "repos/$env:GITHUB_REPOSITORY/actions/caches?key=$cacheKey&ref=$cacheRef"
-
-      - name: Seed verified Ubuntu WSL installer cache from main
+      - name: Seed verified Ubuntu WSL installer cache
         id: seed_ubuntu_wsl_installer
-        if: ${{ success() && github.ref == 'refs/heads/main' && steps.validate_ubuntu_wsl_installer.outputs.valid != 'true' }}
+        if: ${{ success() && steps.validate_ubuntu_wsl_installer.outputs.valid != 'true' }}
         shell: pwsh
         timeout-minutes: 10
         run: |
@@ -221,28 +208,10 @@ jobs:
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ runner.tool_cache }}\Ubuntu\${{ env.WSL_UBUNTU_VERSION }}\x64
-          key: ${{ env.WSL_UBUNTU_CACHE_KEY }}
-
-      - name: Report Ubuntu WSL installer cache availability
-        id: ubuntu_wsl_installer
-        if: ${{ success() }}
-        shell: pwsh
-        run: |
-          $available = '${{ steps.validate_ubuntu_wsl_installer.outputs.valid }}' -eq 'true' -or '${{ steps.seed_ubuntu_wsl_installer.outputs.valid }}' -eq 'true'
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "available=$($available.ToString().ToLowerInvariant())"
-          if (-not $available) {
-            $summary = @(
-              '## Windows WSL integration skipped'
-              ''
-              'The verified Ubuntu installer cache was unavailable or invalid. This PR did not attempt online Ubuntu acquisition. A main run will seed a missing cache; an invalid cache is deleted and replaced on main.'
-            ) -join [Environment]::NewLine
-            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $summary
-            Write-Warning 'Skipping WSL-dependent integration steps because the verified Ubuntu installer cache is unavailable.'
-          }
+          key: ubuntu-wsl-installer-v1-${{ env.WSL_UBUNTU_VERSION }}-${{ env.WSL_UBUNTU_INSTALLER_SHA256 }}
 
       - name: Setup WSL2
         id: setup_wsl2
-        if: ${{ success() && steps.ubuntu_wsl_installer.outputs.available == 'true' }}
         # Kind requires Linux containers. GitHub's windows-latest runner has Docker in Windows
         # container mode with no Docker Desktop to switch it. WSL2 + Docker inside it replicates
         # what Docker Desktop does for Windows users, exposing a Linux daemon via TCP.
@@ -337,12 +306,10 @@ jobs:
           egress-policy: audit
 
       - name: Restart WSL
-        if: ${{ success() && steps.ubuntu_wsl_installer.outputs.available == 'true' }}
         run: wsl --shutdown
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
 
       - name: Install Docker in WSL2
-        if: ${{ success() && steps.ubuntu_wsl_installer.outputs.available == 'true' }}
         shell: wsl-bash {0}
         timeout-minutes: 10
         run: |
@@ -388,7 +355,6 @@ jobs:
           ss -tlnp | grep 2375
 
       - name: Forward Docker TCP Port from WSL2 to Windows
-        if: ${{ success() && steps.ubuntu_wsl_installer.outputs.available == 'true' }}
         shell: pwsh
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
         run: |
@@ -402,7 +368,6 @@ jobs:
           docker info
 
       - name: Render Kind Config for WSL Docker Daemon
-        if: ${{ success() && steps.ubuntu_wsl_installer.outputs.available == 'true' }}
         shell: pwsh
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
         run: |
@@ -438,7 +403,6 @@ jobs:
           "SOLO_KIND_CLUSTER_CONFIG_FILE=$renderedConfig" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: One-Shot Single Deploy
-        if: ${{ success() && steps.ubuntu_wsl_installer.outputs.available == 'true' }}
         shell: pwsh
         timeout-minutes: 70
         env:
@@ -448,7 +412,6 @@ jobs:
           npm run solo -- one-shot single deploy --dev
 
       - name: Check Port Forwarding Still Works After Deploy
-        if: ${{ success() && steps.ubuntu_wsl_installer.outputs.available == 'true' }}
         shell: pwsh
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
         run: |
@@ -456,7 +419,7 @@ jobs:
           npm run solo -- deployment diagnostics connections -d one-shot --check
 
       - name: Collect Diagnostics on Failure
-        if: ${{ failure() && steps.ubuntu_wsl_installer.outputs.available == 'true' }}
+        if: ${{ failure() }}
         shell: pwsh
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
         run: |
@@ -464,7 +427,7 @@ jobs:
           npm run solo -- deployment diagnostics logs -q --dev; $true
 
       - name: One-Shot Single Destroy
-        if: ${{ always() && steps.ubuntu_wsl_installer.outputs.available == 'true' }}
+        if: always()
         shell: pwsh
         timeout-minutes: 15
         run: |

--- a/.github/workflows/flow-standard-runner-one-shot-windows.yaml
+++ b/.github/workflows/flow-standard-runner-one-shot-windows.yaml
@@ -139,12 +139,11 @@ jobs:
         run: |
           $cacheDirectory = Join-Path $env:RUNNER_TOOL_CACHE "Ubuntu\$env:WSL_UBUNTU_VERSION\x64"
           $installerPath = Join-Path $cacheDirectory $env:WSL_UBUNTU_INSTALLER_FILE
-          $completeMarker = Join-Path $cacheDirectory '.complete'
           $cacheHit = '${{ steps.restore_ubuntu_wsl_installer.outputs.cache-hit }}'
           $valid = $false
           $validationResult = 'cache miss'
 
-          if ((Test-Path -LiteralPath $installerPath) -and (Test-Path -LiteralPath $completeMarker)) {
+          if (Test-Path -LiteralPath $installerPath) {
             $actualHash = (Get-FileHash -LiteralPath $installerPath -Algorithm SHA256).Hash.ToLowerInvariant()
             if ($actualHash -eq $env:WSL_UBUNTU_INSTALLER_SHA256) {
               $valid = $true
@@ -154,7 +153,7 @@ jobs:
               $validationResult = "invalid SHA-256: $actualHash"
             }
           } elseif (Test-Path -LiteralPath $cacheDirectory) {
-            $validationResult = 'installer or completion marker is missing'
+            $validationResult = 'installer is missing'
           }
 
           if (-not $valid -and (Test-Path -LiteralPath $cacheDirectory)) {
@@ -306,12 +305,11 @@ jobs:
         run: |
           $cacheDirectory = Join-Path $env:RUNNER_TOOL_CACHE "Ubuntu\$env:WSL_UBUNTU_VERSION\x64"
           $installerPath = Join-Path $cacheDirectory $env:WSL_UBUNTU_INSTALLER_FILE
-          $completeMarker = Join-Path $cacheDirectory '.complete'
           $cacheHit = '${{ steps.restore_ubuntu_wsl_installer_after_failure.outputs.cache-hit }}'
           $valid = $false
           $validationResult = 'cache miss'
 
-          if ((Test-Path -LiteralPath $installerPath) -and (Test-Path -LiteralPath $completeMarker)) {
+          if (Test-Path -LiteralPath $installerPath) {
             $actualHash = (Get-FileHash -LiteralPath $installerPath -Algorithm SHA256).Hash.ToLowerInvariant()
             if ($actualHash -eq $env:WSL_UBUNTU_INSTALLER_SHA256) {
               $valid = $true
@@ -320,7 +318,7 @@ jobs:
               $validationResult = "invalid SHA-256: $actualHash"
             }
           } elseif (Test-Path -LiteralPath $cacheDirectory) {
-            $validationResult = 'installer or completion marker is missing'
+            $validationResult = 'installer is missing'
           }
 
           if (-not $valid -and (Test-Path -LiteralPath $cacheDirectory)) {
@@ -347,9 +345,8 @@ jobs:
           $distributionName = 'Ubuntu-24.04'
           $cacheDirectory = Join-Path $env:RUNNER_TOOL_CACHE "Ubuntu\$env:WSL_UBUNTU_VERSION\x64"
           $installerPath = Join-Path $cacheDirectory $env:WSL_UBUNTU_INSTALLER_FILE
-          $completeMarker = Join-Path $cacheDirectory '.complete'
 
-          if (-not (Test-Path -LiteralPath $installerPath) -or -not (Test-Path -LiteralPath $completeMarker)) {
+          if (-not (Test-Path -LiteralPath $installerPath)) {
             Write-Host 'Validated Ubuntu WSL installer is unavailable; continuing to web fallback.'
             Add-Content -Path $env:GITHUB_OUTPUT -Value 'installed=false'
             exit 0

--- a/.github/workflows/flow-standard-runner-one-shot-windows.yaml
+++ b/.github/workflows/flow-standard-runner-one-shot-windows.yaml
@@ -188,9 +188,8 @@ jobs:
         # The verified restore above uses the pinned action's cache key so this action finds
         # the installer in its tool cache before it considers an Ubuntu download.
         uses: Vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7.0.0
-        continue-on-error: true
-        # A healthy setup completes in about one minute. Bound a stalled action so the
-        # recovery path can run instead of consuming the previous ten-minute timeout.
+        # A healthy setup completes in about one minute. Bound a stalled action so a
+        # distribution problem is reported promptly instead of consuming ten minutes.
         timeout-minutes: 3
         with:
           distribution: Ubuntu-24.04
@@ -204,7 +203,7 @@ jobs:
             software-properties-common
 
       - name: Capture WSL2 diagnostics after setup failure
-        if: ${{ steps.setup_wsl2.outcome == 'failure' }}
+        if: ${{ !cancelled() && steps.setup_wsl2.outcome == 'failure' }}
         shell: pwsh
         continue-on-error: true
         timeout-minutes: 1
@@ -270,93 +269,6 @@ jobs:
             Tee-Object -FilePath (Join-Path $diagnosticsDirectory 'system-events.txt') |
             Format-List
           Write-Host '::endgroup::'
-
-      - name: Recover incomplete WSL2 installation
-        if: ${{ steps.setup_wsl2.outcome == 'failure' }}
-        shell: pwsh
-        # The timed-out action can leave its wsl.exe child process and a partially registered
-        # distribution behind. Remove both before retrying the installation from a clean state.
-        continue-on-error: true
-        timeout-minutes: 1
-        run: |
-          Get-Process -Name wsl -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
-          wsl --shutdown
-          wsl --unregister Ubuntu-24.04
-          if ($LASTEXITCODE -ne 0) {
-            Write-Warning 'Ubuntu-24.04 was not registered after the failed installation.'
-          }
-          $installerCacheDirectory = Join-Path $env:RUNNER_TOOL_CACHE 'Ubuntu\24.4.4\x64'
-          $installerPath = Join-Path $installerCacheDirectory 'ubuntu-24.04.4-wsl-amd64.wsl'
-          if ((Test-Path -LiteralPath $installerCacheDirectory) -and -not (Test-Path -LiteralPath $installerPath)) {
-            Write-Warning "Removing incomplete Ubuntu installer cache: $installerCacheDirectory"
-            Remove-Item -LiteralPath $installerCacheDirectory -Recurse -Force -ErrorAction SilentlyContinue
-          }
-          exit 0
-
-      - name: Rehydrate verified Ubuntu WSL installer cache after setup failure
-        id: restore_ubuntu_wsl_installer_after_failure
-        if: ${{ !cancelled() && steps.setup_wsl2.outcome == 'failure' }}
-        # setup-wsl or wsl.exe can consume the local installer before failing. Restore the
-        # action's repository cache again so the direct fallback below still has an input file.
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ${{ runner.tool_cache }}\Ubuntu\${{ env.WSL_UBUNTU_VERSION }}\x64
-          key: ${{ env.WSL_UBUNTU_CACHE_KEY }}
-
-      - name: Install cached Ubuntu WSL distribution fallback
-        id: install_cached_ubuntu_wsl
-        if: ${{ !cancelled() && steps.setup_wsl2.outcome == 'failure' }}
-        # Bypass both setup-wsl's downloader and WSL's online downloader when the validated
-        # repository cache is available. Retry Setup WSL2 still runs afterwards to configure
-        # the distribution's packages and the wsl-bash shell wrapper.
-        timeout-minutes: 3
-        shell: pwsh
-        run: |
-          $distributionName = 'Ubuntu-24.04'
-          $cacheDirectory = Join-Path $env:RUNNER_TOOL_CACHE "Ubuntu\$env:WSL_UBUNTU_VERSION\x64"
-          $installerPath = Join-Path $cacheDirectory $env:WSL_UBUNTU_INSTALLER_FILE
-
-          if (-not (Test-Path -LiteralPath $installerPath)) {
-            throw "Verified Ubuntu WSL installer is unavailable after setup failure: $installerPath"
-          }
-
-          $actualHash = (Get-FileHash -LiteralPath $installerPath -Algorithm SHA256).Hash.ToLowerInvariant()
-          if ($actualHash -ne $env:WSL_UBUNTU_INSTALLER_SHA256) {
-            throw "Cached Ubuntu WSL installer SHA-256 mismatch: $actualHash"
-          }
-
-          $installedDistributions = @(wsl.exe --list --quiet 2>$null)
-          if ($installedDistributions -match [regex]::Escape($distributionName)) {
-            Write-Host "WSL distribution already installed from the validated cache: $distributionName"
-          } else {
-            Write-Host "Installing $distributionName from the validated repository cache"
-            & "$env:SystemRoot\System32\wsl.exe" --install --from-file $installerPath --no-launch --name $distributionName
-            if ($LASTEXITCODE -ne 0) {
-              throw "wsl.exe failed to install $distributionName from the validated cache with exit code $LASTEXITCODE"
-            }
-          }
-
-          Add-Content -Path $env:GITHUB_OUTPUT -Value 'installed=true'
-
-      - name: Retry Setup WSL2
-        id: retry_setup_wsl2
-        if: ${{ !cancelled() && steps.setup_wsl2.outcome == 'failure' && steps.install_cached_ubuntu_wsl.outcome == 'success' }}
-        # Only retry after the cached fallback installed the distribution. This explicit
-        # condition bypasses GitHub's implicit success() check after the first setup failure.
-        # A failed cached fallback stops the job rather than allowing this action to download
-        # Ubuntu online again.
-        uses: Vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7.0.0
-        timeout-minutes: 5
-        with:
-          distribution: Ubuntu-24.04
-          wsl-version: 2
-          use-cache: true
-          set-as-default: true
-          additional-packages: |
-            apt-transport-https
-            ca-certificates
-            curl
-            software-properties-common
 
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1


### PR DESCRIPTION
## Description

This PR makes the Windows WSL bootstrap resilient to intermittent Ubuntu-distribution acquisition failures without allowing cache availability to turn the Windows compatibility check green.

### Root-cause clarification

An unclear or unstable runner state is **not** the root cause of the Ubuntu-distribution acquisition failure. The failed job diagnostics showed a healthy WSL service, no registered Ubuntu distribution, and no residual WSL process. The timeout occurred in the distribution-acquisition path before the installer was available.

### Current cache behavior

| Condition | Installer handling | Cache write | Test result |
| --- | --- | --- | --- |
| Valid cache, any ref | Hash-validate and add the required `x64.complete` marker | None | Run the full WSL integration test |
| Cache miss or invalid installer on `main` | Direct-download and SHA-256 verify | Save the content-addressed installer | Run the full WSL integration test |
| Cache miss or invalid installer on a pull request | Direct-download and SHA-256 verify | Skip save | Run the full WSL integration test |

### Changes

* Uses a content-addressed installer cache key: Ubuntu version plus expected SHA-256.
* Hash-validates restored installers and creates the sibling `x64.complete` marker required by the setup action. It then installs verified local bytes before reaching the action internal cache or download path.
* Keeps the direct SHA-verified download as self-healing for cache misses and invalid cache contents. A miss cannot skip the test or report a false green result.
* Limits cache publishing to `main`, so pull-request runs never create private 372 MB cache entries.
* Sets `use-cache: false` on the setup action, avoiding a duplicate cache restore.
* Removes post-setup recovery retries. A setup failure captures bounded diagnostics and fails the job promptly.
* Extends the project-build timeout to ten minutes so a slow dependency installation does not consume the compilation budget.

### Related Issues

* Closes #5936

### Pull request checklist

* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] The commit title follows the project guidelines

### Testing

* [x] `task build`
* [x] `npx prettier --check .github/workflows/flow-standard-runner-one-shot-windows.yaml`
* [x] YAML parse validation
* [x] [Marker validation](https://github.com/hiero-ledger/solo/actions/runs/33830097179/job/100900653361) passed end to end: one restore, hash validation, and no second setup-action restore.
* [x] [Content-addressed cache seed](https://github.com/hiero-ledger/solo/actions/runs/33873624502/job/101025237385) passed end to end: cache miss, direct SHA-verified seed, primary WSL setup, and full deploy/destroy test.
* [x] [Current workflow attempt 1](https://github.com/hiero-ledger/solo/actions/runs/33877470289/job/101037774963), [attempt 2](https://github.com/hiero-ledger/solo/actions/runs/33877470289/job/101041914071), and [attempt 3](https://github.com/hiero-ledger/solo/actions/runs/33877470289/job/101046634081) all passed end to end. Each restored and hash-validated the installer, skipped seed/save on the PR, then completed WSL setup, deployment, connectivity, and destroy.