### PR TITLE
fix: continue downloads past an inconclusive HEAD pre-check instead of failing

### DIFF
--- a/src/core/package-downloader.ts
+++ b/src/core/package-downloader.ts
@@ -20,6 +20,7 @@ import {ReadStream} from 'node:fs';
 import {Hash} from 'node:crypto';
 import {ClientRequest} from 'node:http';
 import {Duration} from './time/duration.js';
+import {UrlCheckOutcome} from './url-check-outcome.js';
 
 const URL_EXISTS_TIMEOUT_ENV: string = 'PACKAGE_DOWNLOADER_URL_EXISTS_TIMEOUT_MS';
 const DOWNLOAD_CONNECT_TIMEOUT_ENV: string = 'PACKAGE_DOWNLOADER_DOWNLOAD_CONNECT_TIMEOUT_MS';
@@ -110,8 +111,9 @@ export class PackageDownloader {
     return parsedUrl.hostname === 'github.com' && parsedUrl.pathname.includes('/releases/download/');
   }
 
-  public urlExists(url: string): Promise<boolean> {
-    return new Promise<boolean>((resolve): void => {
+  /** Classifies a URL through a HEAD request: only a 404/410 response is a definitive absence, and a network failure or any other status leaves the answer inconclusive. */
+  public checkUrl(url: string): Promise<UrlCheckOutcome> {
+    return new Promise<UrlCheckOutcome>((resolve): void => {
       try {
         this.logger.debug(`Checking URL: ${url}`);
         // attempt to send a HEAD request to check URL exists
@@ -132,24 +134,30 @@ export class PackageDownloader {
           });
           request.destroy();
           if ([StatusCodes.OK, StatusCodes.MOVED_TEMPORARILY, StatusCodes.MOVED_PERMANENTLY].includes(statusCode)) {
-            resolve(true);
+            resolve(UrlCheckOutcome.EXISTS);
+          } else if ([StatusCodes.NOT_FOUND, StatusCodes.GONE].includes(statusCode)) {
+            resolve(UrlCheckOutcome.MISSING);
+          } else {
+            resolve(UrlCheckOutcome.INCONCLUSIVE);
           }
-
-          resolve(false);
         });
 
         request.on('error', (error): void => {
           this.logger.error(error);
-          resolve(false);
+          resolve(UrlCheckOutcome.INCONCLUSIVE);
           request.destroy();
         });
 
         request.end(); // make the request
       } catch (error) {
         this.logger.error(error);
-        resolve(false);
+        resolve(UrlCheckOutcome.INCONCLUSIVE);
       }
     });
+  }
+
+  public async urlExists(url: string): Promise<boolean> {
+    return (await this.checkUrl(url)) === UrlCheckOutcome.EXISTS;
   }
 
   /**
@@ -171,11 +179,15 @@ export class PackageDownloader {
       throw new SoloErrors.validation.illegalArgument(`package URL '${url}' is invalid`, url);
     }
 
-    if (!(await this.urlExists(url))) {
+    const urlCheck: UrlCheckOutcome = await this.checkUrl(url);
+    if (urlCheck === UrlCheckOutcome.MISSING) {
       if (!this.isHeadCheckOptional(url)) {
         throw new SoloErrors.system.resourceNotFound(url);
       }
       this.logger.warn(`HEAD request reported missing URL; continuing with direct download attempt: ${url}`);
+    } else if (urlCheck === UrlCheckOutcome.INCONCLUSIVE) {
+      // a transient HEAD failure (DNS, timeout, 5xx) must not fail the download outright; the retried GET decides
+      this.logger.warn(`HEAD pre-check was inconclusive; continuing with direct download attempt: ${url}`);
     }
 
     const connectTimeout: number = this.getDownloadConnectTimeout().toMillis();

--- a/src/core/package-downloader.ts
+++ b/src/core/package-downloader.ts
@@ -28,7 +28,9 @@ const DOWNLOAD_RETRY_LIMIT_ENV: string = 'PACKAGE_DOWNLOADER_RETRY_LIMIT';
 const DEFAULT_URL_EXISTS_TIMEOUT: Duration = Duration.ofSeconds(5);
 const DEFAULT_DOWNLOAD_CONNECT_TIMEOUT: Duration = Duration.ofSeconds(10);
 const DEFAULT_DOWNLOAD_RESPONSE_TIMEOUT: Duration = Duration.ofMinutes(2);
-const DEFAULT_DOWNLOAD_RETRY_LIMIT: number = 3;
+const DEFAULT_DOWNLOAD_RETRY_LIMIT: number = 6;
+const DOWNLOAD_RETRY_BASE_DELAY: Duration = Duration.ofSeconds(2);
+const DOWNLOAD_RETRY_MAX_DELAY: Duration = Duration.ofSeconds(32);
 
 @injectable()
 export class PackageDownloader {
@@ -191,7 +193,11 @@ export class PackageDownloader {
           fs.rmSync(destinationPath);
         }
         if (attempt < retryLimit) {
-          const delayMs: number = 2000 * attempt;
+          // capped exponential backoff so a transient upstream outage (e.g. a GitHub 5xx blip) can pass
+          const delayMs: number = Math.min(
+            DOWNLOAD_RETRY_BASE_DELAY.toMillis() * 2 ** (attempt - 1),
+            DOWNLOAD_RETRY_MAX_DELAY.toMillis(),
+          );
           this.logger.warn(`Download attempt ${attempt}/${retryLimit} failed, retrying in ${delayMs}ms: ${url}`, error);
           await new Promise<void>((resolve): void => {
             setTimeout(resolve, delayMs);

--- a/src/core/url-check-outcome.ts
+++ b/src/core/url-check-outcome.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/** The result of the HEAD pre-check a download performs before fetching a URL. */
+export enum UrlCheckOutcome {
+  /** The server definitively reported the URL as available. */
+  EXISTS = 'exists',
+
+  /** The server definitively reported the URL as absent. */
+  MISSING = 'missing',
+
+  /** No definitive answer: a network failure, a timeout, or a non-definitive status such as a 5xx. */
+  INCONCLUSIVE = 'inconclusive',
+}

