### PR TITLE
fix(core): fall back to the binary probe when the mapped package manager is absent

### DIFF
--- a/src/core/package-managers/dnf-package-manager.ts
+++ b/src/core/package-managers/dnf-package-manager.ts
@@ -5,15 +5,14 @@ import {LinuxPackageManager} from './linux-package-manager.js';
 
 /**
  * Package manager for RPM-based distributions that ship dnf (Fedora, RHEL, Rocky, AlmaLinux, ...).
+ *
+ * Dependencies keep their plain upstream names on purpose: EL8 ships a real `iptables` package and
+ * has no `iptables-nft`, while on Fedora and EL9+ `iptables-nft` carries `Provides: iptables`, so
+ * `dnf install iptables` resolves to the right package on every release. A hard-coded
+ * `iptables` -> `iptables-nft` rewrite breaks EL8 (#5355) — do not reintroduce one.
  */
 @injectable()
 export class DnfPackageManager extends LinuxPackageManager {
-  // On Fedora/RHEL 8+ there is no package literally named `iptables`; `iptables-nft` carries
-  // `Provides: iptables`. Install it explicitly rather than relying on that provides-resolution.
-  protected override resolveDependencies(dependencies: string[]): string[] {
-    return dependencies.map((dependency: string): string => (dependency === 'iptables' ? 'iptables-nft' : dependency));
-  }
-
   protected installCommand(dependencies: string[]): string[] {
     return ['dnf', 'install', '-y', ...dependencies];
   }

--- a/src/core/package-managers/os-package-manager.ts
+++ b/src/core/package-managers/os-package-manager.ts
@@ -73,12 +73,15 @@ export class OsPackageManager {
 
     for (const candidate of candidates) {
       const type: LinuxPackageManagerType | undefined = OsPackageManager.DISTRIBUTION_PACKAGE_MANAGERS[candidate];
-      if (type) {
+      // Trust the mapping only when its binary is actually installed: RHEL/CentOS <= 7 and
+      // Amazon Linux 2 match the dnf entries via ID/ID_LIKE but ship only yum (#5355), so a
+      // mapped-but-absent manager falls through to the binary probe below.
+      if (type && OsPackageManager.isCommandAvailable(type)) {
         return OsPackageManager.createManagerByType(type);
       }
     }
 
-    // os-release did not identify a known distribution; fall back to probing for an installed binary.
+    // os-release matched nothing (or the mapped manager is not installed); probe for an installed binary.
     for (const type of OsPackageManager.FALLBACK_PROBE_ORDER) {
       if (OsPackageManager.isCommandAvailable(type)) {
         return OsPackageManager.createManagerByType(type);

--- a/test/unit/core/package-managers/linux-package-managers.test.ts
+++ b/test/unit/core/package-managers/linux-package-managers.test.ts
@@ -35,11 +35,12 @@ const managerCases: Array<{
   {
     name: 'DnfPackageManager',
     create: (): LinuxPackageManager => new DnfPackageManager(),
-    // Fedora/RHEL 8+ ships iptables as `iptables-nft`; the manager maps it explicitly.
-    install: ['dnf', 'install', '-y', 'git', 'iptables-nft'],
-    uninstall: ['dnf', 'remove', '-y', 'git', 'iptables-nft'],
+    // Plain `iptables` on purpose: EL8 ships it literally and has no `iptables-nft`, while
+    // Fedora/EL9+ resolve it through `iptables-nft`'s `Provides: iptables` (#5355).
+    install: ['dnf', 'install', '-y', 'git', 'iptables'],
+    uninstall: ['dnf', 'remove', '-y', 'git', 'iptables'],
     update: ['dnf', 'makecache'],
-    upgrade: ['dnf', 'upgrade', '-y', 'git', 'iptables-nft'],
+    upgrade: ['dnf', 'upgrade', '-y', 'git', 'iptables'],
     version: ['dnf', '--version'],
   },
   {

--- a/test/unit/core/package-managers/os-package-manager.test.ts
+++ b/test/unit/core/package-managers/os-package-manager.test.ts
@@ -13,21 +13,49 @@ function buildOsPackageManager(): OsPackageManager {
   return new OsPackageManager();
 }
 
-const detectionCases: Array<{name: string; osRelease: string; expectedManager: string}> = [
-  {name: 'Fedora', osRelease: 'ID=fedora\nVERSION_ID=40\n', expectedManager: 'DnfPackageManager'},
-  {name: 'Ubuntu', osRelease: 'ID=ubuntu\nID_LIKE=debian\n', expectedManager: 'AptGetPackageManager'},
-  {name: 'Debian', osRelease: 'ID=debian\n', expectedManager: 'AptGetPackageManager'},
+// `available` lists the package-manager binaries present on the simulated system's PATH.
+const detectionCases: Array<{name: string; osRelease: string; available: string[]; expectedManager: string}> = [
+  {name: 'Fedora', osRelease: 'ID=fedora\nVERSION_ID=40\n', available: ['dnf'], expectedManager: 'DnfPackageManager'},
+  {
+    name: 'Ubuntu',
+    osRelease: 'ID=ubuntu\nID_LIKE=debian\n',
+    available: ['apt-get'],
+    expectedManager: 'AptGetPackageManager',
+  },
+  {name: 'Debian', osRelease: 'ID=debian\n', available: ['apt-get'], expectedManager: 'AptGetPackageManager'},
   {
     name: 'openSUSE Leap',
     osRelease: 'ID="opensuse-leap"\nID_LIKE="suse opensuse"\n',
+    available: ['zypper'],
     expectedManager: 'ZypperPackageManager',
   },
-  {name: 'Arch', osRelease: 'ID=arch\n', expectedManager: 'PacmanPackageManager'},
-  {name: 'Alpine', osRelease: 'ID=alpine\n', expectedManager: 'ApkPackageManager'},
+  {name: 'Arch', osRelease: 'ID=arch\n', available: ['pacman'], expectedManager: 'PacmanPackageManager'},
+  {name: 'Alpine', osRelease: 'ID=alpine\n', available: ['apk'], expectedManager: 'ApkPackageManager'},
   {
     name: 'Rocky (matched via ID_LIKE)',
     osRelease: 'ID=rocky\nID_LIKE="rhel centos fedora"\n',
+    available: ['dnf'],
     expectedManager: 'DnfPackageManager',
+  },
+  // The yum-era distributions match the dnf map entries via ID/ID_LIKE but do not ship dnf; the
+  // mapped-but-absent manager must fall through to the binary probe and land on yum (#5355).
+  {
+    name: 'CentOS 7 (maps to dnf, ships only yum)',
+    osRelease: 'ID="centos"\nVERSION_ID="7"\nID_LIKE="rhel fedora"\n',
+    available: ['yum'],
+    expectedManager: 'YumPackageManager',
+  },
+  {
+    name: 'RHEL 7 (maps to dnf, ships only yum)',
+    osRelease: 'ID="rhel"\nVERSION_ID="7.9"\n',
+    available: ['yum'],
+    expectedManager: 'YumPackageManager',
+  },
+  {
+    name: 'Amazon Linux 2 (matches centos/rhel via ID_LIKE, ships only yum)',
+    osRelease: 'ID="amzn"\nVERSION_ID="2"\nID_LIKE="centos rhel fedora"\n',
+    available: ['yum'],
+    expectedManager: 'YumPackageManager',
   },
 ];
 
@@ -47,6 +75,11 @@ describe('OsPackageManager Linux distribution detection', (): void => {
   for (const detectionCase of detectionCases) {
     it(`selects ${detectionCase.expectedManager} for ${detectionCase.name}`, (): void => {
       sinon.stub(fs, 'readFileSync').returns(detectionCase.osRelease);
+      sinon.stub(fs, 'accessSync').callsFake((probedPath: fs.PathLike): void => {
+        if (!detectionCase.available.some((command: string): boolean => String(probedPath).endsWith(command))) {
+          throw new Error('not found');
+        }
+      });
       const osPackageManager: OsPackageManager = buildOsPackageManager();
       expect(osPackageManager.getPackageManager().constructor.name).to.equal(detectionCase.expectedManager);
     });


### PR DESCRIPTION
## Description

This pull request changes the following:

* `OsPackageManager` mapped `centos` and `rhel` (and, through `ID_LIKE`, Amazon Linux 2) straight to `dnf`, which made `YumPackageManager` unreachable: on RHEL 7-era systems dependency installs invoked a `dnf` binary that does not exist there and failed. The `/etc/os-release` mapping is now trusted only when the mapped manager's binary is actually present on the `PATH`; when it is not, resolution falls through to the binary probe that already existed, which lands on `yum` on those systems. This is deliberately a fix for the whole class of mapping-versus-reality mismatches rather than a special case per distribution, and it leaves every currently working distribution on exactly the manager it resolves to today.
* `DnfPackageManager` also rewrote `iptables` to `iptables-nft` for every dependency list, which is fatal on EL8 where no `iptables-nft` package exists. That rewrite has been removed. EL8 ships a real `iptables` package, and on Fedora and EL9+ `iptables-nft` carries `Provides: iptables`, so `dnf install iptables` resolves to the correct package on every release without the rewrite. A comment on the class records why a rewrite must not be reintroduced.
* The package-manager unit tests now pin which binaries are available per detection case, so the mapping and the probe are exercised independently, and three new cases cover CentOS 7, RHEL 7, and Amazon Linux 2 selecting `YumPackageManager`.

### Related Issues

* Fixes #5355

### Pull request (PR) checklist

* [x] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [ ] Any technical debt has been documented as a separate issue and linked to this PR
* [x] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [x] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [ ] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* None. The change is covered by unit tests that stub `/etc/os-release` and the set of installed binaries for each distribution case.

The following was not tested:

* A real install run on a live CentOS 7 / RHEL 7 / Amazon Linux 2 host, and a real `dnf install iptables` on EL8. Both paths are covered by unit tests at the resolution and command-construction level only.
