### PR TITLE
fix(ci): retry any setup or build step killed by its time budget

### DIFF
--- a/.github/workflows/zxf-transient-failure-retry.yaml
+++ b/.github/workflows/zxf-transient-failure-retry.yaml
@@ -34,6 +34,10 @@ on:
       - 'Install Validation (Podman Runtime)'
       - 'Performance Test Solo Deployment'
       - 'CodeQL'
+    # `completed` is the only usable activity type here: a workflow_run trigger fires regardless
+    # of the upstream conclusion and GitHub offers no conclusion filter, so the failure check has
+    # to live in the job condition below. The runs this creates for successful upstream workflows
+    # skip that condition and never occupy a runner.
     types:
       - completed
 

--- a/.github/workflows/zxf-transient-failure-retry.yaml
+++ b/.github/workflows/zxf-transient-failure-retry.yaml
@@ -85,18 +85,13 @@ jobs:
             const run = context.payload.workflow_run;
             const maxRunAttempts = Number(process.env.MAX_RUN_ATTEMPTS);
 
-            // Each rule needs a failed step whose name matches one of its prefixes (an empty list
-            // matches any failed step), the `required` signature present in the job log, and the
-            // `forbidden` signature absent. Matching on the log as well as the step name keeps a
+            // Signature rules for failures that are not step timeouts; timeouts are handled
+            // generically above. Each rule needs a failed step whose name matches one of its
+            // prefixes (an empty list matches any failed step), the `required` signature present
+            // in the job log, and the `forbidden` signature absent. Matching on the log as well as the step name keeps a
             // deterministic failure in an infrastructure step - a moved dependency version, a bad
             // ref, a compile error - from being retried, which only burns runners and hides the bug.
             const rules = [
-              {
-                description: 'checkout could not reach the remote',
-                stepPrefixes: ['checkout'],
-                required: /The action 'Checkout[^']*' has timed out after \d+ minutes?/,
-                forbidden: /fatal:|RPC failed|index-pack failed|Repository not found|could not read Username/,
-              },
               {
                 // The runner downloads every referenced action before the first step runs, so a
                 // stall at codeload.github.com fails the implicit `Set up job` step. The runner
@@ -107,15 +102,6 @@ jobs:
                 stepPrefixes: ['set up job'],
                 required: /Action '[^']*' download has timed out|Failed to download archive '[^']*' after \d+ attempts/,
                 forbidden: /Unable to resolve action|error TS\d{4}/,
-              },
-              {
-                // The distribution is fetched by `Setup WSL2`, by its retry, and by an explicit
-                // web-download fallback. Any of the three can be the step that runs out of time,
-                // so all three gate this rule: run 33757121299 timed out in the fallback alone.
-                description: 'WSL distribution download exceeded its budget',
-                stepPrefixes: ['setup wsl2', 'retry setup wsl2', 'install ubuntu wsl distribution fallback'],
-                required: /The action '(Setup WSL2|Retry Setup WSL2|Install Ubuntu WSL distribution fallback)' has timed out after \d+ minutes?/,
-                forbidden: /error TS\d{4}/,
               },
               {
                 description: 'kind could not bind a host port held by a leaked cluster',
@@ -130,6 +116,30 @@ jobs:
                 forbidden: /error TS\d{4}|Failed to run task "build:compile"/,
               },
             ];
