### PR TITLE
fix: bound libsodium install in NLG pod and give it its own test step

### DIFF
--- a/src/commands/rapid-fire.ts
+++ b/src/commands/rapid-fire.ts
@@ -3,6 +3,7 @@
 import {Listr} from 'listr2';
 import {SoloErrors} from '../core/errors/solo-errors.js';
 import * as constants from '../core/constants.js';
+import {NetworkLoadGeneratorLibraries} from '../core/network-load-generator-libraries.js';
 import {BaseCommand} from './base.js';
 import {Flags as flags} from './flags.js';
 import {type AnyListrContext, type ArgvStruct} from '../types/aliases.js';
@@ -244,10 +245,7 @@ export class RapidFireCommand extends BaseCommand {
                   pod.podReference,
                   constants.NETWORK_LOAD_GENERATOR_CONTAINER,
                 );
-                const container: Container = k8Containers.readByRef(containerReference);
-                await container.execContainer('apt-get update -qq');
-                await container.execContainer('apt-get install -y libsodium23');
-                await container.execContainer('apt-get clean -qq');
+                await NetworkLoadGeneratorLibraries.install(k8Containers.readByRef(containerReference));
               }
             },
           },

--- a/src/core/network-load-generator-libraries.ts
+++ b/src/core/network-load-generator-libraries.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {type Container} from '../integration/kube/resources/container/container.js';
+
+/**
+ * Installs the native libraries the network-load-generator image needs at runtime but does not ship.
+ * Delete once the image bundles libsodium23 (hiero-ledger/solo#5988, root fix).
+ */
+export class NetworkLoadGeneratorLibraries {
+  // One sh script so the pod is touched by a single exec. apt defaults (IPv6-first, 120 s connect
+  // timeout, no retries) let a slow public mirror stall for >10 min; the apt.conf caps that (#5988).
+  private static readonly INSTALL_SCRIPT: string = [
+    'set -e',
+    'if dpkg -s libsodium23 >/dev/null 2>&1; then echo "libsodium23 already installed"; exit 0; fi',
+    String.raw`printf 'Acquire::ForceIPv4 "true";\nAcquire::Retries "5";\nAcquire::http::Timeout "30";\n' > /etc/apt/apt.conf.d/99-solo`,
+    'apt-get update -q',
+    'apt-get install -y libsodium23',
+    'apt-get clean -q',
+  ].join('; ');
+
+  public static async install(container: Container): Promise<void> {
+    await container.execContainer(['sh', '-c', NetworkLoadGeneratorLibraries.INSTALL_SCRIPT]);
+  }
+}

--- a/test/e2e/commands/performance.test.ts
+++ b/test/e2e/commands/performance.test.ts
@@ -16,6 +16,8 @@ import {type EndToEndTestSuite} from '../end-to-end-test-suite.js';
 import {type BaseTestOptions} from './tests/base-test-options.js';
 import {main} from '../../../src/index.js';
 import {BaseCommandTest} from './tests/base-command-test.js';
+import {NetworkLoadGeneratorTest} from './tests/network-load-generator-test.js';
+import {NamespaceName} from '../../../src/types/namespace/namespace-name.js';
 import {OneShotCommandDefinition} from '../../../src/commands/command-definitions/one-shot-command-definition.js';
 import {BlockCommandDefinition} from '../../../src/commands/command-definitions/block-command-definition.js';
 import {MetricsServerImpl} from '../../../src/business/runtime-state/services/metrics-server-impl.js';
@@ -248,6 +250,13 @@ const endToEndTestSuite: EndToEndTestSuite = new EndToEndTestSuiteBuilder()
         // fungible tokens, NftTransferLoadTest with -R would load those fungible tokens as NFTs
         // and produce 0 TPS (and vice versa). To avoid this cross-contamination, NftTransferLoadTest
         // does NOT use -R so it always creates its own fresh NFT tokens.
