### PR TITLE
fix: load component images only into the component's target Kind clusters

### DIFF
--- a/src/commands/base.ts
+++ b/src/commands/base.ts
@@ -318,20 +318,17 @@ export abstract class BaseCommand extends ShellRunner {
     return checkDockerImageExists(name, tag);
   }
 
-  protected async kindLoadComponentImage(componentImage: string, clusterContext: string): Promise<void> {
-    const additionalKindContexts: Context[] = this.remoteConfig
-      .getContexts()
-      .filter((context: Context): boolean => context.startsWith('kind-') && context !== clusterContext);
-    const targetContexts: Context[] = [...new Set<Context>([clusterContext, ...additionalKindContexts])];
-    const nonKindContexts: Context[] = targetContexts.filter(
-      (context: Context): boolean => !context.startsWith('kind-'),
-    );
-
-    if (nonKindContexts.length > 0) {
+  /** Loads a local component image into the required cluster context's Kind cluster, then best-effort into any additional Kind contexts. */
+  protected async kindLoadComponentImage(
+    componentImage: string,
+    clusterContext: string,
+    additionalContexts: Context[] = [],
+  ): Promise<void> {
+    if (!clusterContext.startsWith('kind-')) {
       throw new SoloErrors.validation.illegalArgument(
-        `Component image '${componentImage}' requires Kind image loading, but target cluster context(s) ` +
-          `'${nonKindContexts.join("', '")}' are not Kind clusters. Push the image to a registry reachable ` +
-          'from every target cluster and pass that registry image reference to --component-image.',
+        `Component image '${componentImage}' requires Kind image loading, but target cluster context ` +
+          `'${clusterContext}' is not a Kind cluster. Push the image to a registry reachable ` +
+          'from the target cluster and pass that registry image reference to --component-image.',
         componentImage,
       );
     }
@@ -339,14 +336,42 @@ export abstract class BaseCommand extends ShellRunner {
     const kindExecutable: string = await this.depManager.getExecutable(constants.KIND);
     const kindClient: KindClient = await this.kindBuilder.executable(kindExecutable).build();
 
-    for (const targetContext of targetContexts) {
-      const kindClusterName: string = this.kindClusterNameFromContext(targetContext);
-      this.logger.debug(`Loading '${componentImage}' into Kind cluster '${kindClusterName}'`);
-      await kindClient.loadDockerImage(
-        componentImage,
-        LoadDockerImageOptionsBuilder.builder().name(kindClusterName).build(),
-      );
+    await this.loadImageIntoKindContext(kindClient, componentImage, clusterContext);
+
+    const extraContexts: Context[] = [...new Set<Context>(additionalContexts)].filter(
+      (context: Context): boolean => context !== clusterContext,
+    );
+    for (const targetContext of extraContexts) {
+      if (!targetContext.startsWith('kind-')) {
+        this.logger.warn(
+          `Skipping preload of component image '${componentImage}' into non-Kind cluster context ` +
+            `'${targetContext}'; components deployed there must pull the image from a registry.`,
+        );
+        continue;
+      }
+      try {
+        await this.loadImageIntoKindContext(kindClient, componentImage, targetContext);
+      } catch (error) {
+        // best-effort: a stale or unreachable additional Kind context must not fail the deploy to the required cluster
+        this.logger.warn(
+          `Failed to preload component image '${componentImage}' into Kind cluster context '${targetContext}'; continuing`,
+          error,
+        );
+      }
     }
+  }
+
+  private async loadImageIntoKindContext(
+    kindClient: KindClient,
+    componentImage: string,
+    targetContext: Context,
+  ): Promise<void> {
+    const kindClusterName: string = this.kindClusterNameFromContext(targetContext);
+    this.logger.debug(`Loading '${componentImage}' into Kind cluster '${kindClusterName}'`);
+    await kindClient.loadDockerImage(
+      componentImage,
+      LoadDockerImageOptionsBuilder.builder().name(kindClusterName).build(),
+    );
   }
 
   protected async throwIfNamespaceIsMissing(context: Context, namespace: NamespaceName): Promise<void> {

--- a/test/unit/commands/base.test.ts
+++ b/test/unit/commands/base.test.ts
@@ -31,7 +31,12 @@ import {type KindClient} from '../../../src/integration/kind/kind-client.js';
 
 interface BaseCommandInternal {
   isLocalImageReference: (imageReference: string) => boolean;
-  kindLoadComponentImage: (componentImage: string, clusterContext: string) => Promise<void>;
+  kindLoadComponentImage: (
+    componentImage: string,
+    clusterContext: string,
+    additionalContexts?: Context[],
+  ) => Promise<void>;
+  logger: SoloLogger;
   remoteConfig: {getContexts: () => Context[]};
   depManager: {getExecutable: (dependency: string) => Promise<string>};
   kindBuilder: {
@@ -312,11 +317,17 @@ describe('BaseCommand', (): void => {
   });
 
   describe('kindLoadComponentImage', (): void => {
-    it('should load a local image into every Kind target context', async (): Promise<void> => {
-      const baseCommandInternal: BaseCommandInternal = baseCmd as unknown as BaseCommandInternal;
-      const loadDockerImageStub: SinonStub = sinon.stub().resolves();
+    let baseCommandInternal: BaseCommandInternal;
+    let loadDockerImageStub: SinonStub;
+    let warnStub: SinonStub;
+
+    beforeEach((): void => {
+      baseCommandInternal = baseCmd as unknown as BaseCommandInternal;
+      loadDockerImageStub = sinon.stub().resolves();
+      warnStub = sinon.stub();
       const kindClient: KindClient = {loadDockerImage: loadDockerImageStub} as unknown as KindClient;
 
+      baseCommandInternal.logger = {warn: warnStub, debug: sinon.stub()} as unknown as SoloLogger;
       baseCommandInternal.remoteConfig = {
         getContexts: (): Context[] => ['kind-first', 'kind-second'],
       };
@@ -332,8 +343,21 @@ describe('BaseCommand', (): void => {
           return {build: async (): Promise<KindClient> => kindClient};
         },
       };
+    });
 
+    it('should load a local image only into the caller-supplied Kind context', async (): Promise<void> => {
       await baseCommandInternal.kindLoadComponentImage('block-node-server:0.38.0', 'kind-first');
+
+      expect(loadDockerImageStub).to.have.been.calledOnce;
+      expect(loadDockerImageStub).to.have.been.calledWith('block-node-server:0.38.0', sinon.match.has('name', 'first'));
+      expect(warnStub).to.not.have.been.called;
+    });
+
+    it('should preload additional Kind contexts and deduplicate the caller-supplied context', async (): Promise<void> => {
+      await baseCommandInternal.kindLoadComponentImage('block-node-server:0.38.0', 'kind-first', [
+        'kind-first',
+        'kind-second',
+      ]);
 
       expect(loadDockerImageStub).to.have.been.calledTwice;
       expect(loadDockerImageStub).to.have.been.calledWith('block-node-server:0.38.0', sinon.match.has('name', 'first'));
@@ -341,48 +365,60 @@ describe('BaseCommand', (): void => {
         'block-node-server:0.38.0',
         sinon.match.has('name', 'second'),
       );
+      expect(warnStub).to.not.have.been.called;
     });
 
-    it('should ignore non-Kind deployment contexts when loading a local image onto a selected Kind context', async (): Promise<void> => {
-      const baseCommandInternal: BaseCommandInternal = baseCmd as unknown as BaseCommandInternal;
-      const loadDockerImageStub: SinonStub = sinon.stub().resolves();
-      const kindClient: KindClient = {loadDockerImage: loadDockerImageStub} as unknown as KindClient;
+    it('should warn and continue when preloading into a stale additional Kind context fails', async (): Promise<void> => {
+      loadDockerImageStub
+        .withArgs('block-node-server:0.38.0', sinon.match.has('name', 'stale'))
+        .rejects(new Error('failed to list nodes for cluster "stale"'));
 
-      baseCommandInternal.remoteConfig = {
-        getContexts: (): Context[] => ['remote-cluster', 'kind-first'],
-      };
-      baseCommandInternal.depManager = {
-        getExecutable: async (dependency: string): Promise<string> => {
-          expect(dependency).to.equal('kind');
-          return 'kind';
-        },
-      };
-      baseCommandInternal.kindBuilder = {
-        executable: (executable: string): {build: () => Promise<KindClient>} => {
-          expect(executable).to.equal('kind');
-          return {build: async (): Promise<KindClient> => kindClient};
-        },
-      };
+      await baseCommandInternal.kindLoadComponentImage('block-node-server:0.38.0', 'kind-first', [
+        'kind-stale',
+        'kind-second',
+      ]);
 
-      await baseCommandInternal.kindLoadComponentImage('block-node-server:0.38.0', 'kind-first');
+      expect(loadDockerImageStub).to.have.been.calledThrice;
+      expect(loadDockerImageStub).to.have.been.calledWith('block-node-server:0.38.0', sinon.match.has('name', 'first'));
+      expect(loadDockerImageStub).to.have.been.calledWith(
+        'block-node-server:0.38.0',
+        sinon.match.has('name', 'second'),
+      );
+      expect(warnStub).to.have.been.calledOnce;
+      expect(warnStub.firstCall.args[0]).to.include('kind-stale');
+    });
+
+    it('should skip non-Kind additional contexts with a warning', async (): Promise<void> => {
+      await baseCommandInternal.kindLoadComponentImage('block-node-server:0.38.0', 'kind-first', ['remote-cluster']);
 
       expect(loadDockerImageStub).to.have.been.calledOnce;
       expect(loadDockerImageStub).to.have.been.calledWith('block-node-server:0.38.0', sinon.match.has('name', 'first'));
+      expect(warnStub).to.have.been.calledOnce;
+      expect(warnStub.firstCall.args[0]).to.include('remote-cluster');
+    });
+
+    it('should fail when loading into the caller-supplied Kind context fails', async (): Promise<void> => {
+      loadDockerImageStub
+        .withArgs('block-node-server:0.38.0', sinon.match.has('name', 'first'))
+        .rejects(new Error('failed to list nodes for cluster "first"'));
+
+      await expect(
+        baseCommandInternal.kindLoadComponentImage('block-node-server:0.38.0', 'kind-first', ['kind-second']),
+      ).to.be.rejectedWith('failed to list nodes for cluster "first"');
+
+      expect(loadDockerImageStub).to.have.been.calledOnce;
     });
 
     it('should explain how to make an image available to a non-Kind target context', async (): Promise<void> => {
-      const baseCommandInternal: BaseCommandInternal = baseCmd as unknown as BaseCommandInternal;
-      baseCommandInternal.remoteConfig = {
-        getContexts: (): Context[] => ['kind-first'],
-      };
-
       await expect(
         baseCommandInternal.kindLoadComponentImage('block-node-server:0.38.0', 'remote-cluster'),
       ).to.be.rejectedWith(
-        "Component image 'block-node-server:0.38.0' requires Kind image loading, but target cluster context(s) " +
-          "'remote-cluster' are not Kind clusters. Push the image to a registry reachable from every target " +
+        "Component image 'block-node-server:0.38.0' requires Kind image loading, but target cluster context " +
+          "'remote-cluster' is not a Kind cluster. Push the image to a registry reachable from the target " +
           'cluster and pass that registry image reference to --component-image.',
       );
+
+      expect(loadDockerImageStub).to.not.have.been.called;
     });
   });
 


### PR DESCRIPTION
## Description

`BaseCommand.kindLoadComponentImage` (introduced in #5949) preloaded a local `--component-image` into every `kind-*` context returned by `remoteConfig.getContexts()`, because remote config only exposes consensus-node contexts, not the contexts a component actually deploys to. As a result a stale `kind-*` consensus context failed the whole component deploy even though it is not required for correctness, and the extra-context preloading was not truly best-effort since the load loop had no per-context error handling.

This change makes the caller-supplied cluster context the only required load target:

- The remote-config fan-out is removed; the image is loaded only into the contexts the caller passes. All four call sites (relay, mirror-node, explorer, block-node) already pass their actual deployment target context, so only that cluster is loaded.
- A new optional `additionalContexts` parameter supports components that target multiple clusters. Loads into these contexts are best-effort: a failed load (for example a stale or unreachable Kind context) or a non-Kind context logs a warning and continues instead of failing the deploy.
- The non-Kind guidance error now applies only to the required caller-supplied context and reads in the singular.

## Related Issues

Fixes #5964