+
+            // A step killed by its own `timeout-minutes` budget reports a generic error naming the
+            // step, and the API exposes no structured cause - a step carries only a name, a
+            // conclusion and timestamps - so this log line is the sole signal:
+            //
+            //   ##[error]The action 'Setup Node' has timed out after 5 minutes.
+            //
+            // Steps that prepare the environment - fetching sources, toolchains, packages, images -
+            // run out of time because the network stalled, and a fresh runner is the remedy, so any
+            // of them is retried without needing a rule of its own. Steps that execute Solo are
+            // excluded: `Run E2E Tests` timed out in four of the audited logs and every one was a
+            // reproducible product hang, so retrying those would only hide the bug.
+            const environmentStepPattern =
+              /^(set up job|harden runner|checkout|set ?up|install|configure|bootstrap|restore|retry)\b/i;
+
+            // A setup step can also fail for a settled reason no rerun will change - a bad ref or
+            // credentials, an unresolvable action, a compile error - which vetoes a timeout retry.
+            const settledFailurePattern =
+              /fatal:|RPC failed|index-pack failed|Repository not found|could not read Username|Unable to resolve action|error TS\d{4}/;
+
+            const escapeForRegExp = (text) => text.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+            const stepRanOutOfTime = (stepName, log) =>
+              new RegExp(`The action '${escapeForRegExp(stepName)}' has timed out after \\d+ minutes?`).test(log);
 
             const readJobLog = async (jobId) => {
               try {
@@ -178,15 +188,18 @@ jobs:
             const reasons = [];
 
             for (const job of failedJobs) {
-              const failedStepNames = (job.steps ?? [])
-                .filter(step => step.conclusion === 'failure')
-                .map(step => step.name.toLowerCase());
+              // Rule prefixes compare lower case, but the timeout error quotes the step name
+              // exactly as written, so the original casing has to survive.
+              const failedSteps = (job.steps ?? []).filter(step => step.conclusion === 'failure').map(step => step.name);
+              const failedStepNames = failedSteps.map(name => name.toLowerCase());
 
               const candidates = rules.filter(rule =>
                 rule.stepPrefixes.length === 0 ||
                 failedStepNames.some(name => rule.stepPrefixes.some(prefix => name.startsWith(prefix))));
 
-              if (candidates.length === 0) {
+              const environmentSteps = failedSteps.filter(name => environmentStepPattern.test(name));
+
+              if (candidates.length === 0 && environmentSteps.length === 0) {
                 continue;
               }
 
@@ -198,6 +211,12 @@ jobs:
               const matched = candidates.find(rule => rule.required.test(log) && !rule.forbidden.test(log));
               if (matched) {
                 reasons.push(`${job.name}: ${matched.description}`);
+                continue;
+              }
+
+              const timedOutStep = environmentSteps.find(name => stepRanOutOfTime(name, log));
+              if (timedOutStep && !settledFailurePattern.test(log)) {
+                reasons.push(`${job.name}: '${timedOutStep}' exceeded its time budget`);
               }
             }
 

--- a/.github/workflows/zxf-transient-failure-retry.yaml
+++ b/.github/workflows/zxf-transient-failure-retry.yaml
@@ -123,15 +123,27 @@ jobs:
             //
             //   ##[error]The action 'Setup Node' has timed out after 5 minutes.
             //
-            // Steps that prepare the environment - fetching sources, toolchains, packages, images -
-            // run out of time because the network stalled, and a fresh runner is the remedy, so any
-            // of them is retried without needing a rule of its own. Steps that execute Solo are
-            // excluded: `Run E2E Tests` timed out in four of the audited logs and every one was a
-            // reproducible product hang, so retrying those would only hide the bug.
-            const environmentStepPattern =
-              /^(set up job|harden runner|checkout|set ?up|install|configure|bootstrap|restore|retry)\b/i;
+            // Two families of step are retried when they run out of time, so neither needs a rule
+            // of its own. Steps that prepare the environment - fetching sources, toolchains,
+            // packages, images - stall on the network, and a fresh runner is the remedy. Steps that
+            // build the project stall the same way: a successful `Compile Project` averages 30
+            // seconds against a 300 second budget, so exhausting that budget is a ten-fold
+            // deviation - a stall in `npm ci` or in `npx tsc` - rather than a slow build. A real
+            // compile error fails in seconds instead, and `error TS####` vetoes the retry anyway.
+            //
+            // Steps that execute Solo are excluded: `Run E2E Tests` timed out in four of the
+            // audited logs and every one was a reproducible product hang, so retrying those would
+            // only hide the bug.
+            // A step that runs or serves something can occupy its whole budget by design or hang on a
+            // product bug, so it is never retried even when its name opens with a retryable verb.
+            // `Build and Start Metrics Plotter tool` is the case that matters: it leaves a
+            // foreground server listening on 127.0.0.1:8123 and can only ever end by timing out.
+            const longRunningStepPattern = /\b(start|serve|run|test|deploy|destroy|launch|migrate)\b/i;
 
-            // A setup step can also fail for a settled reason no rerun will change - a bad ref or
+            const retryableStepPattern =
+              /^(set up job|harden runner|checkout|set ?up|install|configure|bootstrap|restore|retry|build|compile|pack)\b/i;
+
+            // Such a step can also fail for a settled reason no rerun will change - a bad ref or
             // credentials, an unresolvable action, a compile error - which vetoes a timeout retry.
             const settledFailurePattern =
               /fatal:|RPC failed|index-pack failed|Repository not found|could not read Username|Unable to resolve action|error TS\d{4}/;
@@ -197,9 +209,10 @@ jobs:
                 rule.stepPrefixes.length === 0 ||
                 failedStepNames.some(name => rule.stepPrefixes.some(prefix => name.startsWith(prefix))));
 
-              const environmentSteps = failedSteps.filter(name => environmentStepPattern.test(name));
+              const retryableSteps = failedSteps.filter(
+                name => retryableStepPattern.test(name) && !longRunningStepPattern.test(name));
 
-              if (candidates.length === 0 && environmentSteps.length === 0) {
+              if (candidates.length === 0 && retryableSteps.length === 0) {
                 continue;
               }
 
@@ -214,7 +227,7 @@ jobs:
                 continue;
               }
 
-              const timedOutStep = environmentSteps.find(name => stepRanOutOfTime(name, log));
+              const timedOutStep = retryableSteps.find(name => stepRanOutOfTime(name, log));
               if (timedOutStep && !settledFailurePattern.test(log)) {
                 reasons.push(`${job.name}: '${timedOutStep}' exceeded its time budget`);
               }

--- a/.github/workflows/zxf-transient-failure-retry.yaml
+++ b/.github/workflows/zxf-transient-failure-retry.yaml
@@ -94,6 +94,17 @@ jobs:
                 forbidden: /fatal:|RPC failed|index-pack failed|Repository not found|could not read Username/,
               },
               {
+                // The runner downloads every referenced action before the first step runs, so a
+                // stall at codeload.github.com fails the implicit `Set up job` step. The runner
+                // has already retried internally ("after 3 attempts"), so the archive is
+                // genuinely unreachable rather than misreferenced; a bad ref reports "Unable to
+                // resolve action" instead and must not be retried.
+                description: 'action archive download timed out',
+                stepPrefixes: ['set up job'],
+                required: /Action '[^']*' download has timed out|Failed to download archive '[^']*' after \d+ attempts/,
+                forbidden: /Unable to resolve action|error TS\d{4}/,
+              },
+              {
                 // The distribution is fetched by `Setup WSL2`, by its retry, and by an explicit
                 // web-download fallback. Any of the three can be the step that runs out of time,
                 // so all three gate this rule: run 33757121299 timed out in the fallback alone.


### PR DESCRIPTION
## Description

This pull request changes the following:

* **Replaces the per-step timeout rules with one generic check.** Any step that runs out of its `timeout-minutes` budget is retried, provided it is a step that prepares the environment or builds the project. This removes the dedicated checkout and WSL rules, which it subsumes, so adding a rule per step name is no longer necessary.
* **Adds a rule for the runner's implicit `Set up job` step**, so a stalled action-archive download is retried.
* **Excludes steps that run or serve something**, so a product hang is never retried.
* Documents, in the workflow itself, why the failed-run check has to live in the job condition rather than the trigger.

### Why a generic check

Adding a rule per step name did not scale — each new stall needed its own rule, and three arrived in as many days: `Install Ubuntu WSL distribution fallback`, then `Setup Node`, then `Install Dependencies`.

GitHub reports no structured cause for a timeout: a step carries only a name, a conclusion and timestamps, and a timed-out step is indistinguishable from any other failure. The log line, however, names the step and is otherwise generic:

```
##[error]The action 'Setup Node' has timed out after 5 minutes.
```

So the check now builds that pattern from the name of the step that actually failed.

**Retried** when such a step runs out of time — name opens with `set up job`, `harden runner`, `checkout`, `setup`/`set up`, `install`, `configure`, `bootstrap`, `restore`, `retry`, `build`, `compile` or `pack`.

**Never retried**, even when the name opens with one of those verbs — name contains `start`, `serve`, `run`, `test`, `deploy`, `destroy`, `launch` or `migrate`. `Build and Start Metrics Plotter tool` is the case that matters: it leaves a foreground server listening on `127.0.0.1:8123` and prints `Hit CTRL-C to stop the server`, so it can only ever end by timing out and a rerun would fail identically.

**Vetoed** by a settled-failure signature in the log — `fatal:`, `RPC failed`, `index-pack failed`, `Repository not found`, `could not read Username`, `Unable to resolve action`, `error TS####` — so a bad ref, missing credentials, an unresolvable action or a compile error is never retried even when a covered step is the one that failed.

### Why build steps count as transient

A stalled build was by far the largest unretried transient: in one six-hour window, **48 jobs** ran out of time in `Compile Project`, `Build Application` or `Build Project`, against a single job retried for a setup step.

These are stalls, not slow builds:

* A successful compile averages **30 seconds** (n=52, range 21s–237s) against a **300 second** budget, so exhausting the budget is a ten-fold deviation.
* The logs show the step sitting in `npm ci` or in `npx tsc` when the budget expires; on Windows, `task: Failed to run task "npm:install": exit status 58`.
* A genuine compile error fails in seconds instead — and is vetoed by `error TS####` regardless.
* The jobs cluster in time (34 in one hour, 19 the next, then 2) and almost all ran on the self-hosted pool, which points at the pool rather than at any branch. None of the 176 job logs from the previous week contain a build timeout at all.

### The `Set up job` rule

The runner downloads every referenced action before the first step of a job runs, so a stall at `codeload.github.com` fails the implicit `Set up job` step, which no rule covered:

```
##[error]Action 'https://codeload.github.com/hiero-ledger/solo/tar.gz/3a17a70b6' download has timed out.
   Error: The request was canceled due to the configured HttpClient.Timeout of 100 seconds elapsing.
##[error]Failed to download archive 'https://codeload.github.com/...' after 3 attempts.
```

The runner had already retried three times internally, so the archive was genuinely unreachable rather than misreferenced. A misreferenced action reports `Unable to resolve action`, which the veto excludes.

### On triggering only for completed *and* failed runs

This is already the behaviour, but it cannot be expressed in the trigger. Per the [GitHub documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows): *"A workflow run is triggered regardless of the conclusion of the previous workflow. If you want to run a job or step based on the result of the triggering workflow, you can use a conditional with the `github.event.workflow_run.conclusion` property."*

`workflow_run` accepts only `workflows`, `types` (`requested`, `in_progress`, `completed`) and `branches`/`branches-ignore` — there is no conclusion filter. The job condition already requires a completed run that concluded in failure from a pull request, so the runs created for successful upstream workflows skip that condition and never occupy a runner; they cost nothing beyond an entry in the run list. A comment in the workflow now records this.

### Reviewer note on load

Had this been live during the six-hour window analysed above, it would have issued roughly 50 reruns onto the self-hosted pool that was already degraded. The three-attempt cap bounds each run, not the fleet. That trade-off is deliberate: those jobs were red and would have been rerun by hand anyway.

### Related Issues

* Related to #5954
* No issue filed; this came out of runs on `ci/wsl-installer-cache-recovery` and `5370-solo---version-throws-a-bunch-of-solo-9007-warnings` that were not retried

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[x] This PR updated documentation
* \[x] This PR added no TODOs or commented out code
* \[x] This PR has no breaking changes
* \[x] Any technical debt has been documented as a separate issue and linked to this PR
* \[x] Any `package.json` changes have been explained to and approved by a repository manager
* \[x] All related issues have been linked to this PR
* \[x] All changes in this PR are included in the description
* \[x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

The unchecked box: the repository has no harness for executing workflow YAML, so the logic was verified by simulating the embedded script against real GitHub API payloads and real job logs, as documented below.

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[x] These changes required manual testing that is documented below
* \[x] Anything not tested is documented

The following manual testing was done:

* **Every reported failure replayed against the updated workflow**, using each run's real `listJobsForWorkflowRun` payload and real job logs:

| Run | Failed step | Expected | Result |
|---|---|---|---|
| `33861664433` | `Build Project` timed out | rerun | rerun |
| `33861664432` | `Install Dependencies` timed out | rerun | rerun (both GCS jobs) |
| `33861664388` | `Build Application` timed out | rerun | rerun (all three jobs) |
| `33877470559` | `Setup Node` timed out | rerun | rerun |
| `33877470260` | `Checkout Code` timed out | rerun | rerun |
| `33757121299` | `Install Ubuntu WSL distribution fallback` timed out | rerun | rerun |
| `33877470287` | `Set up job` — archive download timed out | rerun | rerun |
| `33866004182` | `Run E2E Tests` timed out after 35 min | no rerun | no rerun |
| `33376447381` | `Run E2E Tests` timed out after 40 min | no rerun | no rerun |

  The checkout and WSL cases confirm the rules deleted in this PR were genuinely subsumed.

* **Sweep of every timing-out step in a six-hour window** (56 occurrences), to see the split the rule produces:

```
RETRIED:      29 Compile Project · 15 Build Application · 4 Build Project · 2 Setup WSL2
              2 Install Ubuntu WSL distribution fallback · 2 Install Dependencies · 1 Pack Solo
NOT RETRIED:  1 Run E2E Tests · 1 Build and Start Metrics Plotter tool
```

* **Full analysis of all 34 failed runs in that window** confirmed the failures left alone are genuine: `Validate System-Dependency Install` exit 201 across nine distros, an ESLint `no-unused-vars` error in `Pack Solo`, `Install grpcurl` Go module resolution, an invalid workflow template, and `Launch Network with Prior Release 0.87.1`.
* **Regression suite** — the twelve-scenario simulation still passes 12/12, including every guard that must refuse a rerun: deterministic `grpcurl` toolchain pin, genuine E2E failures, unit-test fixtures, cancelled and interrupted runs, mixed transient/genuine runs, non-pull-request runs and the attempt cap.
* **False-positive checks** — the `Set up job` pattern matches exactly one of 175 retained job logs, the intended one. Gating on step names also keeps the rules clear of the unit tests, which embed infrastructure error strings such as `ImagePullBackOff` and `connection reset by peer` as *passing*-test fixtures.
* **Static validation** — the YAML parses, the embedded `github-script` body parses as JavaScript, and the file is Prettier-clean.

The following was not tested:

* Live behaviour after merge — `workflow_run` only acts on the copy of the workflow on the default branch, so the first real exercise is the first matching failure after merge.
* `rerun-failed-jobs` requires a **completed** run, so a retry cannot fire when a job fails, only when the whole run concludes. For a long matrix that means a minute-one checkout failure waits for the rest of the run. Reducing that latency would need a different mechanism and is not attempted here.
* `Build and Start Metrics Plotter tool` looks like a workflow bug in its own right — a foreground server that never exits, so the step always times out. This PR only stops it being retried; it does not fix it.

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)