+        // NLG chart install + libsodium download get their own budget, so a slow apt mirror fails here
+        // instead of eating the first load test's timeout and surfacing as a killed exec (#5988).
+        it('Deploy Network Load Generator', async (): Promise<void> => {
+          logEvent('Deploying Network Load Generator');
+          await NetworkLoadGeneratorTest.deployChart(contexts[0], NamespaceName.of(await getNamespaceFromDeployment()));
+        }).timeout(Duration.ofMinutes(20).toMillis());
+
         it('TokenTransferLoadTest', async (): Promise<void> => {
           logEvent('Starting TokenTransferLoadTest');
           await runLoadTest(

--- a/test/e2e/commands/performance.test.ts
+++ b/test/e2e/commands/performance.test.ts
@@ -17,7 +17,6 @@ import {type BaseTestOptions} from './tests/base-test-options.js';
 import {main} from '../../../src/index.js';
 import {BaseCommandTest} from './tests/base-command-test.js';
 import {NetworkLoadGeneratorTest} from './tests/network-load-generator-test.js';
-import {NamespaceName} from '../../../src/types/namespace/namespace-name.js';
 import {OneShotCommandDefinition} from '../../../src/commands/command-definitions/one-shot-command-definition.js';
 import {BlockCommandDefinition} from '../../../src/commands/command-definitions/block-command-definition.js';
 import {MetricsServerImpl} from '../../../src/business/runtime-state/services/metrics-server-impl.js';
@@ -254,7 +253,7 @@ const endToEndTestSuite: EndToEndTestSuite = new EndToEndTestSuiteBuilder()
         // instead of eating the first load test's timeout and surfacing as a killed exec (#5988).
         it('Deploy Network Load Generator', async (): Promise<void> => {
           logEvent('Deploying Network Load Generator');
-          await NetworkLoadGeneratorTest.deployChart(contexts[0], NamespaceName.of(await getNamespaceFromDeployment()));
+          await NetworkLoadGeneratorTest.deployChart(deploymentName);
         }).timeout(Duration.ofMinutes(20).toMillis());
 
         it('TokenTransferLoadTest', async (): Promise<void> => {

--- a/test/e2e/commands/small-memory-load.test.ts
+++ b/test/e2e/commands/small-memory-load.test.ts
@@ -84,7 +84,7 @@ const endToEndTestSuite: EndToEndTestSuite = new EndToEndTestSuiteBuilder()
 
           // Phase 2: Pre-deploy NLG chart (bypassing rapid-fire to allow file copy before test start)
           testLogger.info(`${testName}: deploying NLG chart`);
-          await NetworkLoadGeneratorTest.deployChart(context, NamespaceName.of(await getNamespaceFromDeployment()));
+          await NetworkLoadGeneratorTest.deployChart(deploymentName);
           testLogger.info(`${testName}: NLG chart deployed`);
 
           // Phase 3: Copy throttles.json into NLG pod

--- a/test/e2e/commands/small-memory-load.test.ts
+++ b/test/e2e/commands/small-memory-load.test.ts
@@ -18,21 +18,14 @@ import {type EndToEndTestSuite} from '../end-to-end-test-suite.js';
 import {type BaseTestOptions} from './tests/base-test-options.js';
 import {main} from '../../../src/index.js';
 import {BaseCommandTest} from './tests/base-command-test.js';
+import {NetworkLoadGeneratorTest} from './tests/network-load-generator-test.js';
 import {OneShotCommandDefinition} from '../../../src/commands/command-definitions/one-shot-command-definition.js';
 import {MetricsServerImpl} from '../../../src/business/runtime-state/services/metrics-server-impl.js';
 import * as constants from '../../../src/core/constants.js';
 import {Flags} from '../../../src/commands/flags.js';
 import {type LocalConfigRuntimeState} from '../../../src/business/runtime-state/config/local/local-config-runtime-state.js';
 import {type Deployment} from '../../../src/business/runtime-state/config/local/deployment.js';
-import {type ChartManager} from '../../../src/core/chart-manager.js';
-import {HelmChartValues} from '../../../src/integration/helm/model/values.js';
-import {
-  HEDERA_PLATFORM_VERSION,
-  MINIMUM_HIERO_PLATFORM_VERSION_FOR_NETWORK_LOAD_GENERATOR,
-  NETWORK_LOAD_GENERATOR_CHART_VERSION_AFTER_CN_72,
-  NETWORK_LOAD_GENERATOR_CHART_VERSION_BEFORE_CN_72,
-} from '../../../version.js';
-import {SemanticVersion} from '../../../src/business/utils/semantic-version.js';
+
 import {type Pod} from '../../../src/integration/kube/resources/pod/pod.js';
 import {ContainerReference} from '../../../src/integration/kube/resources/container/container-reference.js';
 import {type Containers} from '../../../src/integration/kube/resources/container/containers.js';
@@ -91,7 +84,7 @@ const endToEndTestSuite: EndToEndTestSuite = new EndToEndTestSuiteBuilder()
 
           // Phase 2: Pre-deploy NLG chart (bypassing rapid-fire to allow file copy before test start)
           testLogger.info(`${testName}: deploying NLG chart`);
-          await deployNlgChart(context);
+          await NetworkLoadGeneratorTest.deployChart(context, NamespaceName.of(await getNamespaceFromDeployment()));
           testLogger.info(`${testName}: NLG chart deployed`);
 
           // Phase 3: Copy throttles.json into NLG pod
@@ -207,77 +200,6 @@ function soloRapidFire(testNameArgument: string, performanceTest: string, argume
   );
   argvPushGlobalFlags(argv, testNameArgument);
   return argv;
-}
-
-/**
- * Deploy the NLG Helm chart directly (bypassing rapid-fire) so we can copy
- * the throttles.json file into the pod before any load test starts.
- *
- * This mirrors the deployment logic in RapidFireCommand.deployNlgChart().
- */
-async function deployNlgChart(kubeContext: string): Promise<void> {
-  const chartManager: ChartManager = container.resolve<ChartManager>(InjectTokens.ChartManager);
-  const k8Factory: K8Factory = container.resolve<K8Factory>(InjectTokens.K8Factory);
-  const k8Instance: K8 = k8Factory.getK8(kubeContext);
-
-  const namespaceName: string = await getNamespaceFromDeployment();
-  const namespaceObject: NamespaceName = NamespaceName.of(namespaceName);
-
-  // Build values argument with HAProxy pod IPs (same as rapid-fire does)
-  const chartValues: HelmChartValues = new HelmChartValues().file(constants.RAPID_FIRE_VALUES_FILE);
-
-  const haproxyPods: Pod[] = await k8Instance.pods().list(namespaceObject, ['solo.hedera.com/type=haproxy']);
-
-  const port: number = constants.GRPC_PORT;
-  const networkProperties: string[] = haproxyPods.map((pod: Pod): string => {
-    const accountId: string = pod.labels['solo.hedera.com/account-id'] ?? 'unknown';
-    // eslint-disable-next-line unicorn/prefer-string-raw
-    return `${pod.podIp}\\:${port}=${accountId}`;
-  });
-
-  for (const [index, row] of networkProperties.entries()) {
-    chartValues.setLiteral(`loadGenerator.properties[${index}]`, row);
-  }
-
-  // Install NLG Helm chart
-  await chartManager.install(
-    namespaceObject,
-    constants.NETWORK_LOAD_GENERATOR_RELEASE_NAME,
-    constants.NETWORK_LOAD_GENERATOR_CHART,
-    constants.NETWORK_LOAD_GENERATOR_CHART_URL,
-    new SemanticVersion(HEDERA_PLATFORM_VERSION).greaterThanOrEqual(
-      new SemanticVersion(MINIMUM_HIERO_PLATFORM_VERSION_FOR_NETWORK_LOAD_GENERATOR),
-    )
-      ? NETWORK_LOAD_GENERATOR_CHART_VERSION_AFTER_CN_72
-      : NETWORK_LOAD_GENERATOR_CHART_VERSION_BEFORE_CN_72,
-    chartValues,
-    kubeContext,
-  );
-
-  // Wait for NLG pod readiness
-  await k8Instance
-    .pods()
-    .waitForReadyStatus(
-      namespaceObject,
-      constants.NETWORK_LOAD_GENERATOR_POD_LABELS,
-      constants.NETWORK_LOAD_GENERATOR_POD_RUNNING_MAX_ATTEMPTS,
-      constants.NETWORK_LOAD_GENERATOR_POD_RUNNING_DELAY,
-    );
-
-  // Install libsodium in NLG pod (required dependency)
-  const nlgPods: Pod[] = await k8Instance.pods().list(namespaceObject, constants.NETWORK_LOAD_GENERATOR_POD_LABELS);
-
-  const k8Containers: Containers = k8Instance.containers();
-  for (const pod of nlgPods) {
-    const containerReference: ContainerReference = ContainerReference.of(
-      pod.podReference,
-      constants.NETWORK_LOAD_GENERATOR_CONTAINER,
-    );
-    const nlgContainer: Container = k8Containers.readByRef(containerReference);
-    await nlgContainer.execContainer('apt-get update -qq');
-    await nlgContainer.execContainer('apt-get install -y libsodium23');
-    await nlgContainer.execContainer('apt-get clean -qq');
-  }
 }
 
 /**

--- a/test/e2e/commands/tests/network-load-generator-test.ts
+++ b/test/e2e/commands/tests/network-load-generator-test.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {container} from 'tsyringe-neo';
+import {InjectTokens} from '../../../../src/core/dependency-injection/inject-tokens.js';
+import * as constants from '../../../../src/core/constants.js';
+import {type ChartManager} from '../../../../src/core/chart-manager.js';
+import {type K8Factory} from '../../../../src/integration/kube/k8-factory.js';
+import {type K8} from '../../../../src/integration/kube/k8.js';
+import {HelmChartValues} from '../../../../src/integration/helm/model/values.js';
+import {SemanticVersion} from '../../../../src/business/utils/semantic-version.js';
+import {type NamespaceName} from '../../../../src/types/namespace/namespace-name.js';
+import {type Pod} from '../../../../src/integration/kube/resources/pod/pod.js';
+import {ContainerReference} from '../../../../src/integration/kube/resources/container/container-reference.js';
+import {type Containers} from '../../../../src/integration/kube/resources/container/containers.js';
+import {NetworkLoadGeneratorLibraries} from '../../../../src/core/network-load-generator-libraries.js';
+import {
+  HEDERA_PLATFORM_VERSION,
+  MINIMUM_HIERO_PLATFORM_VERSION_FOR_NETWORK_LOAD_GENERATOR,
+  NETWORK_LOAD_GENERATOR_CHART_VERSION_AFTER_CN_72,
+  NETWORK_LOAD_GENERATOR_CHART_VERSION_BEFORE_CN_72,
+} from '../../../../version.js';
+
+export class NetworkLoadGeneratorTest {
+  /**
+   * Deploy the NLG Helm chart directly (bypassing rapid-fire) so the chart install, pod readiness and the
+   * libsodium install run under their own mocha timeout instead of inside the first load test (#5988).
+   *
+   * This mirrors the deployment logic in RapidFireCommand.deployNlgChart(); rapid-fire skips its own
+   * deploy step when it finds the chart already installed.
+   */
+  public static async deployChart(kubeContext: string, namespace: NamespaceName): Promise<void> {
+    const chartManager: ChartManager = container.resolve<ChartManager>(InjectTokens.ChartManager);
+    const k8Factory: K8Factory = container.resolve<K8Factory>(InjectTokens.K8Factory);
+    const k8Instance: K8 = k8Factory.getK8(kubeContext);
+
+    // Build values argument with HAProxy pod IPs (same as rapid-fire does)
+    const chartValues: HelmChartValues = new HelmChartValues().file(constants.RAPID_FIRE_VALUES_FILE);
+
+    const haproxyPods: Pod[] = await k8Instance.pods().list(namespace, ['solo.hedera.com/type=haproxy']);
+
+    const port: number = constants.GRPC_PORT;
+    const networkProperties: string[] = haproxyPods.map((pod: Pod): string => {
+      const accountId: string = pod.labels['solo.hedera.com/account-id'] ?? 'unknown';
+      // eslint-disable-next-line unicorn/prefer-string-raw
+      return `${pod.podIp}\\:${port}=${accountId}`;
+    });
+
+    for (const [index, row] of networkProperties.entries()) {
+      chartValues.setLiteral(`loadGenerator.properties[${index}]`, row);
+    }
+
+    await chartManager.install(
+      namespace,
+      constants.NETWORK_LOAD_GENERATOR_RELEASE_NAME,
+      constants.NETWORK_LOAD_GENERATOR_CHART,
+      constants.NETWORK_LOAD_GENERATOR_CHART_URL,
+      new SemanticVersion(HEDERA_PLATFORM_VERSION).greaterThanOrEqual(
+        new SemanticVersion(MINIMUM_HIERO_PLATFORM_VERSION_FOR_NETWORK_LOAD_GENERATOR),
+      )
+        ? NETWORK_LOAD_GENERATOR_CHART_VERSION_AFTER_CN_72
+        : NETWORK_LOAD_GENERATOR_CHART_VERSION_BEFORE_CN_72,
+      chartValues,
+      kubeContext,
+    );
+
+    await k8Instance
+      .pods()
+      .waitForReadyStatus(
+        namespace,
+        constants.NETWORK_LOAD_GENERATOR_POD_LABELS,
+        constants.NETWORK_LOAD_GENERATOR_POD_RUNNING_MAX_ATTEMPTS,
+        constants.NETWORK_LOAD_GENERATOR_POD_RUNNING_DELAY,
+      );
+
+    const nlgPods: Pod[] = await k8Instance.pods().list(namespace, constants.NETWORK_LOAD_GENERATOR_POD_LABELS);
+    const k8Containers: Containers = k8Instance.containers();
+    for (const pod of nlgPods) {
+      const containerReference: ContainerReference = ContainerReference.of(
+        pod.podReference,
+        constants.NETWORK_LOAD_GENERATOR_CONTAINER,
+      );
+      await NetworkLoadGeneratorLibraries.install(k8Containers.readByRef(containerReference));
+    }
+  }
+}

--- a/test/e2e/commands/tests/network-load-generator-test.ts
+++ b/test/e2e/commands/tests/network-load-generator-test.ts
@@ -8,7 +8,9 @@ import {type K8Factory} from '../../../../src/integration/kube/k8-factory.js';
 import {type K8} from '../../../../src/integration/kube/k8.js';
 import {HelmChartValues} from '../../../../src/integration/helm/model/values.js';
 import {SemanticVersion} from '../../../../src/business/utils/semantic-version.js';
-import {type NamespaceName} from '../../../../src/types/namespace/namespace-name.js';
+import {NamespaceName} from '../../../../src/types/namespace/namespace-name.js';
+import {type LocalConfigRuntimeState} from '../../../../src/business/runtime-state/config/local/local-config-runtime-state.js';
+import {type Deployment} from '../../../../src/business/runtime-state/config/local/deployment.js';
 import {type Pod} from '../../../../src/integration/kube/resources/pod/pod.js';
 import {ContainerReference} from '../../../../src/integration/kube/resources/container/container-reference.js';
 import {type Containers} from '../../../../src/integration/kube/resources/container/containers.js';
@@ -28,7 +30,19 @@ export class NetworkLoadGeneratorTest {
    * This mirrors the deployment logic in RapidFireCommand.deployNlgChart(); rapid-fire skips its own
    * deploy step when it finds the chart already installed.
    */
-  public static async deployChart(kubeContext: string, namespace: NamespaceName): Promise<void> {
+  public static async deployChart(deploymentName: string): Promise<void> {
+    const localConfig: LocalConfigRuntimeState = container.resolve<LocalConfigRuntimeState>(
+      InjectTokens.LocalConfigRuntimeState,
+    );
+    await localConfig.load();
+    const deployment: Deployment = localConfig.configuration.deploymentByName(deploymentName);
+    const namespace: NamespaceName = NamespaceName.of(deployment.namespace);
+    // Resolve the context from the deployment's cluster reference, as rapid-fire does. The suite's
+    // contexts[] come from SOLO_TEST_CLUSTER, which one-shot ignores when it creates its own kind cluster.
+    const kubeContext: string = localConfig.configuration.clusterRefs
+      .get(deployment.clusters.get(0).toString())
+      .toString();
+
     const chartManager: ChartManager = container.resolve<ChartManager>(InjectTokens.ChartManager);
     const k8Factory: K8Factory = container.resolve<K8Factory>(InjectTokens.K8Factory);
     const k8Instance: K8 = k8Factory.getK8(kubeContext);

--- a/test/unit/core/network-load-generator-libraries.test.ts
+++ b/test/unit/core/network-load-generator-libraries.test.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {expect} from 'chai';
+import {describe, it} from 'mocha';
+import sinon, {type SinonStub} from 'sinon';
+import {NetworkLoadGeneratorLibraries} from '../../../src/core/network-load-generator-libraries.js';
+import {type Container} from '../../../src/integration/kube/resources/container/container.js';
+
+describe('NetworkLoadGeneratorLibraries', (): void => {
+  it('installs libsodium23 in one sh exec with apt mirror timeouts and an already-installed guard', async (): Promise<void> => {
+    const execContainerStub: SinonStub = sinon.stub().resolves('');
+    const container: Container = {execContainer: execContainerStub} as unknown as Container;
+
+    await NetworkLoadGeneratorLibraries.install(container);
+
+    expect(execContainerStub.calledOnce).to.equal(true);
+    const [shell, flag, script]: string[] = execContainerStub.firstCall.args[0];
+    expect(shell).to.equal('sh');
+    expect(flag).to.equal('-c');
+    expect(script).to.match(/^set -e; if dpkg -s libsodium23 /);
+    expect(script).to.include('Acquire::ForceIPv4 "true"');
+    expect(script).to.include('Acquire::http::Timeout "30"');
+    expect(script).to.include('apt-get install -y libsodium23');
+    expect(script).to.not.include('-qq');
+  });
+});


### PR DESCRIPTION
## Description

This pull request changes the following:

* Adds `NetworkLoadGeneratorLibraries.install()`, the single place that installs `libsodium23` in the NLG pod. It runs one `sh -c` script that:
  * skips the install when `dpkg -s libsodium23` already succeeds,
  * writes `Acquire::ForceIPv4 "true"; Acquire::Retries "5"; Acquire::http::Timeout "30";` to `/etc/apt/apt.conf.d/99-solo` before `apt-get update`, so a slow public mirror is bounded by apt's own timeouts instead of the caller's (same mitigation as #5986 on the Windows runner),
  * uses `-q` instead of `-qq` so the job log shows which fetch stalls.
* `rapid-fire load start` and the small-memory e2e test both call that helper; the duplicated three-line `apt-get` block is gone from both.
* Moves the NLG chart deploy (chart install, pod readiness, library install) out of the small-memory test file into a shared `NetworkLoadGeneratorTest.deployChart()` e2e helper.
* `performance.test.ts` now deploys the NLG in its own `Deploy Network Load Generator` case with a 20-minute timeout, before `TokenTransferLoadTest`. `rapid-fire` skips its own deploy step because the chart is already installed, so the 660 s load-test budget is spent on the load test only, and an apt stall fails as its own step rather than as a `kubectl exec` killed with exit 137.

The cross-repo root fix (ship `libsodium23` in the `network-load-generator` image and delete this helper) is tracked in #5988.

### Related Issues

* Closes #5988
* Related to #5985, #5986

### Pull request (PR) checklist

- [x] This PR added tests (unit, integration, and/or end-to-end)
- [ ] This PR updated documentation
- [x] This PR added no TODOs or commented out code
- [x] This PR has no breaking changes
- [x] Any technical debt has been documented as a separate issue and linked to this PR
- [x] Any `package.json` changes have been explained to and approved by a repository manager
- [x] All related issues have been linked to this PR
- [x] All changes in this PR are included in the description
- [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

- [x] This PR added unit tests
- [x] This PR added integration/end-to-end tests
- [ ] These changes required manual testing that is documented below
- [x] Anything not tested is documented

The following manual testing was done:

* `npx tsc --noEmit`, `npx eslint` on the touched files, `npx dpdm --exit-code circular:1 ./solo.ts` (no cycles).
* `npx mocha test/unit/core/network-load-generator-libraries.test.ts test/unit/commands/rapid-fire.test.ts` (18 passing).

The following was not tested:

* The Performance Test and small-memory e2e workflows; they run in CI on this PR.
