### PR TITLE
fix: detect Kind clusters through kubeconfig cluster entries for renamed contexts

### DIFF
--- a/src/business/runtime-state/config/remote/remote-config-runtime-state.ts
+++ b/src/business/runtime-state/config/remote/remote-config-runtime-state.ts
@@ -77,9 +77,6 @@ interface VersionField {
 export class RemoteConfigRuntimeState implements RemoteConfigRuntimeStateApi {
   private static readonly SOLO_REMOTE_CONFIGMAP_DATA_KEY: string = 'remote-config-data';
 
-  /** Kind names the kubeconfig context it writes `kind-<cluster-name>`. */
-  private static readonly KIND_CONTEXT_PREFIX: string = 'kind-';
-
   /** How long to wait for a resumed kind cluster's API: 30 attempts every 2 seconds, so at most a minute. */
   private static readonly KIND_RESUME_MAX_ATTEMPTS: number = 30;
   private static readonly KIND_RESUME_RETRY_INTERVAL: Duration = Duration.ofSeconds(2);
@@ -341,15 +338,16 @@ export class RemoteConfigRuntimeState implements RemoteConfigRuntimeStateApi {
       }
 
       // A kind cluster runs on this machine, so a failure there is a local problem rather than a cluster solo
-      // cannot reach — and the usual local problem is a node container that is simply stopped. Kind names its
-      // kubeconfig context `kind-<cluster-name>`, the same heuristic the one-shot deploy orchestrator uses.
+      // cannot reach — and the usual local problem is a node container that is simply stopped. Detection
+      // follows the `kind-<cluster-name>` names kind writes into the kubeconfig, including renamed contexts.
       // Either way the original failure is kept as the cause so the real reason (context down, RBAC denial,
       // API error) reaches the error output and the logs.
-      if (!context.startsWith(RemoteConfigRuntimeState.KIND_CONTEXT_PREFIX)) {
+      const kindClusterName: string | undefined = Helpers.kindClusterNameForContext(context, this.k8Factory);
+      if (kindClusterName === undefined) {
         throw new SoloErrors.system.clusterUnreachable(context, error);
       }
 
-      configMap = await this.resumeKindClusterAndRead(namespace, context, error);
+      configMap = await this.resumeKindClusterAndRead(namespace, kindClusterName, context, error);
     }
     if (!configMap) {
       throw new SoloErrors.system.resourceNotFound(
@@ -372,11 +370,16 @@ export class RemoteConfigRuntimeState implements RemoteConfigRuntimeStateApi {
    * failure is reported unchanged, so this never turns an unrelated API failure into a long wait.
    *
    * @param namespace - the namespace holding the remote config ConfigMap.
+   * @param clusterName - the kind cluster name the failed context targets.
    * @param context - the kind kubeconfig context the read failed against.
    * @param cause - the failure that triggered the recovery attempt.
    */
-  private async resumeKindClusterAndRead(namespace: NamespaceName, context: Context, cause: Error): Promise<ConfigMap> {
-    const clusterName: string = context.slice(RemoteConfigRuntimeState.KIND_CONTEXT_PREFIX.length);
+  private async resumeKindClusterAndRead(
+    namespace: NamespaceName,
+    clusterName: string,
+    context: Context,
+    cause: Error,
+  ): Promise<ConfigMap> {
     const outcome: ClusterNodeResumeOutcome = await this.containerEngine.resumeStoppedClusterNode(clusterName);
 
     if (outcome === ClusterNodeResumeOutcome.ENGINE_UNAVAILABLE) {
@@ -479,7 +482,10 @@ export class RemoteConfigRuntimeState implements RemoteConfigRuntimeStateApi {
     try {
       await this.load(this.namespace, context);
     } catch (error) {
-      if (RemoteConfigRuntimeState.isMissingRemoteConfigError(error) && Helpers.isKindContext(context)) {
+      if (
+        RemoteConfigRuntimeState.isMissingRemoteConfigError(error) &&
+        Helpers.isKindContext(context, this.k8Factory)
+      ) {
         throw new SoloErrors.config.remoteConfigMissingOnKindCluster(
           deploymentName,
           this.namespace?.name,

--- a/src/commands/base.ts
+++ b/src/commands/base.ts
@@ -45,7 +45,7 @@ import {type ConfigProvider} from '../data/configuration/api/config-provider.js'
 import {type DefaultKindClientBuilder} from '../integration/kind/impl/default-kind-client-builder.js';
 import {type KindClient} from '../integration/kind/kind-client.js';
 import {LoadDockerImageOptionsBuilder} from '../integration/kind/model/load-docker-image/load-docker-image-options-builder.js';
-import {checkDockerImageExists} from '../core/helpers.js';
+import {checkDockerImageExists, Helpers} from '../core/helpers.js';
 import {PathEx} from '../business/utils/path-ex.js';
 import {OperatingSystem} from '../business/utils/operating-system.js';
 import {ImageReference, type ParsedImageReference} from '../business/utils/image-reference.js';
@@ -272,8 +272,9 @@ export abstract class BaseCommand extends ShellRunner {
     return resolveNamespaceFromDeployment(this.localConfig, this.configManager, task);
   }
 
-  protected kindClusterNameFromContext(clusterContext: string): string {
-    return clusterContext.startsWith('kind-') ? clusterContext.slice('kind-'.length) : clusterContext;
+  /** Resolves the Kind cluster name the given kubeconfig context targets, or undefined for a non-Kind context. */
+  protected kindClusterNameFromContext(clusterContext: string): string | undefined {
+    return Helpers.kindClusterNameForContext(clusterContext, this.k8Factory);
   }
 
   protected isLocalImageReference(imageReference: string): boolean {
@@ -324,7 +325,8 @@ export abstract class BaseCommand extends ShellRunner {
     clusterContext: string,
     additionalContexts: Context[] = [],
   ): Promise<void> {
-    if (!clusterContext.startsWith('kind-')) {
+    const primaryKindCluster: string | undefined = this.kindClusterNameFromContext(clusterContext);
+    if (primaryKindCluster === undefined) {
       throw new SoloErrors.validation.illegalArgument(
         `Component image '${componentImage}' requires Kind image loading, but target cluster context ` +
           `'${clusterContext}' is not a Kind cluster. Push the image to a registry reachable ` +
@@ -336,21 +338,27 @@ export abstract class BaseCommand extends ShellRunner {
     const kindExecutable: string = await this.depManager.getExecutable(constants.KIND);
     const kindClient: KindClient = await this.kindBuilder.executable(kindExecutable).build();
 
-    await this.loadImageIntoKindContext(kindClient, componentImage, clusterContext);
+    await this.loadImageIntoKindCluster(kindClient, componentImage, primaryKindCluster);
 
+    const loadedKindClusters: Set<string> = new Set<string>([primaryKindCluster]);
     const extraContexts: Context[] = [...new Set<Context>(additionalContexts)].filter(
       (context: Context): boolean => context !== clusterContext,
     );
     for (const targetContext of extraContexts) {
-      if (!targetContext.startsWith('kind-')) {
+      const kindClusterName: string | undefined = this.kindClusterNameFromContext(targetContext);
+      if (kindClusterName === undefined) {
         this.logger.warn(
           `Skipping preload of component image '${componentImage}' into non-Kind cluster context ` +
             `'${targetContext}'; components deployed there must pull the image from a registry.`,
         );
         continue;
       }
+      if (loadedKindClusters.has(kindClusterName)) {
+        continue;
+      }
+      loadedKindClusters.add(kindClusterName);
       try {
-        await this.loadImageIntoKindContext(kindClient, componentImage, targetContext);
+        await this.loadImageIntoKindCluster(kindClient, componentImage, kindClusterName);
       } catch (error) {
         // best-effort: a stale or unreachable additional Kind context must not fail the deploy to the required cluster
         this.logger.warn(
@@ -361,12 +369,11 @@ export abstract class BaseCommand extends ShellRunner {
     }
   }
 
-  private async loadImageIntoKindContext(
+  private async loadImageIntoKindCluster(
     kindClient: KindClient,
     componentImage: string,
-    targetContext: Context,
+    kindClusterName: string,
   ): Promise<void> {
-    const kindClusterName: string = this.kindClusterNameFromContext(targetContext);
     this.logger.debug(`Loading '${componentImage}' into Kind cluster '${kindClusterName}'`);
     await kindClient.loadDockerImage(
       componentImage,

--- a/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
+++ b/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
@@ -958,7 +958,7 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
    */
   private async isRemoteConfigOrphanedOnKindCluster(deployConfig: OneShotSingleDeployConfigClass): Promise<boolean> {
     try {
-      if (!Helpers.isKindContext(deployConfig.context)) {
+      if (!Helpers.isKindContext(deployConfig.context, this.k8Factory)) {
         return false;
       }
 
@@ -1341,7 +1341,7 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
     config: OneShotSingleDeployConfigClass,
     task: SoloListrTaskWrapper<OneShotSingleDeployContext>,
   ): Promise<void> {
-    if (config.quiet === true || Helpers.isKindContext(config.context)) {
+    if (config.quiet === true || Helpers.isKindContext(config.context, this.k8Factory)) {
       return;
     }
 

--- a/src/core/helpers.ts
+++ b/src/core/helpers.ts
@@ -607,8 +607,28 @@ export class Helpers {
     return consensusNode ? consensusNode.context : undefined;
   }
 
-  public static isKindContext(context: string | undefined): boolean {
-    return !!context?.startsWith(Helpers.KIND_CONTEXT_PREFIX);
+  /** Resolves the Kind cluster name a kubeconfig context targets, or undefined for a non-Kind context. */
+  public static kindClusterNameForContext(context: string | undefined, k8Factory?: K8Factory): string | undefined {
+    if (context?.startsWith(Helpers.KIND_CONTEXT_PREFIX)) {
+      return context.slice(Helpers.KIND_CONTEXT_PREFIX.length);
+    }
+    if (!context || !k8Factory) {
+      return undefined;
+    }
+    try {
+      // a renamed context still references the cluster entry kind wrote as `kind-<cluster-name>`
+      const clusterEntryName: string = k8Factory.default().contexts().readClusterOfContext(context);
+      if (clusterEntryName.startsWith(Helpers.KIND_CONTEXT_PREFIX)) {
+        return clusterEntryName.slice(Helpers.KIND_CONTEXT_PREFIX.length);
+      }
+    } catch {
+      // best-effort: when the kubeconfig entry cannot be read, detection falls back to the context name prefix alone
+    }
+    return undefined;
+  }
+
+  public static isKindContext(context: string | undefined, k8Factory?: K8Factory): boolean {
+    return Helpers.kindClusterNameForContext(context, k8Factory) !== undefined;
   }
 
   public static hasMultipleKubernetesContexts(consensusNodes: ConsensusNode[]): boolean {

--- a/src/integration/kube/k8-client/resources/context/k8-client-contexts.ts
+++ b/src/integration/kube/k8-client/resources/context/k8-client-contexts.ts
@@ -25,6 +25,10 @@ export class K8ClientContexts implements Contexts {
     return NamespaceName.of(this.kubeConfig.getContextObject(this.readCurrent())?.namespace);
   }
 
+  public readClusterOfContext(context: string): string {
+    return this.kubeConfig.getContextObject(context)?.cluster ?? '';
+  }
+
   public updateCurrent(context: string): void {
     this.kubeConfig.setCurrentContext(context);
   }

--- a/src/integration/kube/resources/context/contexts.ts
+++ b/src/integration/kube/resources/context/contexts.ts
@@ -22,6 +22,13 @@ export interface Contexts {
   readCurrentNamespace(): NamespaceName;
 
   /**
+   * Read the name of the cluster entry a context references in the kubeconfig
+   * @param context - the context name
+   * @returns the cluster entry name, or an empty string when the context is unknown
+   */
+  readClusterOfContext(context: string): string;
+
+  /**
    * Set the current context in the kubeconfig
    * @param context - the context name to set
    */

--- a/test/unit/business/runtime-state/remote-config-runtime-state.test.ts
+++ b/test/unit/business/runtime-state/remote-config-runtime-state.test.ts
@@ -31,13 +31,25 @@ import {type Context} from '../../../../src/types/index.js';
 const namespace: NamespaceName = NamespaceName.of('solo');
 const remoteConfigMap: ConfigMap = {name: 'solo-remote-config'} as unknown as ConfigMap;
 
+/** Kubeconfig cluster entry lookup for the stubbed K8Factory; a context defaults to an equally-named entry. */
+function stubReadClusterOfContext(clusterEntriesByContext: Record<string, string>): (context: string) => string {
+  return (context: string): string => clusterEntriesByContext[context] ?? context;
+}
+
 /**
  * Builds a runtime state over a stubbed ConfigMap read and a stubbed container engine. Only those two
  * dependencies are exercised; the rest are non-null so they are not resolved from the container.
  */
-function buildRuntimeState(read: SinonStub, resumeStoppedClusterNode: SinonStub): RemoteConfigRuntimeState {
+function buildRuntimeState(
+  read: SinonStub,
+  resumeStoppedClusterNode: SinonStub,
+  clusterEntriesByContext: Record<string, string> = {},
+): RemoteConfigRuntimeState {
   const k8Factory: K8Factory = {
     getK8: (): unknown => ({configMaps: (): unknown => ({read})}),
+    default: (): unknown => ({
+      contexts: (): unknown => ({readClusterOfContext: stubReadClusterOfContext(clusterEntriesByContext)}),
+    }),
   } as unknown as K8Factory;
 
   return new RemoteConfigRuntimeState(
@@ -97,6 +109,9 @@ describe('RemoteConfigRuntimeState', (): void => {
     const k8Factory: K8Factory = {
       getK8: (): {configMaps: () => {read: sinon.SinonStub}} => ({
         configMaps: (): {read: sinon.SinonStub} => ({read: readStub}),
+      }),
+      default: (): unknown => ({
+        contexts: (): unknown => ({readClusterOfContext: stubReadClusterOfContext({})}),
       }),
     } as unknown as K8Factory;
 
@@ -251,6 +266,20 @@ describe('RemoteConfigRuntimeState', (): void => {
       namespace,
       'kind-solo',
     );
+
+    expect(exists).to.be.true;
+    expect(resumeStoppedClusterNode).to.have.been.calledOnceWithExactly('solo');
+    expect(read).to.have.been.calledTwice;
+  });
+
+  it('should resume a stopped kind cluster reached through a renamed context', async (): Promise<void> => {
+    read.onFirstCall().rejects(new Error('connect ECONNREFUSED 127.0.0.1:52810'));
+    read.onSecondCall().resolves(remoteConfigMap);
+    resumeStoppedClusterNode.resolves(ClusterNodeResumeOutcome.RESUMED);
+
+    const exists: boolean = await buildRuntimeState(read, resumeStoppedClusterNode, {
+      'solo-renamed': 'kind-solo',
+    }).remoteConfigExists(namespace, 'solo-renamed');
 
     expect(exists).to.be.true;
     expect(resumeStoppedClusterNode).to.have.been.calledOnceWithExactly('solo');

--- a/test/unit/commands/base.test.ts
+++ b/test/unit/commands/base.test.ts
@@ -31,6 +31,7 @@ import {type KindClient} from '../../../src/integration/kind/kind-client.js';
 
 interface BaseCommandInternal {
   isLocalImageReference: (imageReference: string) => boolean;
+  kindClusterNameFromContext: (clusterContext: string) => string | undefined;
   kindLoadComponentImage: (
     componentImage: string,
     clusterContext: string,
@@ -39,11 +40,23 @@ interface BaseCommandInternal {
   logger: SoloLogger;
   remoteConfig: {getContexts: () => Context[]};
   depManager: {getExecutable: (dependency: string) => Promise<string>};
+  k8Factory: K8Factory;
   kindBuilder: {
     executable: (executable: string) => {
       build: () => Promise<KindClient>;
     };
   };
+}
+
+/** Builds a K8Factory whose default kubeconfig resolves a context to the given cluster entry names. */
+function stubK8FactoryWithClusterEntries(clusterEntriesByContext: Record<string, string>): K8Factory {
+  return {
+    default: (): unknown => ({
+      contexts: (): unknown => ({
+        readClusterOfContext: (context: string): string => clusterEntriesByContext[context] ?? '',
+      }),
+    }),
+  } as unknown as K8Factory;
 }
 
 class TestBaseCommand extends BaseCommand {
@@ -328,6 +341,14 @@ describe('BaseCommand', (): void => {
       const kindClient: KindClient = {loadDockerImage: loadDockerImageStub} as unknown as KindClient;
 
       baseCommandInternal.logger = {warn: warnStub, debug: sinon.stub()} as unknown as SoloLogger;
+      baseCommandInternal.k8Factory = stubK8FactoryWithClusterEntries({
+        'kind-first': 'kind-first',
+        'kind-second': 'kind-second',
+        'kind-stale': 'kind-stale',
+        'renamed-first': 'kind-first',
+        'renamed-second': 'kind-second',
+        'remote-cluster': 'remote-cluster-entry',
+      });
       baseCommandInternal.remoteConfig = {
         getContexts: (): Context[] => ['kind-first', 'kind-second'],
       };
@@ -420,23 +441,60 @@ describe('BaseCommand', (): void => {
 
       expect(loadDockerImageStub).to.not.have.been.called;
     });
+
+    it('should load a local image through a Kind context renamed without the kind- prefix', async (): Promise<void> => {
+      await baseCommandInternal.kindLoadComponentImage('block-node-server:0.38.0', 'renamed-first');
+
+      expect(loadDockerImageStub).to.have.been.calledOnce;
+      expect(loadDockerImageStub).to.have.been.calledWith('block-node-server:0.38.0', sinon.match.has('name', 'first'));
+      expect(warnStub).to.not.have.been.called;
+    });
+
+    it('should preload an additional Kind context renamed without the kind- prefix', async (): Promise<void> => {
+      await baseCommandInternal.kindLoadComponentImage('block-node-server:0.38.0', 'kind-first', ['renamed-second']);
+
+      expect(loadDockerImageStub).to.have.been.calledTwice;
+      expect(loadDockerImageStub).to.have.been.calledWith('block-node-server:0.38.0', sinon.match.has('name', 'first'));
+      expect(loadDockerImageStub).to.have.been.calledWith(
+        'block-node-server:0.38.0',
+        sinon.match.has('name', 'second'),
+      );
+      expect(warnStub).to.not.have.been.called;
+    });
+
+    it('should load once when an additional context resolves to the same Kind cluster', async (): Promise<void> => {
+      await baseCommandInternal.kindLoadComponentImage('block-node-server:0.38.0', 'kind-first', ['renamed-first']);
+
+      expect(loadDockerImageStub).to.have.been.calledOnce;
+      expect(loadDockerImageStub).to.have.been.calledWith('block-node-server:0.38.0', sinon.match.has('name', 'first'));
+      expect(warnStub).to.not.have.been.called;
+    });
   });
 
   describe('kindClusterNameFromContext', (): void => {
+    let baseCommandInternal: BaseCommandInternal;
+
     before((): void => {
       resetForTest();
       // @ts-expect-error - allow to create instance of abstract class
       baseCmd = new BaseCommand();
+      baseCommandInternal = baseCmd as unknown as BaseCommandInternal;
+      baseCommandInternal.k8Factory = stubK8FactoryWithClusterEntries({
+        'renamed-context': 'kind-solo-cluster',
+        'my-cluster': 'my-cluster-entry',
+      });
     });
 
     it('should strip kind- prefix from context', (): void => {
-      // @ts-expect-error - TS2445: protected method
-      expect(baseCmd.kindClusterNameFromContext('kind-solo-cluster')).to.equal('solo-cluster');
+      expect(baseCommandInternal.kindClusterNameFromContext('kind-solo-cluster')).to.equal('solo-cluster');
     });
 
-    it('should return context unchanged when no kind- prefix', (): void => {
-      // @ts-expect-error - TS2445: protected method
-      expect(baseCmd.kindClusterNameFromContext('my-cluster')).to.equal('my-cluster');
+    it('should resolve a renamed context through its kubeconfig cluster entry', (): void => {
+      expect(baseCommandInternal.kindClusterNameFromContext('renamed-context')).to.equal('solo-cluster');
+    });
+
+    it('should return undefined when neither context nor cluster entry is Kind-named', (): void => {
+      expect(baseCommandInternal.kindClusterNameFromContext('my-cluster')).to.be.undefined;
     });
   });
 

--- a/test/unit/core/helpers.test.ts
+++ b/test/unit/core/helpers.test.ts
@@ -32,6 +32,18 @@ import {ConsensusNode} from '../../../src/core/model/consensus-node.js';
 import {type NodeAlias} from '../../../src/types/aliases.js';
 import {InjectTokens} from '../../../src/core/dependency-injection/inject-tokens.js';
 import {SoloErrors} from '../../../src/core/errors/solo-errors.js';
+import {type K8Factory} from '../../../src/integration/kube/k8-factory.js';
+
+/** Builds a K8Factory whose default kubeconfig resolves a context to the given cluster entry names. */
+function stubK8FactoryWithClusterEntries(clusterEntriesByContext: Record<string, string>): K8Factory {
+  return {
+    default: (): unknown => ({
+      contexts: (): unknown => ({
+        readClusterOfContext: (context: string): string => clusterEntriesByContext[context] ?? '',
+      }),
+    }),
+  } as unknown as K8Factory;
+}
 
 function makeConsensusNode(name: NodeAlias, nodeId: number): ConsensusNode {
   return new ConsensusNode(
@@ -514,6 +526,39 @@ describe('Helpers', (): void => {
       const unresolvedContext: string = undefined;
       expect(Helpers.isKindContext(unresolvedContext)).to.be.false;
       expect(Helpers.isKindContext('')).to.be.false;
+    });
+
+    it('recognizes a renamed context through its kubeconfig cluster entry', (): void => {
+      expect(Helpers.isKindContext('solo-renamed', stubK8FactoryWithClusterEntries({'solo-renamed': 'kind-solo'}))).to
+        .be.true;
+    });
+  });
+
+  describe('kindClusterNameForContext', (): void => {
+    it('resolves the cluster name from a context kind wrote', (): void => {
+      expect(Helpers.kindClusterNameForContext('kind-solo')).to.equal('solo');
+      expect(Helpers.kindClusterNameForContext('kind-solo-cluster')).to.equal('solo-cluster');
+    });
+
+    it('resolves the cluster name of a renamed context through its kubeconfig cluster entry', (): void => {
+      const k8Factory: K8Factory = stubK8FactoryWithClusterEntries({'solo-renamed': 'kind-solo'});
+      expect(Helpers.kindClusterNameForContext('solo-renamed', k8Factory)).to.equal('solo');
+    });
+
+    it('returns undefined when neither the context nor its cluster entry is Kind-named', (): void => {
+      const k8Factory: K8Factory = stubK8FactoryWithClusterEntries({'gke-prod': 'gke-prod-entry'});
+      expect(Helpers.kindClusterNameForContext('gke-prod', k8Factory)).to.be.undefined;
+      expect(Helpers.kindClusterNameForContext('gke-prod')).to.be.undefined;
+      expect(Helpers.kindClusterNameForContext(undefined, k8Factory)).to.be.undefined;
+    });
+
+    it('returns undefined when the kubeconfig cluster entry cannot be read', (): void => {
+      const k8Factory: K8Factory = {
+        default: (): never => {
+          throw new Error('kubeconfig unavailable');
+        },
+      } as unknown as K8Factory;
+      expect(Helpers.kindClusterNameForContext('solo-renamed', k8Factory)).to.be.undefined;
     });
   });
 


### PR DESCRIPTION
## Description

Fixes #5963

`BaseCommand.kindLoadComponentImage` identified Kind clusters solely by the `kind-` prefix of the kubeconfig context name, so a Kind cluster attached under a renamed context was treated as a non-Kind target and the deploy failed with the push-to-a-registry guidance.

### Changes

- **Detection via cluster metadata instead of the context name alone.** Kind writes both the kubeconfig context and the cluster entry as `kind-<cluster-name>`, and `kubectl config rename-context` renames only the context — the cluster entry it references is untouched. The new `Helpers.kindClusterNameForContext(context, k8Factory?)` first checks the context name prefix (fast path, unchanged behavior) and then falls back to the cluster entry the context references. Matching the bare context name against `kind get clusters` was deliberately avoided: a remote context coincidentally named like a local Kind cluster would be silently misclassified.
- **New `Contexts.readClusterOfContext()`** on the kube wrapper exposes the cluster entry a context references.
- **`kindLoadComponentImage`** resolves the Kind cluster name for the primary and additional contexts through the new detection, and deduplicates by resolved cluster name (two contexts pointing at the same Kind cluster load once).
- **Reused at the other detection call sites** (sub-task 2): the kind-cluster resume path and missing-remote-config guidance in `RemoteConfigRuntimeState`, and the one-shot orchestrator's non-Kind confirmation prompt and orphaned-config check now recognize renamed contexts too. The `kind-` prefix usages in `backup-restore.ts` and `cache.ts` construct names for clusters Solo itself creates, so no detection applies there.
- **Unit tests** cover a Kind cluster attached under a renamed context for image loading, name resolution, and the kind resume path, plus the unreadable-kubeconfig fallback.

### Testing

- `npx mocha` on the affected suites (base, explorer, helpers, remote-config-runtime-state, one-shot orchestrator) — 175 passing
- `task build` — clean (0 errors)