### PR TITLE
fix: retry transient download failures with a longer capped exponential backoff

### DIFF
--- a/src/core/package-downloader.ts
+++ b/src/core/package-downloader.ts
@@ -28,7 +28,9 @@ const DOWNLOAD_RETRY_LIMIT_ENV: string = 'PACKAGE_DOWNLOADER_RETRY_LIMIT';
 const DEFAULT_URL_EXISTS_TIMEOUT: Duration = Duration.ofSeconds(5);
 const DEFAULT_DOWNLOAD_CONNECT_TIMEOUT: Duration = Duration.ofSeconds(10);
 const DEFAULT_DOWNLOAD_RESPONSE_TIMEOUT: Duration = Duration.ofMinutes(2);
-const DEFAULT_DOWNLOAD_RETRY_LIMIT: number = 3;
+const DEFAULT_DOWNLOAD_RETRY_LIMIT: number = 6;
+const DOWNLOAD_RETRY_BASE_DELAY: Duration = Duration.ofSeconds(2);
+const DOWNLOAD_RETRY_MAX_DELAY: Duration = Duration.ofSeconds(32);
 
 @injectable()
 export class PackageDownloader {
@@ -191,7 +193,11 @@ export class PackageDownloader {
           fs.rmSync(destinationPath);
         }
         if (attempt < retryLimit) {
-          const delayMs: number = 2000 * attempt;
+          // capped exponential backoff so a transient upstream outage (e.g. a GitHub 5xx blip) can pass
+          const delayMs: number = Math.min(
+            DOWNLOAD_RETRY_BASE_DELAY.toMillis() * 2 ** (attempt - 1),
+            DOWNLOAD_RETRY_MAX_DELAY.toMillis(),
+          );
           this.logger.warn(`Download attempt ${attempt}/${retryLimit} failed, retrying in ${delayMs}ms: ${url}`, error);
           await new Promise<void>((resolve): void => {
             setTimeout(resolve, delayMs);

--- a/test/unit/core/package-downloader.test.ts
+++ b/test/unit/core/package-downloader.test.ts
@@ -2,7 +2,7 @@
 
 import {expect} from 'chai';
 import {describe, it} from 'mocha';
-import sinon, {type SinonSandbox, type SinonStub} from 'sinon';
+import sinon, {type SinonFakeTimers, type SinonSandbox, type SinonStub} from 'sinon';
 import {Readable} from 'node:stream';
 import got, {type OptionsInit} from 'got';
 
@@ -30,6 +30,7 @@ describe('PackageDownloader', (): void => {
     delete process.env.PACKAGE_DOWNLOADER_URL_EXISTS_TIMEOUT_MS;
     delete process.env.PACKAGE_DOWNLOADER_DOWNLOAD_CONNECT_TIMEOUT_MS;
     delete process.env.PACKAGE_DOWNLOADER_DOWNLOAD_RESPONSE_TIMEOUT_MS;
+    delete process.env.PACKAGE_DOWNLOADER_RETRY_LIMIT;
     sandbox.restore();
   });
 
@@ -133,6 +134,40 @@ describe('PackageDownloader', (): void => {
       expect(fs.readFileSync(destinationPath, 'utf8')).to.equal('payload');
       expect(urlExistsStub.calledOnce).to.equal(true);
       expect(gotStreamStub.calledOnce).to.equal(true);
+
+      fs.rmSync(temporaryDirectory, {recursive: true, force: true});
+    });
+
+    it('should retry transient download failures with capped exponential backoff', async (): Promise<void> => {
+      process.env.PACKAGE_DOWNLOADER_RETRY_LIMIT = '7';
+      const clock: SinonFakeTimers = sandbox.useFakeTimers({toFake: ['setTimeout']});
+      const temporaryDirectory: string = fs.mkdtempSync(PathEx.join(os.tmpdir(), 'downloader-'));
+      const destinationPath: string = PathEx.join(temporaryDirectory, 'artifact.txt');
+      sandbox.stub(downloader, 'urlExists').resolves(true);
+      const gotStreamStub: SinonStub = sandbox.stub(got, 'stream').callsFake((): ReturnType<typeof got.stream> => {
+        if (gotStreamStub.callCount < 7) {
+          throw new Error(`transient failure ${gotStreamStub.callCount}`);
+        }
+        return Readable.from(['payload']) as ReturnType<typeof got.stream>;
+      });
+
+      const pendingFetch: Promise<string> = downloader.fetchFile('https://example.com/artifact.txt', destinationPath);
+      pendingFetch.catch((): void => {
+        // suppress unhandled rejection warnings while the fake clock is advanced; awaited below
+      });
+
+      const expectedDelays: number[] = [2000, 4000, 8000, 16_000, 32_000, 32_000];
+      let expectedAttempts: number = 1;
+      for (const delay of expectedDelays) {
+        await clock.tickAsync(delay - 1);
+        expect(gotStreamStub.callCount).to.equal(expectedAttempts);
+        await clock.tickAsync(1);
+        expectedAttempts++;
+        expect(gotStreamStub.callCount).to.equal(expectedAttempts);
+      }
+
+      await expect(pendingFetch).to.eventually.equal(destinationPath);
+      expect(fs.readFileSync(destinationPath, 'utf8')).to.equal('payload');
 
       fs.rmSync(temporaryDirectory, {recursive: true, force: true});
     });


### PR DESCRIPTION
## Description

Fixes #5976

The **Docs Automation / Command Output** run failed because the kind checksum download (`kind-linux-amd64.sha256sum`, redirected to GitHub releases) hit transient HTTP 500 responses. `PackageDownloader.fetchFile()` retried only 3 times with linear 2s/4s delays, giving a total retry window of ~6 seconds — far shorter than a typical transient GitHub outage.

### Changes

- Raise the default download retry limit from 3 to 6 attempts (still overridable via `PACKAGE_DOWNLOADER_RETRY_LIMIT`).
- Replace the linear `2000 * attempt` delay with capped exponential backoff (2s, 4s, 8s, 16s, 32s, capped at 32s), mirroring the existing pattern in `GitHubApiClient`. The total retry window grows from ~6s to ~62s, enough to ride out a short upstream 5xx blip.
- Add a unit test that drives the retry loop with fake timers and asserts the exact backoff schedule, including the cap.

### Testing

- `npx mocha 'test/unit/core/package-downloader.test.ts'` — 23 passing
- `task build` — clean (0 errors)