--- a/test/unit/core/package-downloader.test.ts
+++ b/test/unit/core/package-downloader.test.ts
@@ -16,6 +16,7 @@ import {ResourceNotFoundError} from '../../../src/core/errors/classes/system/res
 import {PathEx} from '../../../src/business/utils/path-ex.js';
 import {SoloPinoLogger} from '../../../src/core/logging/solo-pino-logger.js';
 import {SoloError} from '../../../src/core/errors/solo-error.js';
+import {UrlCheckOutcome} from '../../../src/core/url-check-outcome.js';
 
 describe('PackageDownloader', (): void => {
   const testLogger: SoloPinoLogger = new SoloPinoLogger('debug', true);
@@ -65,6 +66,24 @@ describe('PackageDownloader', (): void => {
     });
   });
 
+  describe('checkUrl', (): void => {
+    it('should report EXISTS for an available URL', async (): Promise<void> => {
+      const url: string = 'https://builds.hedera.com/node/software/v0.42/build-v0.42.5.sha384';
+      await expect(downloader.checkUrl(url)).to.eventually.equal(UrlCheckOutcome.EXISTS);
+    });
+
+    it('should report MISSING when the server answers 404', async (): Promise<void> => {
+      const url: string = 'https://builds.hedera.com/node/software/v0.42/build-v0.42.5.INVALID';
+      await expect(downloader.checkUrl(url)).to.eventually.equal(UrlCheckOutcome.MISSING);
+    });
+
+    it('should report INCONCLUSIVE when the host cannot be reached', async (): Promise<void> => {
+      await expect(downloader.checkUrl('https://localhost:9/unreachable')).to.eventually.equal(
+        UrlCheckOutcome.INCONCLUSIVE,
+      );
+    });
+  });
+
   describe('fetchFile', (): void => {
     it('should fail if source URL is missing', async (): Promise<void> => {
       await expect(downloader.fetchFile('', os.tmpdir())).to.be.rejectedWith('package URL is required');
@@ -81,11 +100,15 @@ describe('PackageDownloader', (): void => {
       );
     });
 
-    it('should fail with an invalid URL', async (): Promise<void> => {
+    it('should fail without a download attempt when the HEAD check reports a missing URL', async (): Promise<void> => {
+      sandbox.stub(downloader, 'checkUrl').resolves(UrlCheckOutcome.MISSING);
+      const gotStreamStub: SinonStub = sandbox.stub(got, 'stream');
+
       await expect(downloader.fetchFile('https://localhost/INVALID_FILE', os.tmpdir())).to.be.rejectedWith(
         ResourceNotFoundError,
         'Resource not found: https://localhost/INVALID_FILE',
       );
+      expect(gotStreamStub).to.not.have.been.called;
     });
 
     it('should succeed with a valid release artifact URL', async (): Promise<void> => {
@@ -114,7 +137,7 @@ describe('PackageDownloader', (): void => {
 
       const temporaryDirectory: string = fs.mkdtempSync(PathEx.join(os.tmpdir(), 'downloader-'));
       const destinationPath: string = PathEx.join(temporaryDirectory, 'artifact.txt');
-      const urlExistsStub: SinonStub = sandbox.stub(downloader, 'urlExists').resolves(true);
+      const checkUrlStub: SinonStub = sandbox.stub(downloader, 'checkUrl').resolves(UrlCheckOutcome.EXISTS);
       const gotStreamStub: SinonStub = sandbox
         .stub(got, 'stream')
         .callsFake((...arguments_: unknown[]): ReturnType<typeof got.stream> => {
@@ -132,7 +155,7 @@ describe('PackageDownloader', (): void => {
         destinationPath,
       );
       expect(fs.readFileSync(destinationPath, 'utf8')).to.equal('payload');
-      expect(urlExistsStub.calledOnce).to.equal(true);
+      expect(checkUrlStub.calledOnce).to.equal(true);
       expect(gotStreamStub.calledOnce).to.equal(true);
 
       fs.rmSync(temporaryDirectory, {recursive: true, force: true});
@@ -143,7 +166,7 @@ describe('PackageDownloader', (): void => {
       const clock: SinonFakeTimers = sandbox.useFakeTimers({toFake: ['setTimeout']});
       const temporaryDirectory: string = fs.mkdtempSync(PathEx.join(os.tmpdir(), 'downloader-'));
       const destinationPath: string = PathEx.join(temporaryDirectory, 'artifact.txt');
-      sandbox.stub(downloader, 'urlExists').resolves(true);
+      sandbox.stub(downloader, 'checkUrl').resolves(UrlCheckOutcome.EXISTS);
       const gotStreamStub: SinonStub = sandbox.stub(got, 'stream').callsFake((): ReturnType<typeof got.stream> => {
         if (gotStreamStub.callCount < 7) {
           throw new Error(`transient failure ${gotStreamStub.callCount}`);
@@ -175,7 +198,7 @@ describe('PackageDownloader', (): void => {
     it('should continue download when GitHub release HEAD check reports missing URL', async (): Promise<void> => {
       const temporaryDirectory: string = fs.mkdtempSync(PathEx.join(os.tmpdir(), 'downloader-'));
       const destinationPath: string = PathEx.join(temporaryDirectory, 'artifact.txt');
-      const urlExistsStub: SinonStub = sandbox.stub(downloader, 'urlExists').resolves(false);
+      const checkUrlStub: SinonStub = sandbox.stub(downloader, 'checkUrl').resolves(UrlCheckOutcome.MISSING);
       const gotStreamStub: SinonStub = sandbox
         .stub(got, 'stream')
         .returns(Readable.from(['payload']) as ReturnType<typeof got.stream>);
@@ -187,7 +210,41 @@ describe('PackageDownloader', (): void => {
         ),
       ).to.eventually.equal(destinationPath);
       expect(fs.readFileSync(destinationPath, 'utf8')).to.equal('payload');
-      expect(urlExistsStub.calledOnce).to.equal(true);
+      expect(checkUrlStub.calledOnce).to.equal(true);
+      expect(gotStreamStub.calledOnce).to.equal(true);
+
+      fs.rmSync(temporaryDirectory, {recursive: true, force: true});
+    });
+
+    it('should continue download when the HEAD pre-check is inconclusive', async (): Promise<void> => {
+      const temporaryDirectory: string = fs.mkdtempSync(PathEx.join(os.tmpdir(), 'downloader-'));
+      const destinationPath: string = PathEx.join(temporaryDirectory, 'artifact.txt');
+      const checkUrlStub: SinonStub = sandbox.stub(downloader, 'checkUrl').resolves(UrlCheckOutcome.INCONCLUSIVE);
+      const gotStreamStub: SinonStub = sandbox
+        .stub(got, 'stream')
+        .returns(Readable.from(['payload']) as ReturnType<typeof got.stream>);
+
+      await expect(downloader.fetchFile('https://get.helm.sh/artifact.tar.gz', destinationPath)).to.eventually.equal(
+        destinationPath,
+      );
+      expect(fs.readFileSync(destinationPath, 'utf8')).to.equal('payload');
+      expect(checkUrlStub.calledOnce).to.equal(true);
+      expect(gotStreamStub.calledOnce).to.equal(true);
+
+      fs.rmSync(temporaryDirectory, {recursive: true, force: true});
+    });
+
+    it('should report the download failure when both the HEAD pre-check and the download fail', async (): Promise<void> => {
+      process.env.PACKAGE_DOWNLOADER_RETRY_LIMIT = '1';
+      const temporaryDirectory: string = fs.mkdtempSync(PathEx.join(os.tmpdir(), 'downloader-'));
+      const destinationPath: string = PathEx.join(temporaryDirectory, 'artifact.tar.gz');
+      sandbox.stub(downloader, 'checkUrl').resolves(UrlCheckOutcome.INCONCLUSIVE);
+      const gotStreamStub: SinonStub = sandbox.stub(got, 'stream').throws(new Error('connect ECONNREFUSED'));
+
+      await expect(downloader.fetchFile('https://get.helm.sh/artifact.tar.gz', destinationPath)).to.be.rejectedWith(
+        SoloError,
+        'Failed to download package from https://get.helm.sh/artifact.tar.gz',
+      );
       expect(gotStreamStub.calledOnce).to.equal(true);
 
       fs.rmSync(temporaryDirectory, {recursive: true, force: true});

--- a/test/unit/core/package-downloader.test.ts
+++ b/test/unit/core/package-downloader.test.ts
@@ -2,7 +2,7 @@
 
 import {expect} from 'chai';
 import {describe, it} from 'mocha';
-import sinon, {type SinonSandbox, type SinonStub} from 'sinon';
+import sinon, {type SinonFakeTimers, type SinonSandbox, type SinonStub} from 'sinon';
 import {Readable} from 'node:stream';
 import got, {type OptionsInit} from 'got';
 
@@ -30,6 +30,7 @@ describe('PackageDownloader', (): void => {
     delete process.env.PACKAGE_DOWNLOADER_URL_EXISTS_TIMEOUT_MS;
     delete process.env.PACKAGE_DOWNLOADER_DOWNLOAD_CONNECT_TIMEOUT_MS;
     delete process.env.PACKAGE_DOWNLOADER_DOWNLOAD_RESPONSE_TIMEOUT_MS;
+    delete process.env.PACKAGE_DOWNLOADER_RETRY_LIMIT;
     sandbox.restore();
   });
 
@@ -133,6 +134,40 @@ describe('PackageDownloader', (): void => {
       expect(fs.readFileSync(destinationPath, 'utf8')).to.equal('payload');
       expect(urlExistsStub.calledOnce).to.equal(true);
       expect(gotStreamStub.calledOnce).to.equal(true);
+
+      fs.rmSync(temporaryDirectory, {recursive: true, force: true});
+    });
+
+    it('should retry transient download failures with capped exponential backoff', async (): Promise<void> => {
+      process.env.PACKAGE_DOWNLOADER_RETRY_LIMIT = '7';
+      const clock: SinonFakeTimers = sandbox.useFakeTimers({toFake: ['setTimeout']});
+      const temporaryDirectory: string = fs.mkdtempSync(PathEx.join(os.tmpdir(), 'downloader-'));
+      const destinationPath: string = PathEx.join(temporaryDirectory, 'artifact.txt');
+      sandbox.stub(downloader, 'urlExists').resolves(true);
+      const gotStreamStub: SinonStub = sandbox.stub(got, 'stream').callsFake((): ReturnType<typeof got.stream> => {
+        if (gotStreamStub.callCount < 7) {
+          throw new Error(`transient failure ${gotStreamStub.callCount}`);
+        }
+        return Readable.from(['payload']) as ReturnType<typeof got.stream>;
+      });
+
+      const pendingFetch: Promise<string> = downloader.fetchFile('https://example.com/artifact.txt', destinationPath);
+      pendingFetch.catch((): void => {
+        // suppress unhandled rejection warnings while the fake clock is advanced; awaited below
+      });
+
+      const expectedDelays: number[] = [2000, 4000, 8000, 16_000, 32_000, 32_000];
+      let expectedAttempts: number = 1;
+      for (const delay of expectedDelays) {
+        await clock.tickAsync(delay - 1);
+        expect(gotStreamStub.callCount).to.equal(expectedAttempts);
+        await clock.tickAsync(1);
+        expectedAttempts++;
+        expect(gotStreamStub.callCount).to.equal(expectedAttempts);
+      }
+
+      await expect(pendingFetch).to.eventually.equal(destinationPath);
+      expect(fs.readFileSync(destinationPath, 'utf8')).to.equal('payload');
 
       fs.rmSync(temporaryDirectory, {recursive: true, force: true});
     });


### PR DESCRIPTION
## Description

Fixes #5981

> **Note:** this PR is based on `main` and includes the commit from #5978 (the capped exponential retry for the GET download loop), which this fix builds on. Merging this PR delivers both changes; #5978 can then be closed. If #5978 is merged first, this diff shrinks to just the HEAD pre-check change.

`PackageDownloader.urlExists()` sent a single HEAD request with no retry before every download and treated any failure — DNS `EAI_AGAIN`, timeout, 5xx — as "resource not found", failing the download outright for URLs outside the github.com releases exemption. A short runner DNS outage failed the E2E Tests (Dual Cluster Full) job this way on `https://get.helm.sh/helm-v3.14.2-linux-amd64.tar.gz.sha256sum`.

### Changes

- New `checkUrl()` classifies the HEAD result as `EXISTS` (200/301/302), `MISSING` (404/410 — a definitive server answer), or `INCONCLUSIVE` (network failure, timeout, or any other status). `urlExists()` keeps its boolean contract by delegating.
- `fetchFile()` fails fast with `ResourceNotFoundError` only on a definitive `MISSING` answer. An `INCONCLUSIVE` pre-check logs a warning and falls through to the download attempt, which carries a capped exponential retry (from #5978) — no second retry loop needed, and a persistent failure surfaces as an accurate download error with the real cause instead of a misleading "resource not found".
- Retries stay strictly bounded: the download loop makes at most `PACKAGE_DOWNLOADER_RETRY_LIMIT` attempts (default 6) with delays capped at 32s, and the HEAD pre-check is a single attempt with a 5s timeout — there is no unbounded retry path.
- Unit tests cover the three HEAD classifications, the fall-through on an inconclusive pre-check, the unchanged fast-fail on a definitive 404, and the accurate error when both the pre-check and the download fail.

### Testing

- `npx mocha 'test/unit/core/package-downloader.test.ts'` — 28 passing
- `task build` — clean (0 errors)