### PR TITLE
ci: keep WSL2 setup off the network and use the Azure apt mirror

### DIFF
--- a/.github/workflows/flow-standard-runner-one-shot-windows.yaml
+++ b/.github/workflows/flow-standard-runner-one-shot-windows.yaml
@@ -342,7 +342,7 @@ jobs:
             # IPv4 because the WSL2 NAT has no IPv6 route and each v6 attempt burns a timeout, and
             # bound each fetch so a bad connection fails fast and retries instead of sitting in
             # apt's default 120-second connect timeout.
-            grep -rl 'ubuntu.com' /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null | xargs -r sed -i -E 's#http://(archive|security)\.ubuntu\.com/ubuntu#http://azure.archive.ubuntu.com/ubuntu#'
+            grep -rl -e 'archive.ubuntu.com' -e 'security.ubuntu.com' /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null | xargs -r sed -i -e 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|' -e 's|http://security.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|'
             printf 'Acquire::ForceIPv4 "true";\nAcquire::Retries "5";\nAcquire::http::Timeout "30";\n' > /etc/apt/apt.conf.d/99-solo-ci
             mkdir -p /etc/apt/keyrings
             cp $WORKSPACE/.github/workflows/resources/docker-apt-public-gpg-key.key /etc/apt/keyrings/docker.asc

--- a/.github/workflows/flow-standard-runner-one-shot-windows.yaml
+++ b/.github/workflows/flow-standard-runner-one-shot-windows.yaml
@@ -228,19 +228,18 @@ jobs:
         # The verified restore above creates setup-wsl's .complete marker so find()
         # returns the installer before the action reaches its cache or download path.
         uses: Vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7.0.0
-        # A healthy setup completes in about one minute. Bound a stalled action so a
+        # A healthy setup completes in well under a minute. Bound a stalled action so a
         # distribution problem is reported promptly instead of consuming ten minutes.
+        # Keep this step off the network: `additional-packages` would run `apt-get update`
+        # inside this budget, and a slow Ubuntu mirror alone blew it three runs in a row
+        # (issue #5985). The Ubuntu WSL image already ships ca-certificates and curl; every
+        # apt call this job needs lives in "Install Docker in WSL2" with its own timeout.
         timeout-minutes: 3
         with:
           distribution: Ubuntu-24.04
           wsl-version: 2
           use-cache: false
           set-as-default: true
-          additional-packages: |
-            apt-transport-https
-            ca-certificates
-            curl
-            software-properties-common
 
       - name: Capture WSL2 diagnostics after setup failure
         if: ${{ !cancelled() && steps.setup_wsl2.outcome == 'failure' }}
@@ -335,17 +334,26 @@ jobs:
             echo "::group::Memory (free -h):"
             free -h
             echo "::endgroup::"
-            # Ubuntu 24.04 uses iptables-nft by default which prevents Docker from starting in WSL2.
-            # iptables must be installed before alternatives can be switched.
-            echo "::group::Adding Docker APT Repository"
-            apt-get install -y -q iptables
-            update-alternatives --set iptables /usr/sbin/iptables-legacy
-            update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+            echo "::group::Configuring APT"
+            # GitHub-hosted runners live in Azure; archive.ubuntu.com from there is the mirror that
+            # stalled or timed out in issue #5985. Use the in-network Azure mirror, as GitHub's own
+            # Ubuntu runner images do, and bound each fetch so a bad connection fails fast and
+            # retries instead of sitting in apt's default 120-second connect timeout.
+            grep -rl 'archive.ubuntu.com' /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null | xargs -r sed -i 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|'
+            printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\n' > /etc/apt/apt.conf.d/99-solo-ci
             mkdir -p /etc/apt/keyrings
             cp $WORKSPACE/.github/workflows/resources/docker-apt-public-gpg-key.key /etc/apt/keyrings/docker.asc
             chmod 644 /etc/apt/keyrings/docker.asc
             echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu noble stable" > /etc/apt/sources.list.d/docker.list
+            # The fresh WSL image has no package lists yet; this is the job's only apt-get update.
             apt-get update -q
+            echo "::endgroup::"
+            echo "::group::Switching iptables to legacy"
+            # Ubuntu 24.04 uses iptables-nft by default which prevents Docker from starting in WSL2.
+            # iptables must be installed before alternatives can be switched.
+            apt-get install -y -q iptables
+            update-alternatives --set iptables /usr/sbin/iptables-legacy
+            update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
             echo "::endgroup::"
             echo "::group::Installing Docker Engine"
             apt-get -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin docker-buildx-plugin

--- a/.github/workflows/flow-standard-runner-one-shot-windows.yaml
+++ b/.github/workflows/flow-standard-runner-one-shot-windows.yaml
@@ -335,12 +335,15 @@ jobs:
             free -h
             echo "::endgroup::"
             echo "::group::Configuring APT"
-            # GitHub-hosted runners live in Azure; archive.ubuntu.com from there is the mirror that
-            # stalled or timed out in issue #5985. Use the in-network Azure mirror, as GitHub's own
-            # Ubuntu runner images do, and bound each fetch so a bad connection fails fast and
-            # retries instead of sitting in apt's default 120-second connect timeout.
-            grep -rl 'archive.ubuntu.com' /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null | xargs -r sed -i 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|'
-            printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\n' > /etc/apt/apt.conf.d/99-solo-ci
+            # GitHub-hosted runners live in Azure; archive.ubuntu.com and security.ubuntu.com from
+            # there are the hosts that stalled or timed out in issue #5985 (the Azure mirror served
+            # every index in one second while security.ubuntu.com alone took two minutes). Use the
+            # in-network Azure mirror for both pockets, as Azure's own Ubuntu images do, stay on
+            # IPv4 because the WSL2 NAT has no IPv6 route and each v6 attempt burns a timeout, and
+            # bound each fetch so a bad connection fails fast and retries instead of sitting in
+            # apt's default 120-second connect timeout.
+            grep -rl 'ubuntu.com' /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null | xargs -r sed -i -E 's#http://(archive|security)\.ubuntu\.com/ubuntu#http://azure.archive.ubuntu.com/ubuntu#'
+            printf 'Acquire::ForceIPv4 "true";\nAcquire::Retries "5";\nAcquire::http::Timeout "30";\n' > /etc/apt/apt.conf.d/99-solo-ci
             mkdir -p /etc/apt/keyrings
             cp $WORKSPACE/.github/workflows/resources/docker-apt-public-gpg-key.key /etc/apt/keyrings/docker.asc
             chmod 644 /etc/apt/keyrings/docker.asc


### PR DESCRIPTION
## Description

This pull request changes the following:

* Drops the `additional-packages` input from the `Setup WSL2` step. It made setup-wsl run `apt-get update` inside the step's 3-minute budget, and a slow `archive.ubuntu.com` mirror alone timed the step out on three consecutive attempts (#5985). None of the listed packages is used: the Ubuntu 24.04 WSL image already ships `ca-certificates` and `curl`, and the Docker install script writes its apt source directly instead of calling `add-apt-repository`. `Setup WSL2` now only installs the distribution and never touches the network.
* Moves the job's single `apt-get update` into the 10-minute `Install Docker in WSL2` step, ahead of the `iptables` install that previously relied on the package lists setup-wsl used to prime. The second `apt-get update` that step ran is gone.
* Points both the archive and security Ubuntu apt pockets at `azure.archive.ubuntu.com`, the in-network mirror GitHub's own Ubuntu runner images use, forces IPv4 (the WSL2 NAT has no IPv6 route, so each v6 attempt burns a timeout), and bounds apt fetches with `Acquire::http::Timeout "30"` plus `Acquire::Retries "5"` instead of apt's 120-second default connect timeout.

### Related Issues

* Closes #5985
* Related to #5975, #5984

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[x] This PR added no TODOs or commented out code
* \[x] This PR has no breaking changes
* \[x] Any technical debt has been documented as a separate issue and linked to this PR
* \[x] Any `package.json` changes have been explained to and approved by a repository manager
* \[x] All related issues have been linked to this PR
* \[x] All changes in this PR are included in the description
* \[x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[x] These changes required manual testing that is documented below
* \[x] Anything not tested is documented

The following manual testing was done:

* Two `Windows Deploy and Destroy` runs on this PR, both green end to end including Solo deploy and destroy:
  * [Run 1](https://github.com/hiero-ledger/solo/actions/runs/34592792089) (first commit): `Setup WSL2` 35s. `Install Docker in WSL2` 3m55s; its log showed the Azure mirror serving all 50 archive indexes in one second while `security.ubuntu.com` alone took two minutes, plus a 30s stall before the `iptables` download.
  * [Run 2](https://github.com/hiero-ledger/solo/actions/runs/34594286294) (security pocket on the Azure mirror + `Acquire::ForceIPv4`): `Setup WSL2` 29s. `Install Docker in WSL2` 50s. `apt-get update` fetched 39.8 MB in 4s, `iptables` in under a second, Docker Engine in one second.
* Verified against the Ubuntu 24.04 WSL image manifest (`cloud-images.ubuntu.com/wsl/releases/24.04/current`) that `ca-certificates`, `curl` and `software-properties-common` are preinstalled; `iptables` is not, which is why its install now follows the moved `apt-get update`.

The following was not tested:

* Behaviour when `azure.archive.ubuntu.com` itself is unreachable. The retry and timeout settings bound that case to a fast failure rather than a hang.
